### PR TITLE
ci(homebrew): add a prebuilt-binary Homebrew tap

### DIFF
--- a/.github/homebrew/xssmaze.rb.tmpl
+++ b/.github/homebrew/xssmaze.rb.tmpl
@@ -1,0 +1,58 @@
+# typed: strict
+# frozen_string_literal: true
+
+# This file is rendered by xssmaze's release pipeline (.github/workflows/publish-homebrew.yml).
+# DO NOT EDIT by hand.
+class Xssmaze < Formula
+  desc "Intentionally vulnerable XSS testing lab web server (Crystal/Kemal)"
+  homepage "https://github.com/hahwul/xssmaze"
+  version "__VERSION__"
+  license "MIT"
+
+  on_macos do
+    # macOS binaries are dynamically linked; openssl@3 is the only non-system
+    # dependency (enforced by an otool guard in release-binary.yml).
+    depends_on "openssl@3"
+
+    on_arm do
+      url "https://github.com/hahwul/xssmaze/releases/download/v__VERSION__/xssmaze-v__VERSION__-osx-arm64"
+      sha256 "__SHA_OSX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/xssmaze/releases/download/v__VERSION__/xssmaze-v__VERSION__-osx-x86_64"
+      sha256 "__SHA_OSX_X86_64__"
+    end
+  end
+
+  on_linux do
+    # Linux release binaries are statically linked (musl), so they are self-contained.
+    on_arm do
+      url "https://github.com/hahwul/xssmaze/releases/download/v__VERSION__/xssmaze-v__VERSION__-linux-arm64"
+      sha256 "__SHA_LINUX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/xssmaze/releases/download/v__VERSION__/xssmaze-v__VERSION__-linux-x86_64"
+      sha256 "__SHA_LINUX_X86_64__"
+    end
+  end
+
+  def install
+    bin.install Dir["xssmaze-v__VERSION__-*"].first => "xssmaze"
+  end
+
+  def caveats
+    <<~EOS
+      xssmaze is an intentionally vulnerable XSS lab for security testing.
+      It binds to 127.0.0.1 by default; start it with, e.g.:
+        xssmaze -b 127.0.0.1 -p 3000
+      Do not expose it on an untrusted network.
+    EOS
+  end
+
+  test do
+    # Run the boot path used by the project's own specs (KEMAL_ENV=test builds
+    # the catalog and exits without binding a TCP socket).
+    ENV["KEMAL_ENV"] = "test"
+    system bin/"xssmaze"
+  end
+end

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,0 +1,104 @@
+---
+name: Homebrew tap Publish
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.2.0)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+permissions:
+  contents: read
+jobs:
+  publish-formula:
+    name: Publish prebuilt formula to tap
+    # Run after a release-triggered binary build succeeds, or on manual
+    # dispatch. The prebuilt formula needs the release binaries to exist first.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source (formula template)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+
+      - name: Resolve version
+        id: ver
+        # Pass event data via env (never interpolate ${{ }} straight into the
+        # script body) so a crafted tag/branch name can't inject shell.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RAW="$DISPATCH_VERSION"
+          else
+            RAW="$RUN_BRANCH"
+          fi
+          # Strip leading 'v' if present
+          VERSION="${RAW#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Download release binaries and compute checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          # Linux binaries are static musl; macOS binaries link only openssl@3.
+          for asset in osx-arm64 osx-x86_64 linux-arm64 linux-x86_64; do
+            gh release download "v$V" --repo hahwul/xssmaze \
+              --pattern "xssmaze-v$V-$asset" --output "xssmaze-v$V-$asset"
+          done
+          {
+            echo "SHA_OSX_ARM64=$(sha256sum "xssmaze-v$V-osx-arm64" | awk '{print $1}')"
+            echo "SHA_OSX_X86_64=$(sha256sum "xssmaze-v$V-osx-x86_64" | awk '{print $1}')"
+            echo "SHA_LINUX_ARM64=$(sha256sum "xssmaze-v$V-linux-arm64" | awk '{print $1}')"
+            echo "SHA_LINUX_X86_64=$(sha256sum "xssmaze-v$V-linux-x86_64" | awk '{print $1}')"
+          } >> "$GITHUB_ENV"
+
+      - name: Render formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p out
+          sed \
+            -e "s|__VERSION__|$V|g" \
+            -e "s|__SHA_OSX_ARM64__|$SHA_OSX_ARM64|g" \
+            -e "s|__SHA_OSX_X86_64__|$SHA_OSX_X86_64|g" \
+            -e "s|__SHA_LINUX_ARM64__|$SHA_LINUX_ARM64|g" \
+            -e "s|__SHA_LINUX_X86_64__|$SHA_LINUX_X86_64|g" \
+            .github/homebrew/xssmaze.rb.tmpl > out/xssmaze.rb
+          echo "----- rendered formula -----"
+          cat out/xssmaze.rb
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: hahwul/homebrew-xssmaze
+          token: ${{ secrets.XSSMAZE_PUBLISH_TOKEN }}
+          path: tap
+
+      - name: Commit and push formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p tap/Formula
+          cp out/xssmaze.rb tap/Formula/xssmaze.rb
+          cd tap
+          git config user.name "hahwul"
+          git config user.email "hahwul@gmail.com"
+          git add Formula/xssmaze.rb
+          if git diff --cached --quiet; then
+            echo "Formula unchanged; nothing to publish."
+            exit 0
+          fi
+          git commit -m "xssmaze $V"
+          git push

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,100 @@
+---
+name: Build and Release Binaries
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+permissions:
+  contents: write
+jobs:
+  build:
+    name: Build Binaries
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: ubuntu-24.04-arm
+            platform: linux
+          - os: macos-latest
+            platform: macos
+          - os: macos-15-intel
+            platform: macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Checkout source code
+        uses: actions/checkout@v6
+      - name: Install dependencies
+        run: shards install
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v5
+      - name: Set architecture environment variable
+        run: |
+          if [ "$RUNNER_ARCH" == "X64" ]; then
+            echo "ARCH=x86_64" >> $GITHUB_ENV
+          elif [ "$RUNNER_ARCH" == "ARM64" ]; then
+            echo "ARCH=arm64" >> $GITHUB_ENV
+          else
+            echo "ARCH=unknown" >> $GITHUB_ENV
+          fi
+      - if: matrix.platform == 'linux'
+        name: Build binary (Linux, static musl)
+        # Build a fully static musl binary so the release artifact is
+        # self-contained. xssmaze uses Crystal's HTTP stack and compress/gzip,
+        # so pull the matching zlib -static archive.
+        run: |
+          mkdir -p build
+          docker run --rm -v "$(pwd)":/xssmaze -w /xssmaze --entrypoint="" \
+            crystallang/crystal:1.20.0-alpine sh -c "
+              apk add --no-cache yaml-dev yaml-static zlib-dev zlib-static git curl &&
+              shards install --release --no-debug --production &&
+              mkdir -p build &&
+              crystal build src/xssmaze.cr \
+                -o build/xssmaze-${GITHUB_REF_SLUG}-linux-${ARCH} \
+                --release --no-debug --static
+            "
+      - if: matrix.platform == 'macos'
+        name: Build binary (macOS)
+        run: |
+          mkdir -p build
+          # Pin PKG_CONFIG_PATH to openssl@3 so the binary links the current
+          # OpenSSL instead of an EOL openssl@1.1, which would fail to launch on
+          # a clean machine (dyld: libssl.1.1.dylib not found). openssl@3 is the
+          # only Homebrew dylib the binary needs; it is declared in the formula.
+          brew install openssl@3
+          export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          BIN="build/xssmaze-${GITHUB_REF_SLUG}-osx-${ARCH}"
+          crystal build src/xssmaze.cr \
+            -o "$BIN" \
+            --no-debug --release
+          echo "== otool -L $BIN ==" && otool -L "$BIN"
+          # Guard 1: never ship a macOS binary linked against EOL openssl@1.1.
+          if otool -L "$BIN" | grep -q 'openssl@1.1'; then
+            echo "::error::macOS binary still links EOL openssl@1.1"; exit 1
+          fi
+          # Guard 2: openssl@3 must be the ONLY Homebrew dynamic dep, else the
+          # formula's depends_on list is out of date.
+          EXTRA="$(otool -L "$BIN" \
+            | grep -oE '/(opt/homebrew|usr/local)/(opt|Cellar)/[^/]+' \
+            | grep -v 'openssl@3' | sort -u || true)"
+          if [ -n "$EXTRA" ]; then
+            echo "::error::unexpected non-openssl@3 Homebrew deps (update formula depends_on):"
+            echo "$EXTRA"; exit 1
+          fi
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-${{ matrix.os }}-${{ env.ARCH }}
+          path: build
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Upload to GitHub Releases
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+          file: build/*


### PR DESCRIPTION
## What
Add Homebrew as an additional install channel (alongside the GHCR Docker image) so users can `brew tap hahwul/xssmaze && brew install xssmaze` and get a **prebuilt binary**, mirroring [hwaro](https://github.com/hahwul/hwaro). Greenfield — there was no tap, formula, or binary-release workflow before.

## How it works
1. **new** `release-binary.yml` builds 4 prebuilt binaries (`xssmaze-v<ver>-{osx,linux}-{arm64,x86_64}`) → GitHub Release.
2. **new** `publish-homebrew.yml` downloads them, computes `sha256`, renders `.github/homebrew/xssmaze.rb.tmpl`, and commits `Formula/xssmaze.rb` to `hahwul/homebrew-xssmaze` (tap repo already created).

## Changes
- add `.github/workflows/release-binary.yml` — 4 platforms incl. `macos-15-intel`. Linux = static musl (alpine, `yaml`/`zlib` `-static`); macOS pins `openssl@3` (Crystal HTTP stack) with an `otool` guard.
- add `.github/homebrew/xssmaze.rb.tmpl` — macOS `depends_on "openssl@3"`; `caveats` note it is an intentionally-vulnerable lab that binds loopback by default; the `test` block uses the project's own `KEMAL_ENV=test` boot path so it never binds a TCP socket.
- add `.github/workflows/publish-homebrew.yml`.

## ⚠️ Action required before this works
Add a repo secret **`XSSMAZE_PUBLISH_TOKEN`** (a PAT with `contents:write` on `hahwul/homebrew-xssmaze`) — the publish workflow uses it to push the formula.

## Notes
- Takes effect on the **next tagged release**, which also validates the static-musl Linux build.
- Verified locally: `brew style` clean; formula renders to valid Ruby.
