### PR TITLE
fix: derive VERSION from shard.yml at compile time

### DIFF
--- a/src/registry.cr
+++ b/src/registry.cr
@@ -3,7 +3,9 @@ require "compress/gzip"
 # Catalog of every maze endpoint plus a few shared helpers used by maze
 # definitions and the catalog/server layers.
 module Xssmaze
-  VERSION = "0.1.0"
+  # Single source of truth: read the version straight from shard.yml at compile
+  # time so it can never drift from the released version again.
+  VERSION = {{ read_file("#{__DIR__}/../shard.yml").lines.find(&.starts_with?("version:")).split(":")[1].strip }}
 
   @@mazes = [] of Maze
   @@frozen = false


### PR DESCRIPTION
## Problem

`Xssmaze::VERSION` (`src/registry.cr`) was hardcoded to `"0.1.0"` and never bumped for the **v0.2.0** release. Since `/version`, `/stats`, the landing-page badge, and the `Server` header all read this constant, the lab reported `0.1.0` even though `shard.yml` and the git tag are `0.2.0`:

```
$ docker run … ghcr.io/hahwul/xssmaze:main
/version → {"version":"0.1.0", …}
```

The drift exists on `main` **and** at the `v0.2.0` tag (`shard.yml: 0.2.0`, but `VERSION = "0.1.0"`). It surfaced while recording an external detection-score snapshot against `:main`, which faithfully logged the wrong version.

## Fix

Read the version straight from `shard.yml` at compile time, so the shard manifest is the single source of truth and the constant can't drift again:

```crystal
VERSION = {{ read_file("#{__DIR__}/../shard.yml").lines.find(&.starts_with?("version:")).split(":")[1].strip }}
```

## Verification (local)

- `crystal tool format --check` — clean
- `crystal run lib/ameba/bin/ameba.cr -- src/registry.cr` — `1 inspected, 0 failures`
- `crystal build src/xssmaze.cr` — builds
- Running the binary: `/version → {"version":"0.2.0","endpoints":1013,"categories":169}` ✅