### PR TITLE
feat(map): structured vulnerability metadata + domsource/domsink/taintflow levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crystal Lint](https://github.com/hahwul/xssmaze/actions/workflows/crystal_lint.yml/badge.svg)](https://github.com/hahwul/xssmaze/actions/workflows/crystal_lint.yml)
 [![Docker](https://github.com/hahwul/xssmaze/actions/workflows/ghcr.yml/badge.svg)](https://github.com/hahwul/xssmaze/actions/workflows/ghcr.yml)
 
-XSSMaze is an intentionally vulnerable web application for measuring and improving XSS detection in security testing tools. It covers a wide range of XSS contexts: basic reflection, DOM, header, path, POST, redirect, decode, hidden input, in-JS, in-attribute, in-frame, event handler, CSP bypass, SVG, CSS injection, template injection, WebSocket, JSON, advanced techniques, polyglot, browser-state, opener, storage-event, stream, channel, service-worker, history-state, reparse, referrer, jQuery DOM sinks, dynamic code/module execution sinks, client-state (web storage/cookie/history) sinks, async fetch/XHR API DOM sinks, the 2024 native unsafe HTML-parsing sinks (setHTMLUnsafe/parseHTMLUnsafe), iframe srcdoc property sinks, and navigation sinks (window.open/location.assign/location.replace).
+XSSMaze is an intentionally vulnerable web application for measuring and improving XSS detection in security testing tools. It covers a wide range of XSS contexts: basic reflection, DOM, header, path, POST, redirect, decode, hidden input, in-JS, in-attribute, in-frame, event handler, CSP bypass, SVG, CSS injection, template injection, WebSocket, JSON, advanced techniques, polyglot, browser-state, opener, storage-event, stream, channel, service-worker, history-state, reparse, referrer, jQuery DOM sinks, dynamic code/module execution sinks, client-state (web storage/cookie/history) sinks, async fetch/XHR API DOM sinks, the 2024 native unsafe HTML-parsing sinks (setHTMLUnsafe/parseHTMLUnsafe), iframe srcdoc property sinks, navigation sinks (window.open/location.assign/location.replace), under-covered DOM sources (IndexedDB, hash-as-querystring, popstate, document.currentScript.src, Permissions API callbacks, CSS custom properties, a real same-origin WebSocket), under-covered DOM sinks (createHTMLDocument/importNode, DOMParser/adoptNode, indirect eval, Reflect.apply(eval), map(eval), Object.assign(location), setAttributeNS, form.action+submit), and taint-propagation shapes that defeat naive analyzers (JSON round-trip, Proxy traps, class getters, await, Promise.all, structuredClone, tagged templates, replacer functions).
 
 ![](images/showcase.png)
 
@@ -55,7 +55,12 @@ curl -i "http://localhost:3000/basic/level1/?query=a&set_csp=default-src%20%27se
 curl http://localhost:3000/map/text         # newline-separated URLs
 curl http://localhost:3000/map/json         # full metadata (also: ?type=dom or ?q=csp)
 curl http://localhost:3000/map/markdown     # markdown table
-curl http://localhost:3000/map/categories   # categories with counts
+curl http://localhost:3000/map/categories   # categories with counts + class/reach rollups
+
+# Structured vulnerability metadata (see "Vulnerability metadata" below)
+curl "http://localhost:3000/map/json?vuln=dom"           # only DOM flows
+curl "http://localhost:3000/map/json?reach=server"       # payload fits in an HTTP request
+curl "http://localhost:3000/map/json?exploitable=false"  # deliberate true negatives
 curl http://localhost:3000/map/openapi      # OpenAPI 3.0 catalog
 curl http://localhost:3000/sitemap.xml      # sitemap of all maze paths
 curl http://localhost:3000/health           # liveness probe
@@ -64,6 +69,54 @@ curl -L http://localhost:3000/random        # 302 to a random maze
 ```
 
 The index page (`/`) provides a client-side filter, per-category counts, and links to all of the maps above. Map endpoints serve a payload that is built once at startup, cached, and gzip pre-compressed (`Accept-Encoding: gzip` cuts the index payload by ~85%), so they're safe to poll from tooling.
+
+## Vulnerability metadata
+Every endpoint in `/map/json` carries a `vuln` object so tooling can score per
+vulnerability class without regex-guessing at the served HTML:
+
+```json
+{
+  "name": "dom-level7",
+  "url": "/dom/level7/",
+  "params": ["#hash"],
+  "vuln": {
+    "class": "dom",
+    "reach": "client",
+    "delivery": ["fragment"],
+    "sources": ["location.hash"],
+    "sinks": ["innerHTML"],
+    "exploitable": true,
+    "note": null
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `class` | `reflected-html`, `reflected-attr`, `reflected-js`, `dom`, `stored`, `prototype-pollution`, `csti`, `non-xss-control`, or `unclassified` |
+| `sources` / `sinks` | DOM taint endpoints, e.g. `location.hash` → `innerHTML` |
+| `delivery` | where the payload enters: `query`, `path`, `body`, `header`, `cookie`, `referer`, `fragment`, `postmessage`, `window-name`, … |
+| `reach` | derived — `server` if any delivery channel fits an HTTP request, `client` if the payload only exists browser-side, `unknown` if untriaged |
+| `exploitable` | `false` marks a deliberate control / true negative |
+| `note` | caveats: required user interaction, why it is a control, non-obvious parameter names |
+
+Classification follows the **injection context** — where the bytes land — not
+what the receiving API does with a well-formed argument. A value reflected raw
+into a JS string literal is `reflected-js` however inert the function it is
+passed to.
+
+Two things this is designed to prevent a benchmark from getting wrong:
+
+- **`reach: "client"`** endpoints (fragment, postMessage, window.name,
+  clipboard, drag-and-drop) cannot be reached by a request-only scanner at
+  all. Counting them as misses measures the wrong thing.
+- **`exploitable: false`** endpoints are not bugs. The whole `xsleak` category
+  is cross-site *leaks*, not XSS — a scanner that reports nothing there is
+  correct.
+
+Endpoints that have not been triaged yet are `"unclassified"` with
+`reach: "unknown"`, which is deliberately distinct from "reviewed and found
+safe".
 
 ## XS-Leaks (Cross-Site Leaks)
 XS-Leaks are cross-origin side-channels that let an attacker infer state-dependent data without directly reading the response body. XSSMaze includes `xsleak-*` levels that intentionally vary response size, subresource composition, load/error behavior, timing, and redirect chains based on a "secret" state.

--- a/WORK_SUMMARY.md
+++ b/WORK_SUMMARY.md
@@ -1,0 +1,287 @@
+# Work summary — DOM metadata & coverage
+
+Branch: `hahwul/dom-metadata-and-coverage`. Four commits, nothing pushed.
+
+| | before | after |
+|---|---|---|
+| endpoints | 1036 | 1059 |
+| categories (`/version`) | 171 | 174 |
+| endpoints with vuln metadata | 0 | 221 |
+| endpoints marked as controls | 0 | 6 |
+
+Verification: `shards build`, `crystal spec` (110 examples, 0 failures),
+`crystal tool format`, `ameba` (195 files, 0 failures), and a boot of
+`KEMAL_ENV=production ./bin/xssmaze -p 3100` with `/map/json`,
+`/map/categories`, `/map/openapi`, `/stats`, `/version`, `/health` all parsing
+as JSON.
+
+Exploitability claims were checked empirically, not asserted: every new level
+and every disputed existing one was loaded in headless Chrome 150 over the
+DevTools Protocol, with `Page.javascriptDialogOpening` as the oracle.
+
+---
+
+## Weakness 1 — machine-readable vulnerability metadata
+
+### Schema
+
+Every endpoint in `/map/json` now carries a `vuln` object:
+
+```json
+{
+  "name": "dom-level7",
+  "url": "/dom/level7/",
+  "type": "dom",
+  "desc": "innerHTML (location.hash)",
+  "method": "GET",
+  "params": ["#hash"],
+  "vuln": {
+    "class": "dom",
+    "reach": "client",
+    "delivery": ["fragment"],
+    "sources": ["location.hash"],
+    "sinks": ["innerHTML"],
+    "exploitable": true,
+    "note": null
+  }
+}
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `class` | closed enum | `unclassified`, `reflected-html`, `reflected-attr`, `reflected-js`, `dom`, `stored`, `prototype-pollution`, `csti`, `non-xss-control` |
+| `sources` | `string[]` | DOM taint origins — `location.hash`, `location.search`, `document.referrer`, `postMessage`, `localStorage`, `indexedDB`, `dataTransfer`, `clipboardData`, `dataset`, `fetch-response`, `websocket-message`, `currentScript.src`, `css-custom-property`, `popstate`, `server-reflected`, … |
+| `sinks` | `string[]` | DOM taint sinks — `innerHTML`, `document.write`, `eval`, `Function`, `srcdoc`, `location-nav`, `script.src`, `importNode`, `adoptNode`, `indirect-eval`, `form-submit`, `jquery.html`, … |
+| `delivery` | `string[]` | where the payload enters: `query`, `path`, `body`, `header`, `cookie`, `referer`, `fragment`, `postmessage`, `window-name` |
+| `reach` | derived | `server` if any delivery channel fits an HTTP request, `client` if the payload only exists browser-side, `unknown` if untriaged |
+| `exploitable` | `bool` | `false` marks a deliberate control / true negative |
+| `note` | `string?` | caveats: required user interaction, why it is a control, non-obvious parameter names |
+
+`reach` is **derived**, not stored, so it can never contradict `delivery`.
+`SERVER_CHANNELS` (`query path body header cookie referer`) is the single
+place that definition lives.
+
+### Classification rule
+
+Classify by the **injection context** — where the bytes actually land — not by
+what the receiving API does with a well-formed argument. A value the server
+reflects raw into a JS string literal is `reflected-js` however inert the
+function it is passed to, because the breakout happens before that function is
+ever called. `dom` is for flows whose taint reaches a sink through client-side
+code: either from a client-side source, or from a server-reflected literal
+that a live DOM sink then executes without needing a breakout.
+
+This rule is recorded in `Maze`'s doc comment so it does not drift.
+
+### Backward compatibility
+
+`Xssmaze.push` keeps its positional contract
+(`name, url, desc, method, params`); the six new fields are optional keyword
+args. All 1036 pre-existing call sites compile untouched, and the 838 that
+were not triaged report `class: "unclassified"` / `reach: "unknown"` — which
+is deliberately distinct from "reviewed and found safe".
+
+### Also exposed
+
+- `/map/json?vuln=`, `?reach=`, `?exploitable=` filters (compose with the
+  existing `?type=` and `?q=`).
+- `/map/markdown` gains `Class` / `Reach` / `Sources` / `Sinks` columns.
+- `/map/categories` gains `exploitable`, `controls`, and per-category
+  `classes` / `reach` histograms.
+- `/stats` gains global `classes`, `reach`, `sources`, `sinks`, `exploitable`
+  and `controls` rollups.
+- README gets a "Vulnerability metadata" section.
+
+### What got classified
+
+All 198 endpoints in the 34 DOM-ish categories, plus the 23 new ones = 221.
+
+```
+dom                 160     reflected-attr       19     reflected-html   18
+reflected-js         11     non-xss-control       6     prototype-pollution 4
+csti                  3     unclassified        838
+reach: server 201 · client 20 · unknown 838
+```
+
+### Mislabels this fixes
+
+Each of these previously required reading the served HTML, and each was
+mislabelled by the regex heuristic:
+
+- **`fragment` and `sink` are not DOM categories.** They are server-side
+  HTML/attribute reflections (option value, `<pre>`, `<svg><text>`,
+  `<math><mi>`, details/summary, marquee; href / form-action / embed-src /
+  link-href attributes). Now `reflected-html` / `reflected-attr` /
+  `reflected-js`, each with a note saying the category name is misleading.
+  `sink-level6` is the one genuine DOM flow in `sink` (`dataset` →
+  `innerHTML`), and `sink-level8`'s injectable parameter is `callback`, not
+  `query` — recorded in its note.
+- **`prototype-pattern` is not prototype pollution.** Six framework-shaped
+  server reflections (WordPress / PHP / ASP.NET / Angular-shaped /
+  React-shaped / Jinja-shaped). Only `prototype-pollution-*` carries the
+  `prototype-pollution` class, with the specific gadget key in each note
+  (`html` → innerHTML, `src` → script src, `srcdoc` → iframe, `onInit` →
+  `new Function`).
+- **`mobserver-*` are MutationObserver re-entry cases**, not textContent
+  sinks — each note names the re-entry shape.
+- **`csti-level3` and `csti-level5` are not template evaluation.**
+  `csti-level3` is Vue's `v-html` (an innerHTML sink) and `csti-level5` is
+  jQuery `.html()`. Only levels 1, 2 and 4 are genuinely `csti`.
+- **Fragment-only vs query-driven is now explicit.** 20 endpoints are
+  `reach: "client"` — a request-only scanner physically cannot deliver a
+  payload to them, so counting them as misses measures the wrong thing.
+
+### Controls (`exploitable: false`) — 6 total
+
+- **`xsleak-level1..5`** — cross-site *leak* oracles (response size, frame
+  count, image load/error, timing, redirect-chain length). No injection sink
+  exists; a scanner reporting nothing there is correct, not missing a bug.
+  This is the case you called out explicitly.
+- **`dom-level10`** — `img.src = query`. No modern browser executes a
+  `javascript:` URL from an image src. Verified no-fire in Chrome 150 with
+  both `javascript:alert(1)` and an HTML payload. Pure client-side flow with
+  no server reflection anywhere, so the injection-context rule does not apply.
+
+A spec enforces that every control carries an explanatory `note`, that
+`non-xss-control` and `exploitable: false` stay in sync, that every classified
+endpoint has a delivery channel, and that every `dom`-class endpoint has at
+least one source and one sink.
+
+### Existing documentation this corrected
+
+Three levels were documented as protected/inert and are not. All three
+re-verified in Chrome 150:
+
+- **`dom-level9`** — *was* "non-exploitable in modern browsers". It executes.
+  The inline `<script>` is empty, so prepare-a-script returned before setting
+  the already-started flag; mutating its text re-runs prepare.
+  (`?query=1` → no fire, `?query=alert(1)` → fires. Confirms the alert comes
+  from the injected script text.)
+- **`slot-level4`** — *was* "JSON-safe, no breakout (protected)".
+  `query.to_json` does block a JS-string breakout, but the value still reaches
+  `shadowRoot.innerHTML` as raw HTML and event handlers fire inside a shadow
+  root.
+- **`shadow-dom-level5`** — I initially got this one wrong in the same
+  direction the old docs did, and it was caught in review. The value is
+  reflected raw into the single-quoted JS string argument of
+  `sheet.replaceSync('...')`, so `');alert(1)//` closes the string and runs
+  code; `replaceSync`'s CSS-only semantics never come into play. Now
+  `reflected-js` / exploitable.
+
+`solutions/dom.md`, `solutions/slot.md`, `solutions/shadow-dom.md` and the
+"intentionally hardened" list in `solutions/README.md` were all updated.
+
+---
+
+## Weakness 2 — new source / sink / propagation coverage
+
+23 levels across three new categories. Absence was verified by grep before
+writing each one. **Every level below was confirmed to fire in headless
+Chrome 150** — there are no unsolvable levels.
+
+### `domsource` (7) — sources nothing else in the lab reads
+
+Sinks are deliberately boring (`innerHTML` / `insertAdjacentHTML` /
+`document.write`) so results speak about the source, not the sink.
+
+| Level | Source | Sink | Reach |
+|-------|--------|------|-------|
+| 1 | IndexedDB object store, read back through two async callbacks | `innerHTML` | server |
+| 2 | `new URLSearchParams(location.hash.slice(1))` — fragment as its own querystring | `innerHTML` | client |
+| 3 | `popstate` + `history.state` round-trip via `history.back()` | `insertAdjacentHTML` | server |
+| 4 | `document.currentScript.src` — external script reads its own URL | `document.write` | server |
+| 5 | sink reachable only inside a `navigator.permissions.query()` callback | `innerHTML` | server |
+| 6 | CSS custom property round-tripped through the CSSOM | `insertAdjacentHTML` | client |
+| 7 | **a real same-origin WebSocket** (`ws /domsource/level7/echo`) | `innerHTML` | server |
+
+Level 1 persists to IndexedDB, so it keeps firing on later visits with no
+parameter at all. Level 4 adds an unlisted helper route
+(`/domsource/level4/boot.js`) in the same style as the existing
+`/apidom/levelN/api` echoes. Level 7 is the first genuine WebSocket in the
+repo — the existing `websocket-xss` and `stream` levels only dispatch
+synthetic `MessageEvent`s, which their notes now say.
+
+### `domsink` (8) — sinks nothing else in the lab reaches
+
+The source is always a plain `location.search` read so results speak about the
+sink.
+
+| Level | Sink | Payload kind |
+|-------|------|--------------|
+| 1 | `document.implementation.createHTMLDocument` + `importNode` | HTML |
+| 2 | `DOMParser.parseFromString` + `adoptNode` | HTML |
+| 3 | indirect eval `(0, eval)(x)` | JavaScript |
+| 4 | `Reflect.apply(eval, globalThis, [x])` | JavaScript |
+| 5 | `Array.prototype.map(eval)` | JavaScript |
+| 6 | `Object.assign(location, {href: x})` | `javascript:` URL |
+| 7 | `setAttributeNS(null, 'onclick', x)` + programmatic click | JavaScript |
+| 8 | `form.action = x` + `form.submit()` | `javascript:` URL |
+
+Levels 1–2 launder through a document with no browsing context: the
+`innerHTML` write is genuinely safe *where it happens*, and execution only
+begins when the nodes are moved into the live document. A sink list that only
+knows `innerHTML` sees nothing dangerous.
+
+### `taintflow` (8) — propagation shapes, not new sinks
+
+Every level is the same `location.*` → `innerHTML` flow with one laundering
+step in between. Both ends are obvious; the question is whether the analyzer
+still connects them.
+
+1. `JSON.stringify` / `JSON.parse` round-trip
+2. Proxy `get` trap *(fragment-driven)*
+3. class getter
+4. `async` / `await` (not `.then()`)
+5. `Promise.all` result array, tainted element identified only by index
+6. `structuredClone`
+7. tagged template — the value never appears in the cooked strings *(fragment-driven)*
+8. `String.prototype.replace` with a replacer function — the value is the
+   callback's *return value*, never an argument to `replace()`
+
+A tool that reports all eight has real dataflow. A tool that reports none is
+matching `innerHTML =` against a literal `location.search` in the same
+expression.
+
+Each category has a `solutions/*.md` guide in the existing style, plus routing
+specs.
+
+---
+
+## Deliberately skipped
+
+- **Web Animations / CSS-injection-to-script-gadget** (from the candidate
+  sink list). `element.animate()` cannot execute script, and CSS injection
+  reaching script execution is not achievable in a modern browser without an
+  additional framework gadget — it would have been an unsolvable level. The
+  CSS-custom-property *source* half of that idea is covered by
+  `domsource-level6`.
+- **CSS custom property → `new Function`** — already exists at
+  `modern-bypass` (`--custom-theme-color` → `new Function`). `domsource-level6`
+  adds the distinct fragment-driven, HTML-sink variant rather than duplicating
+  it.
+- **Array `join`/`split` laundering** — already covered by `dom-level35`.
+- **A real registered ServiceWorker** for `service-worker-level1/2`. SW
+  registration is flaky on first load and in headless runs, which risks an
+  intermittently unsolvable level. The existing levels keep their synthetic
+  `MessageEvent`, and their notes now say so explicitly.
+- **Cookie Store API (`cookieStore.get()`) as a source** — Chrome-only with no
+  Firefox support, and `document.cookie` is already covered by `dom-level12`
+  and `clientstate-level4`.
+- **Re-verifying all 1036 pre-existing endpoints in a browser.** Only the
+  disputed ones were probed. The rest were classified by reading the source,
+  and the 838 untriaged endpoints are honestly marked `unclassified` rather
+  than guessed at.
+- **Fixing `sink-level8`'s `params` field** (it says `["query"]` but the
+  injectable parameter is `callback`). Changing `params` would shift
+  `/stats` and `/map/openapi` output for reasons unrelated to this work, so
+  the correction is recorded in the endpoint's `note` instead.
+
+## Known non-obvious constraints
+
+- `domsource-level6` requires a payload that is a valid CSS declaration value:
+  no quotes, no `;`, no `!`, balanced brackets. `<img src=x onerror=alert(1)>`
+  qualifies. Documented in the level's `note` and in `solutions/domsource.md`.
+- `domsink` payload kinds differ per level (HTML vs raw JS vs `javascript:`
+  URL) — each level's `note` says which.
+- 20 endpoints are `reach: "client"` and cannot be driven by a request-only
+  scanner at all.

--- a/solutions/README.md
+++ b/solutions/README.md
@@ -30,9 +30,8 @@ working payload for one or more maze levels.
 - Four categories cover two URL paths each because their solutions share
   filter logic. See [Merged categories](#merged-categories) below.
 - A handful of levels are intentionally hardened (e.g. `sanitizer-level5`,
-  `shadow-dom-level5`, `stored-level2`, `waf-bypass-level5`,
-  `mutfilter-level1`). Those entries document the constraint instead of a
-  fabricated payload.
+  `stored-level2`, `waf-bypass-level5`, `mutfilter-level1`). Those entries
+  document the constraint instead of a fabricated payload.
 - Endpoints that are deliberately *not* XSS carry `vuln.class =
   "non-xss-control"` and `vuln.exploitable = false` in `/map/json`. The whole
   `xsleak` category is one of these: those are cross-site-leak oracles, so a

--- a/solutions/README.md
+++ b/solutions/README.md
@@ -30,9 +30,13 @@ working payload for one or more maze levels.
 - Four categories cover two URL paths each because their solutions share
   filter logic. See [Merged categories](#merged-categories) below.
 - A handful of levels are intentionally hardened (e.g. `sanitizer-level5`,
-  `shadow-dom-level5`, `slot-level4`, `stored-level2`, `waf-bypass-level5`,
+  `shadow-dom-level5`, `stored-level2`, `waf-bypass-level5`,
   `mutfilter-level1`). Those entries document the constraint instead of a
   fabricated payload.
+- Endpoints that are deliberately *not* XSS carry `vuln.class =
+  "non-xss-control"` and `vuln.exploitable = false` in `/map/json`. The whole
+  `xsleak` category is one of these: those are cross-site-leak oracles, so a
+  scanner that reports no XSS on them is correct, not missing a bug.
 
 ## Merged categories
 

--- a/solutions/README.md
+++ b/solutions/README.md
@@ -4,7 +4,7 @@ Per-category exploit notes for every endpoint in the lab. The lab itself runs
 `./bin/xssmaze` (default `http://127.0.0.1:3000`); each entry below shows a
 working payload for one or more maze levels.
 
-**Total**: 164 categories · 957 levels.
+**Total**: 167 categories · 980 levels.
 
 ## How to read an entry
 
@@ -87,6 +87,8 @@ working payload for one or more maze levels.
 | [dialog](dialog.md) | Reflections inside `<dialog>` element bodies, attributes, and JS sinks. |
 | [dom](dom.md) | Client-side DOM sinks driven by URL, hash, query, name, referrer, postMessage. |
 | [domctx](domctx.md) | Server reflections that land in JS strings, JSON, eval, or div bodies (DOM contexts). |
+| [domsink](domsink.md) | DOM sinks the rest of the lab skips: createHTMLDocument/importNode, DOMParser/adoptNode, indirect eval, `Reflect.apply(eval)`, `map(eval)`, `Object.assign(location)`, `setAttributeNS`, `form.action` + `submit()`. |
+| [domsource](domsource.md) | DOM sources the rest of the lab skips: IndexedDB, `URLSearchParams(location.hash)`, popstate/history round-trip, `document.currentScript.src`, a Permissions API callback, a CSS custom property, and a real same-origin WebSocket. |
 | [doublereflect](doublereflect.md) | Same input reflected in multiple places — exploit the weaker sink. |
 | [dragdrop](dragdrop.md) | Reflections passed through to_json into JS, used in drag-and-drop sinks. |
 | [ecommerce](ecommerce.md) | Raw reflections in storefront widgets (titles, prices, filters, cart, reviews, breadcrumbs). |
@@ -202,6 +204,7 @@ working payload for one or more maze levels.
 | [svgctx](svgctx.md) | Reflection inside SVG sub-elements (text/desc/title/xlink:href/foreignObject/animate). |
 | [tablecontext](tablecontext.md) | Plain reflections inside table-related and list-related text elements; no filtering. |
 | [tagattrmix](tagattrmix.md) | Mixed reflection in tag content and various attributes; pick the simplest breakout. |
+| [taintflow](taintflow.md) | Taint-propagation shapes rather than new sinks: the same `location.*` → `innerHTML` flow laundered through JSON round-trip, a Proxy get trap, a class getter, `await`, `Promise.all`, `structuredClone`, a tagged template, and a `String.replace` replacer function. |
 | [template](template.md) | Server-side and client-side template-style substitution sinks under `/template/`. |
 | [timing](timing.md) | Reflection in various JS literal contexts (string, object key, comment, regex, template). |
 | [tplel](tplel.md) | HTML `<template>` element reflections: inert content reactivated via innerHTML/appendChild. |

--- a/solutions/dom.md
+++ b/solutions/dom.md
@@ -63,14 +63,18 @@ Client-side DOM sinks driven by URL, hash, query, name, referrer, postMessage.
 `/dom/level9/?query=alert(1)`
 
 - payload: `alert(1)`
-- context: scriptTag.innerText = query — does not execute by default; payload becomes script body but innerText set after script already inserted — note: scriptTag is inert; this lab is generally non-exploitable in modern browsers but content is detectable in response
+- context: `scriptTag.innerText = query`. The inline `<script>` is *empty*, so
+  prepare-a-script bailed out before setting the already-started flag; mutating
+  its text re-runs prepare and the code executes. Verified in Chrome 150.
 
 ### dom-level10
 
 `/dom/level10/?query=javascript:alert(1)`
 
 - payload: `javascript:alert(1)`
-- context: img.src = query; modern browsers ignore js: on img, but the URL is reflected — limited; treat as detectable taint sink
+- context: `img.src = query`. Control / true negative: no modern browser
+  executes a `javascript:` URL from an image src, so the taint reaches a sink
+  but nothing runs. Marked `exploitable: false` in `/map/json`.
 
 ### dom-level11
 

--- a/solutions/domsink.md
+++ b/solutions/domsink.md
@@ -1,0 +1,86 @@
+# domsink — solutions
+
+DOM *sinks* the rest of the lab never exercises. The taint always arrives the
+same boring way (a `query` parameter read client-side off `location.search`),
+so whatever a tool does or does not find here is a statement about the sink,
+not the source. All payloads below were verified in Chrome 150.
+
+Note the payload *kind* differs per level: levels 1–2 take HTML, levels 3–5
+take raw JavaScript, and levels 6 and 8 take a `javascript:` URL.
+
+### domsink-level1
+
+`/domsink/level1/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: `document.implementation.createHTMLDocument()` produces a document
+  with no browsing context, so `inert.body.innerHTML = query` loads nothing
+  and fires nothing. `document.importNode(inert.body, true)` copies the nodes
+  into the live document and appending them activates them. A sink list that
+  only knows `innerHTML` sees a write that is genuinely safe at the point it
+  happens.
+
+### domsink-level2
+
+`/domsink/level2/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: same inert-document shape as level 1, but with
+  `DOMParser.parseFromString` + `document.adoptNode` — the nodes are *moved*
+  into the live document rather than copied.
+
+### domsink-level3
+
+`/domsink/level3/?query=alert(1)`
+
+- payload: `alert(1)` (JavaScript, not HTML)
+- context: `(0, eval)(query)`. The comma operator detaches `eval` from its
+  reference, so this is *indirect* eval and runs in global scope. The call
+  shape differs from a plain `eval(x)` that name-based sink lists match on.
+
+### domsink-level4
+
+`/domsink/level4/?query=alert(1)`
+
+- payload: `alert(1)` (JavaScript)
+- context: `Reflect.apply(eval, globalThis, [query])` — `eval` is reached
+  through the reflection API and never appears in call position.
+
+### domsink-level5
+
+`/domsink/level5/?query=alert(1)`
+
+- payload: `alert(1)` (JavaScript)
+- context: `query.split('\n').map(eval)` — `eval` is handed to `.map()` as an
+  iteratee, so the tainted value is never syntactically an argument to it.
+  Extra `map` arguments (index, array) are ignored because `eval` only reads
+  its first parameter. Multiple newline-separated statements each run.
+
+### domsink-level6
+
+`/domsink/level6/?query=javascript:alert(1)`
+
+- payload: `javascript:alert(1)`
+- context: `Object.assign(location, { href: query })`. `Object.assign` invokes
+  the `href` setter on `Location`, so the navigation happens exactly as it
+  would for `location.href = ...` — but the sink is an `Object.assign` target,
+  not an assignment expression.
+
+### domsink-level7
+
+`/domsink/level7/?query=alert(1)`
+
+- payload: `alert(1)` (JavaScript)
+- context: `btn.setAttributeNS(null, 'onclick', query)`. The null-namespace
+  setter installs an event-handler content attribute exactly like
+  `setAttribute` does. The button is clicked programmatically 150 ms after
+  load, so no user interaction is required.
+
+### domsink-level8
+
+`/domsink/level8/?query=javascript:alert(1)`
+
+- payload: `javascript:alert(1)`
+- context: `form.action = query` followed by `form.submit()` 150 ms later. A
+  `javascript:` action executes on submission — a navigation sink reached
+  through the form API rather than through `location`.

--- a/solutions/domsource.md
+++ b/solutions/domsource.md
@@ -1,0 +1,82 @@
+# domsource — solutions
+
+DOM taint *sources* the rest of the lab never exercises. Every level ends in a
+boring sink (`innerHTML` / `insertAdjacentHTML` / `document.write`) on purpose,
+so whatever a tool does or does not find here is a statement about the source,
+not the sink. All payloads below were verified in Chrome 150.
+
+Standard payload unless noted: `<img src=x onerror=alert(1)>`.
+
+### domsource-level1
+
+`/domsource/level1/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: the value is written to an IndexedDB object store, then read back
+  out through `transaction().objectStore().get()` — two async callbacks away
+  from the write — and rendered with `innerHTML`. Because it is persisted, the
+  level keeps firing on later visits to `/domsource/level1/` with no parameter
+  at all.
+
+### domsource-level2
+
+`/domsource/level2/#msg=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>` (in the URL fragment, under the
+  `msg` key)
+- context: `new URLSearchParams(location.hash.slice(1)).get('msg')` — SPA hash
+  routing where the fragment is itself a querystring. Tools that treat
+  `location.hash` as one opaque string miss the named key inside it.
+
+### domsource-level3
+
+`/domsource/level3/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: the value is stashed on the current history entry with
+  `replaceState`, a throwaway entry is pushed on top, and `history.back()`
+  fires `popstate` with the seeded state — which the handler feeds to
+  `insertAdjacentHTML`. The sink is unreachable without the back navigation.
+
+### domsource-level4
+
+`/domsource/level4/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: the server only reflects into a `<script src>` URL. The external
+  script `/domsource/level4/boot.js` reads its *own* URL back out of
+  `document.currentScript.src`, pulls the `msg` parameter off it, and
+  `document.write`s it — the embeddable-widget configuration pattern.
+
+### domsource-level5
+
+`/domsource/level5/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: the `innerHTML` assignment lives inside
+  `navigator.permissions.query({name:'notifications'}).then(...)`. No
+  synchronous path through the page reaches the sink.
+
+### domsource-level6
+
+`/domsource/level6/#%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>` (in the URL fragment)
+- context: the fragment is stored on a CSS custom property with
+  `style.setProperty('--maze-label', ...)`, read back through
+  `getComputedStyle().getPropertyValue()`, and handed to
+  `insertAdjacentHTML` — the taint round-trips through the CSSOM.
+- caveat: the value must stay a valid CSS declaration value. Avoid quotes,
+  `;`, `!` and unbalanced brackets; `<img src=x onerror=alert(1)>` is fine
+  because its parentheses are balanced and it has no quotes.
+
+### domsource-level7
+
+`/domsource/level7/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: a *real* same-origin WebSocket. The page connects to
+  `/domsource/level7/echo`, sends the query parameter, and `innerHTML`s the
+  frame the server echoes back. Unlike the older `websocket-xss` / `stream`
+  levels — which call `onmessage` by hand with a synthetic `MessageEvent` —
+  the taint here genuinely crosses a network boundary.

--- a/solutions/shadow-dom.md
+++ b/solutions/shadow-dom.md
@@ -32,7 +32,12 @@ Open/closed shadow root sinks. Scripts inside shadow innerHTML do not execute, b
 
 ### shadow-dom-level5
 
-`/shadow-dom/level5/?query=test`
+`/shadow-dom/level5/?query=%27%29%3Balert%281%29%2F%2F`
 
-- payload: `test`
-- context: input goes only into CSSStyleSheet.replaceSync; CSS-only sink, no JS path (protected)
+- payload: `');alert(1)//`
+- context: the value is reflected raw into the single-quoted JS string argument
+  of `sheet.replaceSync('...')`, so it never has to be valid CSS — close the
+  string and the statement, then run code. `replaceSync`'s CSS-only semantics
+  never come into play because the breakout happens before the call.
+  Verified in Chrome 150. (This entry previously claimed the level was
+  protected; it is not.)

--- a/solutions/slot.md
+++ b/solutions/slot.md
@@ -25,7 +25,10 @@ Web-component `<slot>` reflections — light DOM text/attribute interpolation th
 
 ### slot-level4
 
-`/slot/level4/?query=test`
+`/slot/level4/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
-- payload: `test`
-- context: `query.to_json` JSON-escapes; sink writes inside `<div>` — JSON-safe, no breakout (protected)
+- payload: `<img src=x onerror=alert(1)>`
+- context: `query.to_json` JSON-escapes the value, so there is no *JS-string*
+  breakout — but the string still reaches `shadowRoot.innerHTML` as raw HTML,
+  and event handlers fire inside a shadow root. Verified in Chrome 150.
+  (This entry previously claimed the level was protected; it is not.)

--- a/solutions/taintflow.md
+++ b/solutions/taintflow.md
@@ -1,0 +1,86 @@
+# taintflow — solutions
+
+Taint-*propagation* shapes, not new sources or sinks. Every level is the same
+trivial flow — read a URL parameter, write it to `innerHTML` — with one
+laundering step in between. Both ends are obvious; the question is whether an
+analyzer still connects them once the value has been round-tripped through a
+serializer, hidden behind a Proxy trap or an accessor, or carried across an
+`await` / `Promise` boundary.
+
+A tool that reports every level here has real dataflow. A tool that reports
+none of them is pattern-matching `innerHTML =` against a literal
+`location.search` in the same expression.
+
+Payload for every level: `<img src=x onerror=alert(1)>`. All verified in
+Chrome 150.
+
+### taintflow-level1
+
+`/taintflow/level1/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: `JSON.parse(JSON.stringify({body: query})).body` — the value leaves
+  the JS heap as text and comes back as a different object before the sink.
+
+### taintflow-level2
+
+`/taintflow/level2/#%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>` (in the URL fragment)
+- context: the value is wrapped in a `new Proxy(...)` whose `get` trap returns
+  it. The property read that produces the taint is a function call on a
+  handler object, not a property access on the store.
+
+### taintflow-level3
+
+`/taintflow/level3/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: the value is stashed on `this._value` in a class constructor and
+  handed back out by a `get body()` accessor. The sink reads a property that
+  is not the field the value was written to.
+
+### taintflow-level4
+
+`/taintflow/level4/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: the value crosses a microtask boundary through
+  `await load(query)` inside an async IIFE — an `await`, not a `.then()`
+  callback.
+
+### taintflow-level5
+
+`/taintflow/level5/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: the value is the second element of a `Promise.all([...])` result
+  array which is then `join('')`ed into the sink. The tainted element is
+  identified only by its index.
+
+### taintflow-level6
+
+`/taintflow/level6/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: `structuredClone({payload: {body: query}})` deep-copies the wrapper
+  across the same serialization boundary `postMessage` uses, entirely
+  in-process; the sink reads the copy.
+
+### taintflow-level7
+
+`/taintflow/level7/#%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>` (in the URL fragment)
+- context: `` html`<article>${raw}</article>` `` — a tagged template. The
+  value never appears in the literal's cooked strings; it arrives as a
+  positional argument to the tag function, which concatenates it back in.
+
+### taintflow-level8
+
+`/taintflow/level8/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: `template.replace('NAME_SLOT', function () { return query; })` —
+  the value is the *return value* of a replacer callback. `replace()` itself
+  never receives it as an argument.

--- a/spec/routing_spec.cr
+++ b/spec/routing_spec.cr
@@ -289,6 +289,129 @@ describe "Kemal routing integration" do
     response.body.should contain("var dest = '#{payload}';")
     response.body.should contain("location.assign(dest)")
   end
+
+  it "serves domsource level1 with an IndexedDB read into innerHTML" do
+    get "/domsource/level1/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("indexedDB.open('xssmaze-domsource'")
+    response.body.should contain("innerHTML = ev.target.result")
+  end
+
+  it "serves domsource level2 parsing the fragment as its own querystring" do
+    get "/domsource/level2/"
+    response.status_code.should eq 200
+    response.body.should contain("new URLSearchParams(location.hash.slice(1))")
+  end
+
+  it "serves domsource level3 with a popstate state round-trip" do
+    get "/domsource/level3/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("addEventListener('popstate'")
+    response.body.should contain("history.back()")
+  end
+
+  it "url-encodes the domsource level4 payload into the boot script src" do
+    payload = "<img src=x onerror=alert(1)>"
+    get "/domsource/level4/?query=#{URI.encode_www_form(payload)}"
+    response.status_code.should eq 200
+    response.body.should contain("/domsource/level4/boot.js?msg=#{URI.encode_www_form(payload)}")
+  end
+
+  it "serves the domsource level4 boot script reading document.currentScript.src" do
+    get "/domsource/level4/boot.js?msg=x"
+    response.status_code.should eq 200
+    (response.headers["Content-Type"]? || "").should contain("javascript")
+    response.body.should contain("document.currentScript.src")
+    response.body.should contain("document.write(msg)")
+  end
+
+  it "serves domsource level5 with the sink inside a permissions callback" do
+    get "/domsource/level5/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("navigator.permissions.query")
+  end
+
+  it "serves domsource level6 reading a CSS custom property back out" do
+    get "/domsource/level6/"
+    response.status_code.should eq 200
+    response.body.should contain("setProperty('--maze-label'")
+    response.body.should contain("getPropertyValue('--maze-label')")
+  end
+
+  it "serves domsource level7 connecting to a real same-origin WebSocket" do
+    get "/domsource/level7/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("/domsource/level7/echo")
+    response.body.should contain("socket.onmessage")
+  end
+
+  it "serves domsink level1 with a createHTMLDocument + importNode sink" do
+    get "/domsink/level1/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("document.implementation.createHTMLDocument")
+    response.body.should contain("document.importNode(inert.body, true)")
+  end
+
+  it "serves domsink level2 with a DOMParser + adoptNode sink" do
+    get "/domsink/level2/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("document.adoptNode(parsed.body.firstChild)")
+  end
+
+  it "serves domsink level3 with an indirect eval sink" do
+    get "/domsink/level3/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("(0, eval)(q)")
+  end
+
+  it "serves domsink level4 with a Reflect.apply(eval) sink" do
+    get "/domsink/level4/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("Reflect.apply(eval, globalThis, [q])")
+  end
+
+  it "serves domsink level5 with an Array.prototype.map(eval) sink" do
+    get "/domsink/level5/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain(".map(eval)")
+  end
+
+  it "serves domsink level6 with an Object.assign(location) navigation sink" do
+    get "/domsink/level6/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("Object.assign(location, { href: q })")
+  end
+
+  it "serves domsink level7 with a setAttributeNS event-handler sink" do
+    get "/domsink/level7/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("setAttributeNS(null, 'onclick', q)")
+  end
+
+  it "serves domsink level8 with a form.action + submit() sink" do
+    get "/domsink/level8/?query=a"
+    response.status_code.should eq 200
+    response.body.should contain("form.action = q")
+    response.body.should contain("form.submit()")
+  end
+
+  it "serves every taintflow level with its laundering step intact" do
+    {
+      1 => "JSON.parse(JSON.stringify({ body: q }))",
+      2 => "new Proxy({ body: raw }",
+      3 => "get body() { return this._value; }",
+      4 => "await load(q)",
+      5 => "Promise.all([",
+      6 => "structuredClone({ payload: { body: q } })",
+      7 => "html`<article>${raw}</article>`",
+      8 => "template.replace('NAME_SLOT', function () { return q; })",
+    }.each do |level, marker|
+      get "/taintflow/level#{level}/?query=a"
+      response.status_code.should eq 200
+      response.body.should contain(marker)
+      response.body.should contain("innerHTML")
+    end
+  end
 end
 
 describe "WAF facade levels" do

--- a/spec/xssmaze_spec.cr
+++ b/spec/xssmaze_spec.cr
@@ -31,6 +31,92 @@ describe Maze do
     obj[:method].should eq("GET")
     obj[:params].should eq(["query"])
   end
+
+  it "defaults vulnerability metadata to unclassified with unknown reach" do
+    maze = Maze.new("basic-level1", "/basic/level1/?query=a", "no escape")
+    maze.vuln.should eq("unclassified")
+    maze.sources.should be_empty
+    maze.sinks.should be_empty
+    maze.delivery.should be_empty
+    maze.exploitable.should be_true
+    maze.note.should be_nil
+    maze.reach.should eq("unknown")
+  end
+
+  it "derives reach=server when any delivery channel fits an HTTP request" do
+    maze = Maze.new("dom-level8", "/dom/level8/", "innerHTML (query param)", "GET", ["query"],
+      "dom", ["location.search"], ["innerHTML"], ["query"])
+    maze.reach.should eq("server")
+  end
+
+  it "derives reach=client when the payload only exists browser-side" do
+    maze = Maze.new("dom-level7", "/dom/level7/", "innerHTML (location.hash)", "GET", ["#hash"],
+      "dom", ["location.hash"], ["innerHTML"], ["fragment"])
+    maze.reach.should eq("client")
+  end
+
+  it "marks controls as non-exploitable" do
+    maze = Maze.new("xsleak-level1", "/xsleak/search?q=admin", "body size oracle", "GET", ["q"],
+      "non-xss-control", [] of String, [] of String, ["query"], false, "cross-site leak, not XSS")
+    maze.exploitable.should be_false
+    maze.vuln.should eq("non-xss-control")
+    maze.note.should eq("cross-site leak, not XSS")
+  end
+
+  it "serializes vulnerability metadata under a vuln object" do
+    maze = Maze.new("dom-level7", "/dom/level7/", "innerHTML (location.hash)", "GET", ["#hash"],
+      "dom", ["location.hash"], ["innerHTML"], ["fragment"])
+    vuln = maze.to_json_object[:vuln]
+    vuln[:class].should eq("dom")
+    vuln[:reach].should eq("client")
+    vuln[:sources].should eq(["location.hash"])
+    vuln[:sinks].should eq(["innerHTML"])
+    vuln[:delivery].should eq(["fragment"])
+    vuln[:exploitable].should be_true
+  end
+
+  it "keeps every declared vuln class inside the closed set" do
+    Maze::VULN_CLASSES.should contain("unclassified")
+    Maze::VULN_CLASSES.should contain("non-xss-control")
+    Maze::VULN_CLASSES.should contain("prototype-pollution")
+  end
+end
+
+describe "maze catalog vulnerability metadata" do
+  it "only uses vuln classes from the closed set" do
+    Xssmaze.get.each do |maze|
+      Maze::VULN_CLASSES.should contain(maze.vuln)
+    end
+  end
+
+  it "keeps non-xss-control and exploitable=false in sync" do
+    Xssmaze.get.each do |maze|
+      if maze.vuln == "non-xss-control"
+        maze.exploitable.should be_false
+      end
+      maze.exploitable.should be_true if maze.vuln == "unclassified"
+    end
+  end
+
+  it "requires a note explaining every control" do
+    Xssmaze.get.reject(&.exploitable).each do |maze|
+      maze.note.should_not be_nil
+    end
+  end
+
+  it "gives every classified endpoint a delivery channel" do
+    Xssmaze.get.reject { |maze| maze.vuln == "unclassified" }.each do |maze|
+      maze.delivery.should_not be_empty
+      maze.reach.should_not eq("unknown")
+    end
+  end
+
+  it "gives every dom-class endpoint at least one source and one sink" do
+    Xssmaze.get.select { |maze| maze.vuln == "dom" }.each do |maze|
+      maze.sources.should_not be_empty
+      maze.sinks.should_not be_empty
+    end
+  end
 end
 
 describe Filters do

--- a/spec/xssmaze_spec.cr
+++ b/spec/xssmaze_spec.cr
@@ -38,7 +38,7 @@ describe Maze do
     maze.sources.should be_empty
     maze.sinks.should be_empty
     maze.delivery.should be_empty
-    maze.exploitable.should be_true
+    maze.exploitable?.should be_true
     maze.note.should be_nil
     maze.reach.should eq("unknown")
   end
@@ -58,7 +58,7 @@ describe Maze do
   it "marks controls as non-exploitable" do
     maze = Maze.new("xsleak-level1", "/xsleak/search?q=admin", "body size oracle", "GET", ["q"],
       "non-xss-control", [] of String, [] of String, ["query"], false, "cross-site leak, not XSS")
-    maze.exploitable.should be_false
+    maze.exploitable?.should be_false
     maze.vuln.should eq("non-xss-control")
     maze.note.should eq("cross-site leak, not XSS")
   end
@@ -92,14 +92,14 @@ describe "maze catalog vulnerability metadata" do
   it "keeps non-xss-control and exploitable=false in sync" do
     Xssmaze.get.each do |maze|
       if maze.vuln == "non-xss-control"
-        maze.exploitable.should be_false
+        maze.exploitable?.should be_false
       end
-      maze.exploitable.should be_true if maze.vuln == "unclassified"
+      maze.exploitable?.should be_true if maze.vuln == "unclassified"
     end
   end
 
   it "requires a note explaining every control" do
-    Xssmaze.get.reject(&.exploitable).each do |maze|
+    Xssmaze.get.reject(&.exploitable?).each do |maze|
       maze.note.should_not be_nil
     end
   end

--- a/src/catalog.cr
+++ b/src/catalog.cr
@@ -142,8 +142,8 @@ module Xssmaze::Catalog
       {
         category:    cat,
         count:       cat_mazes.size,
-        exploitable: cat_mazes.count(&.exploitable),
-        controls:    cat_mazes.count { |maze| !maze.exploitable },
+        exploitable: cat_mazes.count(&.exploitable?),
+        controls:    cat_mazes.count { |maze| !maze.exploitable? },
         classes:     classes,
         reach:       reaches,
       }
@@ -226,8 +226,8 @@ module Xssmaze::Catalog
       params:      params_count.to_a.sort_by! { |(_, v)| -v }.to_h,
       classes:     classes_count.to_a.sort_by! { |(_, v)| -v }.to_h,
       reach:       reach_count,
-      exploitable: mazes.count(&.exploitable),
-      controls:    mazes.count { |maze| !maze.exploitable },
+      exploitable: mazes.count(&.exploitable?),
+      controls:    mazes.count { |maze| !maze.exploitable? },
       sources:     sources_count.to_a.sort_by! { |(_, v)| -v }.to_h,
       sinks:       sinks_count.to_a.sort_by! { |(_, v)| -v }.to_h,
     }.to_json

--- a/src/catalog.cr
+++ b/src/catalog.cr
@@ -99,23 +99,54 @@ module Xssmaze::Catalog
     String.build do |io|
       io << "# XSSMaze Endpoints\n\n"
       io << "Total: " << mazes.size << "\n\n"
-      io << "| Name | Method | URL | Params | Description |\n"
-      io << "|------|--------|-----|--------|-------------|\n"
+      io << "`Class`/`Reach`/`Sources`/`Sinks` are the structured vulnerability\n"
+      io << "metadata also served by `/map/json`. `Class` = `non-xss-control` marks a\n"
+      io << "deliberate true negative; `Reach` = `client` means the payload only exists\n"
+      io << "browser-side (fragment, postMessage, clipboard, ...) and cannot be delivered\n"
+      io << "by a request-only scanner.\n\n"
+      io << "| Name | Method | URL | Params | Class | Reach | Sources | Sinks | Description |\n"
+      io << "|------|--------|-----|--------|-------|-------|---------|-------|-------------|\n"
       mazes.each do |maze|
         io << "| " << maze.name
         io << " | " << maze.method
         io << " | `" << maze.url << "`"
         io << " | `" << maze.params.join(",") << "`"
+        io << " | " << maze.vuln
+        io << " | " << maze.reach
+        io << " | " << md_cell(maze.sources)
+        io << " | " << md_cell(maze.sinks)
         io << " | " << maze.desc.gsub("|", "\\|")
         io << " |\n"
       end
     end
   end
 
+  private def self.md_cell(values : Array(String)) : String
+    return "-" if values.empty?
+    values.map { |v| "`#{v}`" }.join(" ")
+  end
+
+  # Per-category rollup. Beyond the raw count, this breaks each category down
+  # by vulnerability class and reachability so a benchmark can pick its target
+  # set (and exclude controls) without walking every endpoint in /map/json.
   def self.build_categories_json(groups : Hash(String, Array(Maze)),
                                  total : Int32) : String
     arr = groups.keys.sort!.map do |cat|
-      {category: cat, count: groups[cat].size}
+      cat_mazes = groups[cat]
+      classes = Hash(String, Int32).new(0)
+      reaches = Hash(String, Int32).new(0)
+      cat_mazes.each do |maze|
+        classes[maze.vuln] += 1
+        reaches[maze.reach] += 1
+      end
+      {
+        category:    cat,
+        count:       cat_mazes.size,
+        exploitable: cat_mazes.count(&.exploitable),
+        controls:    cat_mazes.count { |maze| !maze.exploitable },
+        classes:     classes,
+        reach:       reaches,
+      }
     end
     {total: total, categories: arr}.to_json
   end
@@ -176,15 +207,29 @@ module Xssmaze::Catalog
   def self.build_stats(mazes : Array(Maze), groups : Hash(String, Array(Maze))) : String
     methods_count = Hash(String, Int32).new(0)
     params_count = Hash(String, Int32).new(0)
+    classes_count = Hash(String, Int32).new(0)
+    reach_count = Hash(String, Int32).new(0)
+    sources_count = Hash(String, Int32).new(0)
+    sinks_count = Hash(String, Int32).new(0)
     mazes.each do |maze|
       methods_count[maze.method] += 1
       maze.params.each { |param| params_count[param] += 1 }
+      classes_count[maze.vuln] += 1
+      reach_count[maze.reach] += 1
+      maze.sources.each { |source| sources_count[source] += 1 }
+      maze.sinks.each { |sink| sinks_count[sink] += 1 }
     end
     {
-      total:      mazes.size,
-      categories: groups.size,
-      methods:    methods_count,
-      params:     params_count.to_a.sort_by! { |(_, v)| -v }.to_h,
+      total:       mazes.size,
+      categories:  groups.size,
+      methods:     methods_count,
+      params:      params_count.to_a.sort_by! { |(_, v)| -v }.to_h,
+      classes:     classes_count.to_a.sort_by! { |(_, v)| -v }.to_h,
+      reach:       reach_count,
+      exploitable: mazes.count(&.exploitable),
+      controls:    mazes.count { |maze| !maze.exploitable },
+      sources:     sources_count.to_a.sort_by! { |(_, v)| -v }.to_h,
+      sinks:       sinks_count.to_a.sort_by! { |(_, v)| -v }.to_h,
     }.to_json
   end
 

--- a/src/maze.cr
+++ b/src/maze.cr
@@ -52,7 +52,7 @@ class Maze
   # Where the payload enters, e.g. "query", "fragment", "postmessage".
   getter delivery : Array(String)
   # False when the endpoint is a control / true negative.
-  getter exploitable : Bool
+  getter? exploitable : Bool
   # Free-form caveat: why it is a control, what interaction it needs, etc.
   getter note : String?
 

--- a/src/maze.cr
+++ b/src/maze.cr
@@ -18,6 +18,15 @@ class Maze
   # carry `vuln == "non-xss-control"` and `exploitable == false`, so a
   # benchmark subtracts them instead of counting them as detection misses.
 
+  # Classification rule: classify by the *injection context* — where the
+  # bytes actually land — not by what the receiving API does with a
+  # well-formed argument. A value the server reflects raw into a JS string
+  # literal is `reflected-js` however inert the function it is passed to,
+  # because the breakout happens before that function is ever called.
+  # `dom` is for flows whose taint reaches a sink through client-side code
+  # (either from a client-side source, or from a server-reflected literal
+  # that a live DOM sink then executes without needing a breakout).
+  #
   # Closed set of `vuln` values. "unclassified" is the default for endpoints
   # that have not been triaged yet — deliberately distinct from
   # "non-xss-control" so unreviewed and reviewed-as-safe never get conflated.

--- a/src/maze.cr
+++ b/src/maze.cr
@@ -1,15 +1,83 @@
 class Maze
+  # ----- Structured vulnerability metadata -----
+  #
+  # name/url/desc/method/params tell a tool *where* to send a payload. The
+  # fields below tell it *what kind of bug lives there*, so a benchmark can
+  # score per vulnerability class without regex-guessing at the served HTML.
+  #
+  # Four questions must be answerable from /map/json alone:
+  #
+  #   1. What class of bug is this?             -> `vuln`
+  #   2. For DOM flows, taint source and sink?  -> `sources` / `sinks`
+  #   3. Can a non-browser scanner even reach
+  #      the input, or is it browser-only?      -> `delivery` / `reach`
+  #   4. Is this deliberately NOT XSS?          -> `exploitable` / `vuln`
+  #
+  # Endpoints that are intentionally safe (true negatives) or that are a
+  # different bug class entirely (e.g. the `xsleak` cross-site-leak oracles)
+  # carry `vuln == "non-xss-control"` and `exploitable == false`, so a
+  # benchmark subtracts them instead of counting them as detection misses.
+
+  # Closed set of `vuln` values. "unclassified" is the default for endpoints
+  # that have not been triaged yet — deliberately distinct from
+  # "non-xss-control" so unreviewed and reviewed-as-safe never get conflated.
+  VULN_CLASSES = %w[
+    unclassified
+    reflected-html
+    reflected-attr
+    reflected-js
+    dom
+    stored
+    prototype-pollution
+    csti
+    non-xss-control
+  ]
+
+  # Delivery channels a plain HTTP client can drive on its own. Anything
+  # else needs a real browser (or a driver) to place the payload.
+  SERVER_CHANNELS = %w[query path body header cookie referer]
+
   getter name : String
   getter url : String
   getter desc : String
   getter method : String
   getter params : Array(String)
 
-  def initialize(@name, @url, @desc, @method = "GET", @params = ["query"])
+  # Vulnerability class; one of VULN_CLASSES.
+  getter vuln : String
+  # DOM taint sources, e.g. "location.hash", "postMessage", "localStorage".
+  getter sources : Array(String)
+  # DOM taint sinks, e.g. "innerHTML", "eval", "location-nav", "srcdoc".
+  getter sinks : Array(String)
+  # Where the payload enters, e.g. "query", "fragment", "postmessage".
+  getter delivery : Array(String)
+  # False when the endpoint is a control / true negative.
+  getter exploitable : Bool
+  # Free-form caveat: why it is a control, what interaction it needs, etc.
+  getter note : String?
+
+  def initialize(@name, @url, @desc, @method = "GET", @params = ["query"],
+                 @vuln = "unclassified",
+                 @sources = [] of String,
+                 @sinks = [] of String,
+                 @delivery = [] of String,
+                 @exploitable = true,
+                 @note = nil)
   end
 
   def type : String
     @name.split("-").first? || "other"
+  end
+
+  # "server"  - the payload fits in the HTTP request (query/path/body/
+  #             header/cookie/referer), so a non-browser scanner can reach it.
+  # "client"  - the payload only exists browser-side (fragment, postMessage,
+  #             clipboard, drag-and-drop, window.name, ...); a request-only
+  #             scanner cannot deliver it at all.
+  # "unknown" - not triaged.
+  def reach : String
+    return "unknown" if @delivery.empty?
+    @delivery.any? { |channel| SERVER_CHANNELS.includes?(channel) } ? "server" : "client"
   end
 
   def to_json_object
@@ -20,6 +88,15 @@ class Maze
       desc:   @desc,
       method: @method,
       params: @params,
+      vuln:   {
+        class:       @vuln,
+        reach:       reach,
+        delivery:    @delivery,
+        sources:     @sources,
+        sinks:       @sinks,
+        exploitable: @exploitable,
+        note:        @note,
+      },
     }
   end
 end

--- a/src/mazes/api_dom_xss.cr
+++ b/src/mazes/api_dom_xss.cr
@@ -11,7 +11,8 @@ require "json"
 # (not listed in the maze map) that reflects the forwarded `q` raw.
 
 # Level 1: fetch() text response -> innerHTML
-Xssmaze.push("apidom-level1", "/apidom/level1/?q=a", "fetch() text response reflected via innerHTML", "GET", ["q"])
+Xssmaze.push("apidom-level1", "/apidom/level1/?q=a", "fetch() text response reflected via innerHTML", "GET", ["q"],
+  vuln: "dom", sources: ["fetch-response"], sinks: ["innerHTML"], delivery: ["query"], note: "end-to-end only: the companion /apidom/levelN/api echo route is not XSS on its own")
 maze_get "/apidom/level1/" do |_env|
   "<html><body>
   <h1>Search</h1>
@@ -32,7 +33,8 @@ get "/apidom/level1/api" do |env|
 end
 
 # Level 2: fetch() JSON field -> innerHTML
-Xssmaze.push("apidom-level2", "/apidom/level2/?q=a", "fetch() JSON field reflected via innerHTML", "GET", ["q"])
+Xssmaze.push("apidom-level2", "/apidom/level2/?q=a", "fetch() JSON field reflected via innerHTML", "GET", ["q"],
+  vuln: "dom", sources: ["fetch-response"], sinks: ["innerHTML"], delivery: ["query"], note: "end-to-end only: the companion /apidom/levelN/api echo route is not XSS on its own")
 maze_get "/apidom/level2/" do |_env|
   "<html><body>
   <h1>Profile Card</h1>
@@ -53,7 +55,8 @@ get "/apidom/level2/api" do |env|
 end
 
 # Level 3: XMLHttpRequest responseText -> innerHTML
-Xssmaze.push("apidom-level3", "/apidom/level3/?q=a", "XMLHttpRequest responseText reflected via innerHTML", "GET", ["q"])
+Xssmaze.push("apidom-level3", "/apidom/level3/?q=a", "XMLHttpRequest responseText reflected via innerHTML", "GET", ["q"],
+  vuln: "dom", sources: ["xhr-response"], sinks: ["innerHTML"], delivery: ["query"], note: "end-to-end only: the companion /apidom/levelN/api echo route is not XSS on its own")
 maze_get "/apidom/level3/" do |_env|
   "<html><body>
   <h1>Status</h1>
@@ -75,7 +78,8 @@ get "/apidom/level3/api" do |env|
 end
 
 # Level 4: fetch() JSON field -> insertAdjacentHTML
-Xssmaze.push("apidom-level4", "/apidom/level4/?q=a", "fetch() JSON field injected via insertAdjacentHTML", "GET", ["q"])
+Xssmaze.push("apidom-level4", "/apidom/level4/?q=a", "fetch() JSON field injected via insertAdjacentHTML", "GET", ["q"],
+  vuln: "dom", sources: ["fetch-response"], sinks: ["insertAdjacentHTML"], delivery: ["query"], note: "end-to-end only: the companion /apidom/levelN/api echo route is not XSS on its own")
 maze_get "/apidom/level4/" do |_env|
   "<html><body>
   <h1>Notifications</h1>
@@ -98,7 +102,8 @@ get "/apidom/level4/api" do |env|
 end
 
 # Level 5: fetch() text response -> document.write
-Xssmaze.push("apidom-level5", "/apidom/level5/?q=a", "fetch() text response written via document.write", "GET", ["q"])
+Xssmaze.push("apidom-level5", "/apidom/level5/?q=a", "fetch() text response written via document.write", "GET", ["q"],
+  vuln: "dom", sources: ["fetch-response"], sinks: ["document.write"], delivery: ["query"], note: "end-to-end only: the companion /apidom/levelN/api echo route is not XSS on its own")
 maze_get "/apidom/level5/" do |_env|
   "<html><body>
   <h1>Widget</h1>
@@ -118,7 +123,8 @@ get "/apidom/level5/api" do |env|
 end
 
 # Level 6: fetch() text response -> Range.createContextualFragment + append
-Xssmaze.push("apidom-level6", "/apidom/level6/?q=a", "fetch() response parsed via createContextualFragment then appended", "GET", ["q"])
+Xssmaze.push("apidom-level6", "/apidom/level6/?q=a", "fetch() response parsed via createContextualFragment then appended", "GET", ["q"],
+  vuln: "dom", sources: ["fetch-response"], sinks: ["createContextualFragment"], delivery: ["query"], note: "end-to-end only: the companion /apidom/levelN/api echo route is not XSS on its own")
 maze_get "/apidom/level6/" do |_env|
   "<html><body>
   <h1>Fragment Loader</h1>

--- a/src/mazes/browser_state_xss.cr
+++ b/src/mazes/browser_state_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("browser-state-level1", "/browser-state/level1/?seed=a", "window.name bootstrap + innerHTML", "GET", ["seed"])
+Xssmaze.push("browser-state-level1", "/browser-state/level1/?seed=a", "window.name bootstrap + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["window.name"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/browser-state/level1/" do |_|
   "<div id='output'></div>
   <script>
@@ -15,7 +16,8 @@ maze_get "/browser-state/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("browser-state-level2", "/browser-state/level2/?seed=a", "localStorage relay + insertAdjacentHTML", "GET", ["seed"])
+Xssmaze.push("browser-state-level2", "/browser-state/level2/?seed=a", "localStorage relay + insertAdjacentHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["localStorage"], sinks: ["insertAdjacentHTML"], delivery: ["query"])
 maze_get "/browser-state/level2/" do |_|
   "<div id='output'></div>
   <script>
@@ -33,7 +35,8 @@ maze_get "/browser-state/level2/" do |_|
   </script>"
 end
 
-Xssmaze.push("browser-state-level3", "/browser-state/level3/?seed=a", "sessionStorage relay + createContextualFragment", "GET", ["seed"])
+Xssmaze.push("browser-state-level3", "/browser-state/level3/?seed=a", "sessionStorage relay + createContextualFragment", "GET", ["seed"],
+  vuln: "dom", sources: ["sessionStorage"], sinks: ["createContextualFragment"], delivery: ["query"])
 maze_get "/browser-state/level3/" do |_|
   "<div id='output'></div>
   <script>
@@ -53,7 +56,8 @@ maze_get "/browser-state/level3/" do |_|
   </script>"
 end
 
-Xssmaze.push("browser-state-level4", "/browser-state/level4/?seed=a", "postMessage relay + structured data + innerHTML", "GET", ["seed"])
+Xssmaze.push("browser-state-level4", "/browser-state/level4/?seed=a", "postMessage relay + structured data + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["postMessage"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/browser-state/level4/" do |_|
   "<div id='output'></div>
   <iframe id='relay' sandbox='allow-scripts' style='display:none'></iframe>
@@ -71,7 +75,8 @@ maze_get "/browser-state/level4/" do |_|
   </script>"
 end
 
-Xssmaze.push("browser-state-level5", "/browser-state/level5/?seed=a", "document.referrer bootstrap + document.write", "GET", ["seed"])
+Xssmaze.push("browser-state-level5", "/browser-state/level5/?seed=a", "document.referrer bootstrap + document.write", "GET", ["seed"],
+  vuln: "dom", sources: ["document.referrer"], sinks: ["document.write"], delivery: ["query", "referer"])
 maze_get "/browser-state/level5/" do |_|
   "<div id='output'></div>
   <iframe id='relay' style='display:none'></iframe>

--- a/src/mazes/channel_xss.cr
+++ b/src/mazes/channel_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("channel-level1", "/channel/level1/?seed=a", "BroadcastChannel relay + innerHTML", "GET", ["seed"])
+Xssmaze.push("channel-level1", "/channel/level1/?seed=a", "BroadcastChannel relay + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["broadcastchannel"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/channel/level1/" do |_|
   "<div id='output'></div>
   <script>
@@ -16,7 +17,8 @@ maze_get "/channel/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("channel-level2", "/channel/level2/?seed=a", "MessageChannel port relay + insertAdjacentHTML", "GET", ["seed"])
+Xssmaze.push("channel-level2", "/channel/level2/?seed=a", "MessageChannel port relay + insertAdjacentHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["messageport"], sinks: ["insertAdjacentHTML"], delivery: ["query"])
 maze_get "/channel/level2/" do |_|
   "<div id='output'></div>
   <script>
@@ -33,7 +35,8 @@ maze_get "/channel/level2/" do |_|
   </script>"
 end
 
-Xssmaze.push("channel-level3", "/channel/level3/?seed=a", "Worker message relay + createContextualFragment", "GET", ["seed"])
+Xssmaze.push("channel-level3", "/channel/level3/?seed=a", "Worker message relay + createContextualFragment", "GET", ["seed"],
+  vuln: "dom", sources: ["worker-message"], sinks: ["createContextualFragment"], delivery: ["query"])
 maze_get "/channel/level3/" do |_|
   "<div id='output'></div>
   <script>
@@ -58,7 +61,8 @@ maze_get "/channel/level3/" do |_|
   </script>"
 end
 
-Xssmaze.push("channel-level4", "/channel/level4/?seed=a", "BroadcastChannel JSON relay + srcdoc sink", "GET", ["seed"])
+Xssmaze.push("channel-level4", "/channel/level4/?seed=a", "BroadcastChannel JSON relay + srcdoc sink", "GET", ["seed"],
+  vuln: "dom", sources: ["broadcastchannel"], sinks: ["srcdoc"], delivery: ["query"], note: "relayed value is laundered through a JSON.stringify / JSON.parse round-trip")
 maze_get "/channel/level4/" do |_|
   "<iframe id='preview'></iframe>
   <script>

--- a/src/mazes/client_state_xss.cr
+++ b/src/mazes/client_state_xss.cr
@@ -7,7 +7,8 @@
 # ability to treat storage/cookie/history reads as tainted.
 
 # Level 1: localStorage value reflected via innerHTML.
-Xssmaze.push("clientstate-level1", "/clientstate/level1/?pref=a", "localStorage value (seeded from URL) reflected via innerHTML", "GET", ["pref"])
+Xssmaze.push("clientstate-level1", "/clientstate/level1/?pref=a", "localStorage value (seeded from URL) reflected via innerHTML", "GET", ["pref"],
+  vuln: "dom", sources: ["localStorage"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/clientstate/level1/" do |_env|
   "<html><body>
   <h1>User Preference</h1>
@@ -22,7 +23,8 @@ maze_get "/clientstate/level1/" do |_env|
 end
 
 # Level 2: sessionStorage value written via document.write.
-Xssmaze.push("clientstate-level2", "/clientstate/level2/?q=a", "sessionStorage value (seeded from URL) written via document.write", "GET", ["q"])
+Xssmaze.push("clientstate-level2", "/clientstate/level2/?q=a", "sessionStorage value (seeded from URL) written via document.write", "GET", ["q"],
+  vuln: "dom", sources: ["sessionStorage"], sinks: ["document.write"], delivery: ["query"])
 maze_get "/clientstate/level2/" do |_env|
   "<html><body>
   <h1>Recent Search</h1>
@@ -36,7 +38,8 @@ maze_get "/clientstate/level2/" do |_env|
 end
 
 # Level 3: localStorage draft injected via insertAdjacentHTML.
-Xssmaze.push("clientstate-level3", "/clientstate/level3/?draft=a", "localStorage draft (seeded from URL) injected via insertAdjacentHTML", "GET", ["draft"])
+Xssmaze.push("clientstate-level3", "/clientstate/level3/?draft=a", "localStorage draft (seeded from URL) injected via insertAdjacentHTML", "GET", ["draft"],
+  vuln: "dom", sources: ["localStorage"], sinks: ["insertAdjacentHTML"], delivery: ["query"])
 maze_get "/clientstate/level3/" do |_env|
   "<html><body>
   <h1>Autosaved Draft</h1>
@@ -51,7 +54,8 @@ maze_get "/clientstate/level3/" do |_env|
 end
 
 # Level 4: document.cookie value reflected via innerHTML.
-Xssmaze.push("clientstate-level4", "/clientstate/level4/?theme=a", "document.cookie value (seeded from URL) reflected via innerHTML", "GET", ["theme"])
+Xssmaze.push("clientstate-level4", "/clientstate/level4/?theme=a", "document.cookie value (seeded from URL) reflected via innerHTML", "GET", ["theme"],
+  vuln: "dom", sources: ["document.cookie"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/clientstate/level4/" do |_env|
   "<html><body>
   <h1>Theme</h1>
@@ -67,7 +71,8 @@ maze_get "/clientstate/level4/" do |_env|
 end
 
 # Level 5: history.state value reflected via innerHTML.
-Xssmaze.push("clientstate-level5", "/clientstate/level5/?note=a", "history.state value (seeded from URL) reflected via innerHTML", "GET", ["note"])
+Xssmaze.push("clientstate-level5", "/clientstate/level5/?note=a", "history.state value (seeded from URL) reflected via innerHTML", "GET", ["note"],
+  vuln: "dom", sources: ["history.state"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/clientstate/level5/" do |_env|
   "<html><body>
   <h1>Sticky Note</h1>
@@ -82,7 +87,8 @@ maze_get "/clientstate/level5/" do |_env|
 end
 
 # Level 6: localStorage JSON profile field reflected via innerHTML.
-Xssmaze.push("clientstate-level6", "/clientstate/level6/?bio=a", "localStorage JSON profile (seeded from URL) field reflected via innerHTML", "GET", ["bio"])
+Xssmaze.push("clientstate-level6", "/clientstate/level6/?bio=a", "localStorage JSON profile (seeded from URL) field reflected via innerHTML", "GET", ["bio"],
+  vuln: "dom", sources: ["localStorage"], sinks: ["innerHTML"], delivery: ["query"], note: "value is laundered through a JSON.stringify / JSON.parse round-trip")
 maze_get "/clientstate/level6/" do |_env|
   "<html><body>
   <h1>Profile</h1>

--- a/src/mazes/clipboard_xss.cr
+++ b/src/mazes/clipboard_xss.cr
@@ -3,7 +3,8 @@
 # innerHTML reflection from the query, so these are real clipboard XSS
 # cases (require user interaction) rather than disguised reflection XSS.
 
-Xssmaze.push("clipboard-level1", "/clipboard/level1/?query=a", "paste handler innerHTMLs clipboardData.getData('text/html')")
+Xssmaze.push("clipboard-level1", "/clipboard/level1/?query=a", "paste handler innerHTMLs clipboardData.getData('text/html')",
+  vuln: "dom", sources: ["clipboardData"], sinks: ["innerHTML"], delivery: ["query"], note: "the reflected prefix only reaches innerHTML when the user pastes into the contenteditable")
 maze_get "/clipboard/level1/" do |env|
   # Query is reflected into a JS string that the paste handler concatenates
   # with the pasted HTML and writes via innerHTML.
@@ -19,7 +20,8 @@ maze_get "/clipboard/level1/" do |env|
    </script>"
 end
 
-Xssmaze.push("clipboard-level2", "/clipboard/level2/?query=a", "navigator.clipboard.readText concatenated with reflected prefix")
+Xssmaze.push("clipboard-level2", "/clipboard/level2/?query=a", "navigator.clipboard.readText concatenated with reflected prefix",
+  vuln: "dom", sources: ["clipboardData"], sinks: ["innerHTML"], delivery: ["query"], note: "requires a user click plus clipboard-read permission")
 maze_get "/clipboard/level2/" do |env|
   query = env.params.query["query"]
   "<button id='b'>read</button><div id='out'></div>
@@ -33,7 +35,8 @@ maze_get "/clipboard/level2/" do |env|
    </script>"
 end
 
-Xssmaze.push("clipboard-level3", "/clipboard/level3/?query=a", "copy event sets reflected text/html on dataTransfer (sink: target page)")
+Xssmaze.push("clipboard-level3", "/clipboard/level3/?query=a", "copy event sets reflected text/html on dataTransfer (sink: target page)",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["clipboardData.setData"], delivery: ["query"], note: "poisons the clipboard with text/html; execution happens in the page the user later pastes into, not here")
 maze_get "/clipboard/level3/" do |env|
   query = env.params.query["query"]
   "<div id='src'>copy me</div>
@@ -46,7 +49,8 @@ maze_get "/clipboard/level3/" do |env|
    </script>"
 end
 
-Xssmaze.push("clipboard-level4", "/clipboard/level4/?query=a", "ClipboardItem blob text/html consumed by paste-listener page")
+Xssmaze.push("clipboard-level4", "/clipboard/level4/?query=a", "ClipboardItem blob text/html consumed by paste-listener page",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["clipboardData.setData"], delivery: ["query"], note: "requires a user click; the ClipboardItem executes in the page the user later pastes into, not here")
 maze_get "/clipboard/level4/" do |env|
   query = env.params.query["query"]
   "<button id='b'>copy</button>

--- a/src/mazes/code_exec_sink_xss.cr
+++ b/src/mazes/code_exec_sink_xss.cr
@@ -7,7 +7,8 @@
 
 # Level 1: dynamic import() of a location.search value. A leading data: or
 # https: specifier loads and runs an attacker-controlled ES module.
-Xssmaze.push("codeexec-level1", "/codeexec/level1/?query=a", "dynamic import() of a location.search value (ESM module load)")
+Xssmaze.push("codeexec-level1", "/codeexec/level1/?query=a", "dynamic import() of a location.search value (ESM module load)",
+  vuln: "dom", sources: ["location.search"], sinks: ["dynamic-import"], delivery: ["query"])
 maze_get "/codeexec/level1/" do |_env|
   "<html><body>
   <h1>Dynamic Module Loader</h1>
@@ -28,7 +29,8 @@ end
 
 # Level 2: dynamic import() with a server-reflected specifier inlined into the
 # import() call. A data: URL runs directly; a quote also breaks the JS string.
-Xssmaze.push("codeexec-level2", "/codeexec/level2/?query=a", "dynamic import() with server-reflected module specifier")
+Xssmaze.push("codeexec-level2", "/codeexec/level2/?query=a", "dynamic import() with server-reflected module specifier",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"])
 maze_get "/codeexec/level2/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -46,7 +48,8 @@ end
 
 # Level 3: inline <script> body taken from location.hash. Assigning to
 # script.text and appending the element executes the code as JavaScript.
-Xssmaze.push("codeexec-level3", "/codeexec/level3/", "inline script element text from location.hash (createElement+append)", "GET", ["#hash"])
+Xssmaze.push("codeexec-level3", "/codeexec/level3/", "inline script element text from location.hash (createElement+append)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["script.text"], delivery: ["fragment"])
 maze_get "/codeexec/level3/" do |_env|
   "<html><body>
   <h1>Hash Script Runner</h1>
@@ -64,7 +67,8 @@ end
 
 # Level 4: server-reflected snippet assigned to an inline script element body.
 # The reflected value becomes the script source text and runs verbatim.
-Xssmaze.push("codeexec-level4", "/codeexec/level4/?query=a", "server-reflected text injected into an inline script element")
+Xssmaze.push("codeexec-level4", "/codeexec/level4/?query=a", "server-reflected text injected into an inline script element",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["script.text"], delivery: ["query"])
 maze_get "/codeexec/level4/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -81,7 +85,8 @@ end
 
 # Level 5: DOM event-handler attribute set from a reflected value via
 # setAttribute('onclick', ...). Programmatically clicking fires the handler.
-Xssmaze.push("codeexec-level5", "/codeexec/level5/?query=a", "DOM event-handler attribute set via setAttribute('onclick', ...)")
+Xssmaze.push("codeexec-level5", "/codeexec/level5/?query=a", "DOM event-handler attribute set via setAttribute('onclick', ...)",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["setAttribute", "event-handler-attribute"], delivery: ["query"], note: "the handler is fired programmatically 200ms after load")
 maze_get "/codeexec/level5/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -100,7 +105,8 @@ end
 
 # Level 6: dynamic external script whose src comes from a reflected value.
 # An attacker-controlled URL (//host/x.js or data:) loads and runs as script.
-Xssmaze.push("codeexec-level6", "/codeexec/level6/?query=a", "dynamic external script src from reflected value")
+Xssmaze.push("codeexec-level6", "/codeexec/level6/?query=a", "dynamic external script src from reflected value",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["script.src"], delivery: ["query"])
 maze_get "/codeexec/level6/" do |env|
   query = env.params.query.fetch("query", "")
 

--- a/src/mazes/csti_xss.cr
+++ b/src/mazes/csti_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("csti-level1", "/csti/level1/?query=a", "AngularJS 1.x template injection via ng-app")
+Xssmaze.push("csti-level1", "/csti/level1/?query=a", "AngularJS 1.x template injection via ng-app",
+  vuln: "csti", delivery: ["query"], note: "AngularJS 1.8.3 ng-app scope; payload is a {{ }} template expression")
 maze_get "/csti/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/csti/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("csti-level2", "/csti/level2/?query=a", "AngularJS 1.x sandbox escape (older version)")
+Xssmaze.push("csti-level2", "/csti/level2/?query=a", "AngularJS 1.x sandbox escape (older version)",
+  vuln: "csti", delivery: ["query"], note: "AngularJS 1.6.0 ng-app scope; sandbox-escape expression")
 maze_get "/csti/level2/" do |env|
   query = env.params.query["query"]
 
@@ -22,7 +24,8 @@ maze_get "/csti/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("csti-level3", "/csti/level3/?query=a", "Vue.js v-html directive injection")
+Xssmaze.push("csti-level3", "/csti/level3/?query=a", "Vue.js v-html directive injection",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["vue.v-html"], delivery: ["query"], note: "not template evaluation: the value is server-inlined into Vue data and rendered by the v-html innerHTML sink")
 maze_get "/csti/level3/" do |env|
   query = env.params.query["query"]
 
@@ -42,7 +45,8 @@ maze_get "/csti/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("csti-level4", "/csti/level4/?query=a", "Vue.js template compilation injection")
+Xssmaze.push("csti-level4", "/csti/level4/?query=a", "Vue.js template compilation injection",
+  vuln: "csti", delivery: ["query"], note: "Vue 2 compiles #app as a template; payload is a {{ }} expression")
 maze_get "/csti/level4/" do |env|
   query = env.params.query["query"]
 
@@ -57,7 +61,8 @@ maze_get "/csti/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("csti-level5", "/csti/level5/?query=a", "jQuery html() method injection")
+Xssmaze.push("csti-level5", "/csti/level5/?query=a", "jQuery html() method injection",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["jquery.html"], delivery: ["query"], note: "not template evaluation: the value reaches jQuery .html(), an innerHTML sink")
 maze_get "/csti/level5/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/data_attribute_xss.cr
+++ b/src/mazes/data_attribute_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflected in <div data-value="QUERY">
 # Bypass: " onfocus=alert(1) autofocus x="
-Xssmaze.push("dataattr-level1", "/data-attribute/level1/?query=a", "reflected in data-value double-quoted attribute")
+Xssmaze.push("dataattr-level1", "/data-attribute/level1/?query=a", "reflected in data-value double-quoted attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/data-attribute/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: Reflected in single-quoted attribute with JSON content
 # Bypass: ' onfocus=alert(1) autofocus x='
-Xssmaze.push("dataattr-level2", "/data-attribute/level2/?query=a", "reflected in single-quoted data-config JSON attribute")
+Xssmaze.push("dataattr-level2", "/data-attribute/level2/?query=a", "reflected in single-quoted data-config JSON attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "single-quoted data-config attribute holding JSON")
 maze_get "/data-attribute/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ end
 
 # Level 3: Reflected in <span data-tooltip="QUERY" class="tip">
 # Bypass: " onfocus=alert(1) autofocus x="
-Xssmaze.push("dataattr-level3", "/data-attribute/level3/?query=a", "reflected in data-tooltip double-quoted attribute")
+Xssmaze.push("dataattr-level3", "/data-attribute/level3/?query=a", "reflected in data-tooltip double-quoted attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/data-attribute/level3/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +30,8 @@ end
 
 # Level 4: Reflected in <button data-action="click->controller#QUERY">
 # Bypass: " onfocus=alert(1) autofocus x="
-Xssmaze.push("dataattr-level4", "/data-attribute/level4/?query=a", "reflected in data-action Stimulus-style attribute")
+Xssmaze.push("dataattr-level4", "/data-attribute/level4/?query=a", "reflected in data-action Stimulus-style attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/data-attribute/level4/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +40,8 @@ end
 
 # Level 5: Reflected in single-quoted <div data-src='QUERY'> where ' is NOT encoded
 # Bypass: ' onfocus=alert(1) autofocus x='
-Xssmaze.push("dataattr-level5", "/data-attribute/level5/?query=a", "reflected in single-quoted data-src (double-quote encoded only)")
+Xssmaze.push("dataattr-level5", "/data-attribute/level5/?query=a", "reflected in single-quoted data-src (double-quote encoded only)",
+  vuln: "reflected-attr", delivery: ["query"], note: "double quotes are encoded; the attribute is single-quoted")
 maze_get "/data-attribute/level5/" do |env|
   query = env.params.query["query"]
   encoded = query.gsub("\"", "&quot;")
@@ -46,7 +51,8 @@ end
 
 # Level 6: Reflected in <tr data-url="QUERY"> inside a table
 # Bypass: " onfocus=alert(1) autofocus x="
-Xssmaze.push("dataattr-level6", "/data-attribute/level6/?query=a", "reflected in data-url attribute inside table row")
+Xssmaze.push("dataattr-level6", "/data-attribute/level6/?query=a", "reflected in data-url attribute inside table row",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/data-attribute/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/decode.cr
+++ b/src/mazes/decode.cr
@@ -2,46 +2,38 @@ require "base64"
 
 Xssmaze.push("decode-level1", "/decode/level1/?query=a", "base64 decode")
 maze_get "/decode/level1/" do |env|
-  begin
-    Base64.decode_string(env.params.query["query"])
-  rescue
-    "Decode Error"
-  end
+  Base64.decode_string(env.params.query["query"])
+rescue
+  "Decode Error"
 end
 
 Xssmaze.push("decode-level2", "/decode/level2/?query=a", "url decode")
 maze_get "/decode/level2/" do |env|
-  begin
-    if env.params.query["query"].includes?("<")
-      "Detect Special Character"
-    else
-      URI.decode(env.params.query["query"])
-    end
-  rescue
-    "Decode Error"
+  if env.params.query["query"].includes?("<")
+    "Detect Special Character"
+  else
+    URI.decode(env.params.query["query"])
   end
+rescue
+  "Decode Error"
 end
 
 Xssmaze.push("decode-level3", "/decode/level3/?query=a", "double url decode")
 maze_get "/decode/level3/" do |env|
-  begin
-    data = URI.decode(env.params.query["query"])
-    if data.includes?("<")
-      "Detect Special Character"
-    else
-      URI.decode(data)
-    end
-  rescue
-    "Decode Error"
+  data = URI.decode(env.params.query["query"])
+  if data.includes?("<")
+    "Detect Special Character"
+  else
+    URI.decode(data)
   end
+rescue
+  "Decode Error"
 end
 
 Xssmaze.push("decode-level4", "/decode/level4/?query=a", "double base64 decode")
 maze_get "/decode/level4/" do |env|
-  begin
-    data = Base64.decode_string(env.params.query["query"])
-    Base64.decode_string(data)
-  rescue
-    "Decode Error"
-  end
+  data = Base64.decode_string(env.params.query["query"])
+  Base64.decode_string(data)
+rescue
+  "Decode Error"
 end

--- a/src/mazes/dom.cr
+++ b/src/mazes/dom.cr
@@ -1,25 +1,29 @@
-Xssmaze.push("dom-level1", "/dom/level1/", "dom write (location.href)", "GET", ["#hash"])
+Xssmaze.push("dom-level1", "/dom/level1/", "dom write (location.href)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.href"], sinks: ["document.write"], delivery: ["fragment", "query"])
 maze_get "/dom/level1/" do |_|
   "<script>
           document.write(decodeURI(location.href))
       </script>"
 end
 
-Xssmaze.push("dom-level2", "/dom/level2/", "dom write (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level2", "/dom/level2/", "dom write (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["document.write"], delivery: ["fragment"])
 maze_get "/dom/level2/" do |_|
   "<script>
           document.write(decodeURI(location.hash))
       </script>"
 end
 
-Xssmaze.push("dom-level3", "/dom/level3/", "redirect (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level3", "/dom/level3/", "redirect (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["location-nav"], delivery: ["fragment"])
 maze_get "/dom/level3/" do |_|
   "<script>
           document.location.href = location.hash.replace('#','')
       </script>"
 end
 
-Xssmaze.push("dom-level4", "/dom/level4/", "dom write (query param)")
+Xssmaze.push("dom-level4", "/dom/level4/", "dom write (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["document.write"], delivery: ["query"])
 maze_get "/dom/level4/" do |_|
   "<script>
           const urlParams = new URL(location.href).searchParams;
@@ -28,7 +32,8 @@ maze_get "/dom/level4/" do |_|
       </script>"
 end
 
-Xssmaze.push("dom-level5", "/dom/level5/", "dom write (query param)")
+Xssmaze.push("dom-level5", "/dom/level5/", "dom write (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["eval"], delivery: ["query"])
 maze_get "/dom/level5/" do |_|
   "<script>
           const urlParams = new URL(location.href).searchParams;
@@ -37,7 +42,8 @@ maze_get "/dom/level5/" do |_|
       </script>"
 end
 
-Xssmaze.push("dom-level6", "/dom/level6/", "location.href (query param)")
+Xssmaze.push("dom-level6", "/dom/level6/", "location.href (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["location-nav"], delivery: ["query"])
 maze_get "/dom/level6/" do |_|
   "<script>
           const urlParams = new URL(location.href).searchParams;
@@ -47,7 +53,8 @@ maze_get "/dom/level6/" do |_|
 end
 
 # Simple innerHTML manipulation
-Xssmaze.push("dom-level7", "/dom/level7/", "innerHTML (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level7", "/dom/level7/", "innerHTML (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["innerHTML"], delivery: ["fragment"])
 maze_get "/dom/level7/" do |_|
   "<div id='output'></div>
   <script>
@@ -55,7 +62,8 @@ maze_get "/dom/level7/" do |_|
   </script>"
 end
 
-Xssmaze.push("dom-level8", "/dom/level8/", "innerHTML (query param)")
+Xssmaze.push("dom-level8", "/dom/level8/", "innerHTML (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/dom/level8/" do |_|
   "<div id='output'></div>
   <script>
@@ -66,7 +74,8 @@ maze_get "/dom/level8/" do |_|
 end
 
 # innerText manipulation (safer but can be misused)
-Xssmaze.push("dom-level9", "/dom/level9/", "innerText to script tag")
+Xssmaze.push("dom-level9", "/dom/level9/", "innerText to script tag",
+  vuln: "dom", sources: ["location.search"], sinks: ["script.text"], delivery: ["query"], note: "the inline <script> is empty, so prepare-a-script returned before setting the already-started flag; mutating its text re-runs prepare and the code executes (verified in Chrome)")
 maze_get "/dom/level9/" do |_|
   "<script id='scriptTag'></script>
   <script>
@@ -77,7 +86,8 @@ maze_get "/dom/level9/" do |_|
 end
 
 # Element attribute manipulation - src
-Xssmaze.push("dom-level10", "/dom/level10/", "img src (query param)")
+Xssmaze.push("dom-level10", "/dom/level10/", "img src (query param)",
+  vuln: "non-xss-control", sources: ["location.search"], sinks: ["img.src"], delivery: ["query"], exploitable: false, note: "img.src does not execute javascript: URLs in any modern browser; the taint only reaches an image URL")
 maze_get "/dom/level10/" do |_|
   "<img id='image'>
   <script>
@@ -88,7 +98,8 @@ maze_get "/dom/level10/" do |_|
 end
 
 # Element attribute manipulation - href
-Xssmaze.push("dom-level11", "/dom/level11/", "anchor href (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level11", "/dom/level11/", "anchor href (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["anchor.href"], delivery: ["fragment"], note: "requires a user click on the anchor")
 maze_get "/dom/level11/" do |_|
   "<a id='link'>Click here</a>
   <script>
@@ -97,7 +108,8 @@ maze_get "/dom/level11/" do |_|
 end
 
 # document.cookie reflection
-Xssmaze.push("dom-level12", "/dom/level12/", "document.write (document.cookie)", "GET", ["document.cookie"])
+Xssmaze.push("dom-level12", "/dom/level12/", "document.write (document.cookie)", "GET", ["document.cookie"],
+  vuln: "dom", sources: ["document.cookie"], sinks: ["document.write"], delivery: ["cookie"], note: "payload is delivered in the Cookie request header")
 maze_get "/dom/level12/" do |_|
   "<script>
       document.write(document.cookie)
@@ -105,7 +117,8 @@ maze_get "/dom/level12/" do |_|
 end
 
 # window.name reflection
-Xssmaze.push("dom-level13", "/dom/level13/", "innerHTML (window.name)", "GET", ["window.name"])
+Xssmaze.push("dom-level13", "/dom/level13/", "innerHTML (window.name)", "GET", ["window.name"],
+  vuln: "dom", sources: ["window.name"], sinks: ["innerHTML"], delivery: ["window-name"], note: "requires a prior navigation from a page that sets window.name")
 maze_get "/dom/level13/" do |_|
   "<div id='output'></div>
   <script>
@@ -114,7 +127,8 @@ maze_get "/dom/level13/" do |_|
 end
 
 # document.referrer reflection
-Xssmaze.push("dom-level14", "/dom/level14/", "document.write (document.referrer)", "GET", ["document.referrer"])
+Xssmaze.push("dom-level14", "/dom/level14/", "document.write (document.referrer)", "GET", ["document.referrer"],
+  vuln: "dom", sources: ["document.referrer"], sinks: ["document.write"], delivery: ["referer"], note: "payload is delivered in the Referer request header")
 maze_get "/dom/level14/" do |_|
   "<script>
       document.write(document.referrer)
@@ -122,7 +136,8 @@ maze_get "/dom/level14/" do |_|
 end
 
 # insertAdjacentHTML
-Xssmaze.push("dom-level15", "/dom/level15/", "insertAdjacentHTML (query param)")
+Xssmaze.push("dom-level15", "/dom/level15/", "insertAdjacentHTML (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["insertAdjacentHTML"], delivery: ["query"])
 maze_get "/dom/level15/" do |_|
   "<div id='output'></div>
   <script>
@@ -133,7 +148,8 @@ maze_get "/dom/level15/" do |_|
 end
 
 # outerHTML manipulation
-Xssmaze.push("dom-level16", "/dom/level16/", "outerHTML (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level16", "/dom/level16/", "outerHTML (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["outerHTML"], delivery: ["fragment"])
 maze_get "/dom/level16/" do |_|
   "<div id='output'>Original content</div>
   <script>
@@ -142,7 +158,8 @@ maze_get "/dom/level16/" do |_|
 end
 
 # createElement with setAttribute
-Xssmaze.push("dom-level17", "/dom/level17/", "setAttribute href (query param)")
+Xssmaze.push("dom-level17", "/dom/level17/", "setAttribute href (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["setAttribute", "anchor.href"], delivery: ["query"], note: "requires a user click on the generated anchor")
 maze_get "/dom/level17/" do |_|
   "<div id='container'></div>
   <script>
@@ -156,7 +173,8 @@ maze_get "/dom/level17/" do |_|
 end
 
 # iframe src manipulation
-Xssmaze.push("dom-level18", "/dom/level18/", "iframe src (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level18", "/dom/level18/", "iframe src (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["iframe.src"], delivery: ["fragment"])
 maze_get "/dom/level18/" do |_|
   "<iframe id='frame'></iframe>
   <script>
@@ -165,7 +183,8 @@ maze_get "/dom/level18/" do |_|
 end
 
 # setTimeout with string
-Xssmaze.push("dom-level19", "/dom/level19/", "setTimeout (query param)")
+Xssmaze.push("dom-level19", "/dom/level19/", "setTimeout (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["setTimeout"], delivery: ["query"])
 maze_get "/dom/level19/" do |_|
   "<script>
       const urlParams = new URL(location.href).searchParams;
@@ -175,7 +194,8 @@ maze_get "/dom/level19/" do |_|
 end
 
 # setInterval with string
-Xssmaze.push("dom-level20", "/dom/level20/", "setInterval (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level20", "/dom/level20/", "setInterval (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["setInterval"], delivery: ["fragment"])
 maze_get "/dom/level20/" do |_|
   "<script>
       const hash = location.hash.substring(1);
@@ -184,7 +204,8 @@ maze_get "/dom/level20/" do |_|
 end
 
 # Function constructor
-Xssmaze.push("dom-level21", "/dom/level21/", "Function constructor (query param)")
+Xssmaze.push("dom-level21", "/dom/level21/", "Function constructor (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["Function"], delivery: ["query"])
 maze_get "/dom/level21/" do |_|
   "<script>
       const urlParams = new URL(location.href).searchParams;
@@ -195,7 +216,8 @@ maze_get "/dom/level21/" do |_|
 end
 
 # JSON.parse with innerHTML
-Xssmaze.push("dom-level22", "/dom/level22/", "JSON.parse + innerHTML (query param)")
+Xssmaze.push("dom-level22", "/dom/level22/", "JSON.parse + innerHTML (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "value is laundered through JSON.parse before reaching the sink")
 maze_get "/dom/level22/" do |_|
   "<div id='output'></div>
   <script>
@@ -211,7 +233,8 @@ maze_get "/dom/level22/" do |_|
 end
 
 # postMessage receiver
-Xssmaze.push("dom-level23", "/dom/level23/", "postMessage + innerHTML", "GET", ["postMessage"])
+Xssmaze.push("dom-level23", "/dom/level23/", "postMessage + innerHTML", "GET", ["postMessage"],
+  vuln: "dom", sources: ["postMessage"], sinks: ["innerHTML"], delivery: ["postmessage"], note: "needs an embedder/opener window to postMessage; a request-only scanner cannot deliver this")
 maze_get "/dom/level23/" do |_|
   "<div id='output'></div>
   <script>
@@ -222,7 +245,8 @@ maze_get "/dom/level23/" do |_|
 end
 
 # Template literal in eval-like context
-Xssmaze.push("dom-level24", "/dom/level24/", "template literal eval (query param)")
+Xssmaze.push("dom-level24", "/dom/level24/", "template literal eval (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["eval"], delivery: ["query"], note: "value is interpolated into a template literal that is passed to eval")
 maze_get "/dom/level24/" do |_|
   "<script>
       const urlParams = new URL(location.href).searchParams;
@@ -232,7 +256,8 @@ maze_get "/dom/level24/" do |_|
 end
 
 # DOM clobbering - name attribute
-Xssmaze.push("dom-level25", "/dom/level25/", "DOM clobbering (query param)")
+Xssmaze.push("dom-level25", "/dom/level25/", "DOM clobbering (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/dom/level25/" do |_|
   "<div id='output'></div>
   <script>
@@ -246,7 +271,8 @@ maze_get "/dom/level25/" do |_|
 end
 
 # document.URL reflection
-Xssmaze.push("dom-level26", "/dom/level26/", "document.write (document.URL)", "GET", ["document.URL"])
+Xssmaze.push("dom-level26", "/dom/level26/", "document.write (document.URL)", "GET", ["document.URL"],
+  vuln: "dom", sources: ["document.URL"], sinks: ["document.write"], delivery: ["fragment", "query"])
 maze_get "/dom/level26/" do |_|
   "<script>
       document.write(document.URL)
@@ -254,7 +280,8 @@ maze_get "/dom/level26/" do |_|
 end
 
 # location.search reflection
-Xssmaze.push("dom-level27", "/dom/level27/", "innerHTML (location.search)")
+Xssmaze.push("dom-level27", "/dom/level27/", "innerHTML (location.search)",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "reads the raw query string, not a named parameter")
 maze_get "/dom/level27/" do |_|
   "<div id='output'></div>
   <script>
@@ -263,7 +290,8 @@ maze_get "/dom/level27/" do |_|
 end
 
 # location.pathname reflection
-Xssmaze.push("dom-level28", "/dom/level28/", "document.write (location.pathname)")
+Xssmaze.push("dom-level28", "/dom/level28/", "document.write (location.pathname)",
+  vuln: "dom", sources: ["location.pathname"], sinks: ["document.write"], delivery: ["path"])
 maze_get "/dom/level28/" do |_|
   "<script>
       document.write(location.pathname)
@@ -271,7 +299,8 @@ maze_get "/dom/level28/" do |_|
 end
 
 # Anchor element with javascript: protocol
-Xssmaze.push("dom-level29", "/dom/level29/", "anchor click with javascript: (query param)")
+Xssmaze.push("dom-level29", "/dom/level29/", "anchor click with javascript: (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["anchor.href"], delivery: ["query"], note: "requires a user click on the anchor")
 maze_get "/dom/level29/" do |_|
   "<a id='link' href='#'>Click me</a>
   <script>
@@ -282,7 +311,8 @@ maze_get "/dom/level29/" do |_|
 end
 
 # document.execCommand (legacy but still works in some contexts)
-Xssmaze.push("dom-level30", "/dom/level30/", "insertHTML execCommand (query param)")
+Xssmaze.push("dom-level30", "/dom/level30/", "insertHTML execCommand (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["execCommand.insertHTML"], delivery: ["query"], note: "execCommand('insertHTML') is deprecated; Chromium only")
 maze_get "/dom/level30/" do |_|
   "<div id='editor' contenteditable='true'></div>
   <script>
@@ -294,7 +324,8 @@ maze_get "/dom/level30/" do |_|
 end
 
 # Range.createContextualFragment
-Xssmaze.push("dom-level31", "/dom/level31/", "createContextualFragment (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level31", "/dom/level31/", "createContextualFragment (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["createContextualFragment"], delivery: ["fragment"])
 maze_get "/dom/level31/" do |_|
   "<div id='output'></div>
   <script>
@@ -305,7 +336,8 @@ maze_get "/dom/level31/" do |_|
 end
 
 # DOMParser
-Xssmaze.push("dom-level32", "/dom/level32/", "DOMParser (query param)")
+Xssmaze.push("dom-level32", "/dom/level32/", "DOMParser (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["DOMParser", "innerHTML"], delivery: ["query"])
 maze_get "/dom/level32/" do |_|
   "<div id='output'></div>
   <script>
@@ -318,7 +350,8 @@ maze_get "/dom/level32/" do |_|
 end
 
 # Multiple URL parameters concatenated
-Xssmaze.push("dom-level33", "/dom/level33/", "multiple params concatenation", "GET", ["query", "query2"])
+Xssmaze.push("dom-level33", "/dom/level33/", "multiple params concatenation", "GET", ["query", "query2"],
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "payload must be split across the query and query2 parameters")
 maze_get "/dom/level33/" do |_|
   "<div id='output'></div>
   <script>
@@ -330,7 +363,8 @@ maze_get "/dom/level33/" do |_|
 end
 
 # Object property access
-Xssmaze.push("dom-level34", "/dom/level34/", "object property innerHTML (query param)")
+Xssmaze.push("dom-level34", "/dom/level34/", "object property innerHTML (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/dom/level34/" do |_|
   "<div id='output'></div>
   <script>
@@ -342,7 +376,8 @@ maze_get "/dom/level34/" do |_|
 end
 
 # Array join
-Xssmaze.push("dom-level35", "/dom/level35/", "array join innerHTML (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level35", "/dom/level35/", "array join innerHTML (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["innerHTML"], delivery: ["fragment"], note: "value is laundered through split(',') / join('')")
 maze_get "/dom/level35/" do |_|
   "<div id='output'></div>
   <script>
@@ -353,7 +388,8 @@ end
 
 # iframe srcdoc property assignment (location.hash) — a full HTML document is
 # parsed inside the frame, so an inline <script> here actually executes.
-Xssmaze.push("dom-level36", "/dom/level36/", "iframe srcdoc property (location.hash)", "GET", ["#hash"])
+Xssmaze.push("dom-level36", "/dom/level36/", "iframe srcdoc property (location.hash)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["srcdoc"], delivery: ["fragment"])
 maze_get "/dom/level36/" do |_|
   "<iframe id='frame'></iframe>
   <script>
@@ -362,7 +398,8 @@ maze_get "/dom/level36/" do |_|
 end
 
 # iframe srcdoc property assignment (query param)
-Xssmaze.push("dom-level37", "/dom/level37/", "iframe srcdoc property (query param)")
+Xssmaze.push("dom-level37", "/dom/level37/", "iframe srcdoc property (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["srcdoc"], delivery: ["query"])
 maze_get "/dom/level37/" do |_|
   "<iframe id='frame'></iframe>
   <script>
@@ -374,7 +411,8 @@ end
 
 # iframe srcdoc via setAttribute (query param) — the attribute-name path some
 # scanners model separately from the .srcdoc property assignment.
-Xssmaze.push("dom-level38", "/dom/level38/", "iframe srcdoc via setAttribute (query param)")
+Xssmaze.push("dom-level38", "/dom/level38/", "iframe srcdoc via setAttribute (query param)",
+  vuln: "dom", sources: ["location.search"], sinks: ["setAttribute", "srcdoc"], delivery: ["query"])
 maze_get "/dom/level38/" do |_|
   "<iframe id='frame'></iframe>
   <script>

--- a/src/mazes/dom_context_xss.cr
+++ b/src/mazes/dom_context_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query reflected inside <div id="output">QUERY</div> with no filtering - basic HTML injection
-Xssmaze.push("domctx-level1", "/domctx/level1/?query=a", "reflection in div body with no filtering")
+Xssmaze.push("domctx-level1", "/domctx/level1/?query=a", "reflection in div body with no filtering",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/domctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/domctx/level1/" do |env|
 end
 
 # Level 2: Query reflected in document.write("QUERY") inside script - close script tag and inject
-Xssmaze.push("domctx-level2", "/domctx/level2/?query=a", "reflection in document.write JS string")
+Xssmaze.push("domctx-level2", "/domctx/level2/?query=a", "reflection in document.write JS string",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/domctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +25,8 @@ maze_get "/domctx/level2/" do |env|
 end
 
 # Level 3: Query reflected in .innerHTML = "QUERY" inside script - close script tag and inject
-Xssmaze.push("domctx-level3", "/domctx/level3/?query=a", "reflection in innerHTML assignment JS string")
+Xssmaze.push("domctx-level3", "/domctx/level3/?query=a", "reflection in innerHTML assignment JS string",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/domctx/level3/" do |env|
   query = env.params.query["query"]
 
@@ -37,7 +40,8 @@ maze_get "/domctx/level3/" do |env|
 end
 
 # Level 4: Query reflected as JSON value in <script>var config = {"name":"QUERY"};</script> - close script tag and inject
-Xssmaze.push("domctx-level4", "/domctx/level4/?query=a", "reflection in JSON object inside script tag")
+Xssmaze.push("domctx-level4", "/domctx/level4/?query=a", "reflection in JSON object inside script tag",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/domctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -48,7 +52,8 @@ maze_get "/domctx/level4/" do |env|
 end
 
 # Level 5: Query URL-decoded then reflected in <div>QUERY</div> (server does URI.decode) - send URL-encoded payload
-Xssmaze.push("domctx-level5", "/domctx/level5/?query=a", "server URL-decodes then reflects in div body")
+Xssmaze.push("domctx-level5", "/domctx/level5/?query=a", "server URL-decodes then reflects in div body",
+  vuln: "reflected-html", delivery: ["query"], note: "the server URL-decodes once before reflecting")
 maze_get "/domctx/level5/" do |env|
   query = env.params.query["query"]
   decoded = URI.decode(query)
@@ -60,7 +65,8 @@ maze_get "/domctx/level5/" do |env|
 end
 
 # Level 6: Query reflected in eval("QUERY") inside script - close script tag and inject
-Xssmaze.push("domctx-level6", "/domctx/level6/?query=a", "reflection in eval string inside script tag")
+Xssmaze.push("domctx-level6", "/domctx/level6/?query=a", "reflection in eval string inside script tag",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/domctx/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/dom_sink_xss.cr
+++ b/src/mazes/dom_sink_xss.cr
@@ -1,0 +1,165 @@
+# DOM *sinks* the rest of the lab never exercises. The taint always arrives
+# the same boring way (a `query` parameter read client-side off
+# location.search) so that whatever a tool does or does not find here is a
+# statement about the sink, not about the source.
+#
+# Two families:
+#   - inert-document laundering: build the nodes in a document that has no
+#     browsing context (createHTMLDocument / DOMParser), then move them into
+#     the live one with importNode / adoptNode. Nothing executes until the
+#     move, so a sink list that only knows `innerHTML` sees a safe write.
+#   - non-obvious code-execution and navigation sinks: indirect eval,
+#     Reflect.apply(eval), Array.prototype.map(eval), Object.assign onto
+#     location, setAttributeNS, and form.action + submit().
+
+# Level 1: document.implementation.createHTMLDocument + importNode.
+# The markup is parsed into an inert document, so no resource loads and no
+# handler fires until the imported copy is appended to the live document.
+Xssmaze.push("domsink-level1", "/domsink/level1/?query=a", "createHTMLDocument + importNode moves inert nodes into the live document",
+  vuln: "dom", sources: ["location.search"], sinks: ["createHTMLDocument", "importNode"], delivery: ["query"],
+  note: "innerHTML is written to a document with no browsing context; execution happens on importNode + appendChild")
+maze_get "/domsink/level1/" do |_env|
+  "<html><body>
+  <h1>Inert Document Import</h1>
+  <div id='out'></div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    // Parsed in a document with no browsing context: nothing runs here.
+    var inert = document.implementation.createHTMLDocument('sandbox');
+    inert.body.innerHTML = q;
+    // ...but importing the nodes into the live document activates them.
+    var imported = document.importNode(inert.body, true);
+    while (imported.firstChild) {
+      document.getElementById('out').appendChild(imported.firstChild);
+    }
+  </script>
+  </body></html>"
+end
+
+# Level 2: DOMParser + adoptNode. Same shape as level 1, but the nodes are
+# moved rather than copied, which some analyzers model differently.
+Xssmaze.push("domsink-level2", "/domsink/level2/?query=a", "DOMParser + adoptNode moves parsed nodes into the live document",
+  vuln: "dom", sources: ["location.search"], sinks: ["DOMParser", "adoptNode"], delivery: ["query"],
+  note: "parsed in a detached document, then adopted node-by-node into the live one")
+maze_get "/domsink/level2/" do |_env|
+  "<html><body>
+  <h1>Adopt Parsed Nodes</h1>
+  <div id='out'></div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    var parsed = new DOMParser().parseFromString(q, 'text/html');
+    var out = document.getElementById('out');
+    while (parsed.body.firstChild) {
+      out.appendChild(document.adoptNode(parsed.body.firstChild));
+    }
+  </script>
+  </body></html>"
+end
+
+# Level 3: indirect eval. `(0, eval)(x)` evaluates in global scope and is a
+# distinct call shape from a plain `eval(x)` reference.
+Xssmaze.push("domsink-level3", "/domsink/level3/?query=a", "indirect eval (0, eval)(value) executes in global scope",
+  vuln: "dom", sources: ["location.search"], sinks: ["indirect-eval"], delivery: ["query"],
+  note: "payload is JavaScript, not HTML: (0, eval)(query)")
+maze_get "/domsink/level3/" do |_env|
+  "<html><body>
+  <h1>Indirect Eval</h1>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    // Comma operator detaches eval from its reference: global-scope eval.
+    if (q) { (0, eval)(q); }
+  </script>
+  </body></html>"
+end
+
+# Level 4: Reflect.apply(eval, ...). eval reached through the reflection API
+# rather than by name.
+Xssmaze.push("domsink-level4", "/domsink/level4/?query=a", "Reflect.apply(eval, globalThis, [value]) executes the value as JS",
+  vuln: "dom", sources: ["location.search"], sinks: ["reflect-apply-eval"], delivery: ["query"],
+  note: "payload is JavaScript, not HTML; eval is never called by name")
+maze_get "/domsink/level4/" do |_env|
+  "<html><body>
+  <h1>Reflected Apply</h1>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    if (q) { Reflect.apply(eval, globalThis, [q]); }
+  </script>
+  </body></html>"
+end
+
+# Level 5: Array.prototype.map(eval). eval is passed as a callback, so it is
+# never syntactically applied to the tainted value at all.
+Xssmaze.push("domsink-level5", "/domsink/level5/?query=a", "Array.prototype.map(eval) evaluates each element as JS",
+  vuln: "dom", sources: ["location.search"], sinks: ["array-map-eval"], delivery: ["query"],
+  note: "payload is JavaScript; eval is handed to .map() as a callback and never appears in call position")
+maze_get "/domsink/level5/" do |_env|
+  "<html><body>
+  <h1>Batch Runner</h1>
+  <div id='out'></div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    if (q) {
+      // 'Run every configured step': eval as an iteratee.
+      var results = q.split('\\n').map(eval);
+      document.getElementById('out').textContent = 'ran ' + results.length + ' step(s)';
+    }
+  </script>
+  </body></html>"
+end
+
+# Level 6: Object.assign onto the Location object. The href setter still
+# fires, so a javascript: URL navigates and runs.
+Xssmaze.push("domsink-level6", "/domsink/level6/?query=a", "Object.assign(location, {href: value}) triggers the href setter",
+  vuln: "dom", sources: ["location.search"], sinks: ["object-assign-location", "location-nav"], delivery: ["query"],
+  note: "payload is a javascript: URL; the navigation sink is an Object.assign target, not an assignment expression")
+maze_get "/domsink/level6/" do |_env|
+  "<html><body>
+  <h1>Bulk Config Apply</h1>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    // Config-merge helper that happens to be handed the Location object.
+    if (q) { Object.assign(location, { href: q }); }
+  </script>
+  </body></html>"
+end
+
+# Level 7: setAttributeNS. The namespaced setter installs an event-handler
+# content attribute exactly like setAttribute does.
+Xssmaze.push("domsink-level7", "/domsink/level7/?query=a", "setAttributeNS(null, 'onclick', value) installs an event handler",
+  vuln: "dom", sources: ["location.search"], sinks: ["setAttributeNS", "event-handler-attribute"], delivery: ["query"],
+  note: "payload is JavaScript; the button is clicked programmatically 150ms after load")
+maze_get "/domsink/level7/" do |_env|
+  "<html><body>
+  <h1>Namespaced Attribute</h1>
+  <button id='go'>Run action</button>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    var btn = document.getElementById('go');
+    if (q) {
+      btn.setAttributeNS(null, 'onclick', q);
+      setTimeout(function () { btn.click(); }, 150);
+    }
+  </script>
+  </body></html>"
+end
+
+# Level 8: form.action + programmatic submit(). A javascript: action runs on
+# submission — a navigation sink reached through the form API rather than
+# through `location`.
+Xssmaze.push("domsink-level8", "/domsink/level8/?query=a", "form.action set to a javascript: URL then submitted programmatically",
+  vuln: "dom", sources: ["location.search"], sinks: ["form.action", "form-submit"], delivery: ["query"],
+  note: "payload is a javascript: URL; form.submit() is called 150ms after load")
+maze_get "/domsink/level8/" do |_env|
+  "<html><body>
+  <h1>Auto-Submit Form</h1>
+  <form id='f' method='get'><input type='hidden' name='x' value='1'></form>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    var form = document.getElementById('f');
+    if (q) {
+      form.action = q;
+      setTimeout(function () { form.submit(); }, 150);
+    }
+  </script>
+  </body></html>"
+end

--- a/src/mazes/dom_source_xss.cr
+++ b/src/mazes/dom_source_xss.cr
@@ -1,0 +1,188 @@
+require "uri"
+
+# DOM taint *sources* the rest of the lab never exercises. Every other
+# category here reads location.search / location.hash / postMessage / web
+# storage; these seven read from places a source-sink analyzer has to model
+# separately — an async IndexedDB cursor, a fragment that is itself a
+# querystring, the history entry a popstate returns to, the script element's
+# own URL, a Permissions API promise, a CSS custom property, and a genuine
+# same-origin WebSocket frame (not a synthetic MessageEvent like the older
+# `websocket-xss` / `stream` levels).
+#
+# The sinks are deliberately boring (innerHTML / insertAdjacentHTML /
+# document.write) so that whatever a tool does or does not find is a
+# statement about the *source*, not about the sink.
+
+# Level 1: IndexedDB. The value is written to an object store on the seeding
+# visit and rendered from the store on every visit afterwards — the read is
+# two async callbacks away from the write.
+Xssmaze.push("domsource-level1", "/domsource/level1/?query=a", "IndexedDB object-store value (seeded from URL) reflected via innerHTML",
+  vuln: "dom", sources: ["indexedDB"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "the value is persisted to IndexedDB and read back through two async callbacks; it renders on every later visit even without the parameter")
+maze_get "/domsource/level1/" do |_env|
+  "<html><body>
+  <h1>Saved Note</h1>
+  <div id='out'>loading...</div>
+  <script>
+    var seed = new URLSearchParams(location.search).get('query');
+    var open = indexedDB.open('xssmaze-domsource', 1);
+    open.onupgradeneeded = function (e) { e.target.result.createObjectStore('notes'); };
+    open.onsuccess = function (e) {
+      var db = e.target.result;
+      function render() {
+        var get = db.transaction('notes', 'readonly').objectStore('notes').get('latest');
+        get.onsuccess = function (ev) {
+          if (ev.target.result != null) {
+            document.getElementById('out').innerHTML = ev.target.result;
+          }
+        };
+      }
+      if (seed !== null) {
+        var tx = db.transaction('notes', 'readwrite');
+        tx.objectStore('notes').put(seed, 'latest');
+        tx.oncomplete = render;
+      } else {
+        render();
+      }
+    };
+  </script>
+  </body></html>"
+end
+
+# Level 2: the fragment parsed as its own querystring. Tools that model
+# `location.hash` as one opaque string miss the named key inside it.
+Xssmaze.push("domsource-level2", "/domsource/level2/", "URLSearchParams over location.hash reflected via innerHTML", "GET", ["#msg"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["innerHTML"], delivery: ["fragment"],
+  note: "the fragment is itself a querystring: new URLSearchParams(location.hash.slice(1)).get('msg')")
+maze_get "/domsource/level2/" do |_env|
+  "<html><body>
+  <h1>Fragment Router</h1>
+  <div id='out'></div>
+  <script>
+    // SPA-style hash routing: the fragment carries its own key/value pairs.
+    var params = new URLSearchParams(location.hash.slice(1));
+    var msg = params.get('msg') || '';
+    if (msg) { document.getElementById('out').innerHTML = msg; }
+  </script>
+  </body></html>"
+end
+
+# Level 3: popstate. The payload is stashed on the *current* history entry,
+# a throwaway entry is pushed on top, and going back delivers it through the
+# popstate event's state object.
+Xssmaze.push("domsource-level3", "/domsource/level3/?query=a", "popstate event state round-trip injected via insertAdjacentHTML",
+  vuln: "dom", sources: ["popstate", "history.state"], sinks: ["insertAdjacentHTML"], delivery: ["query"],
+  note: "the sink only runs from the popstate handler, one history.back() after load")
+maze_get "/domsource/level3/" do |_env|
+  "<html><body>
+  <h1>Back-Button Restore</h1>
+  <div id='out'></div>
+  <script>
+    var seed = new URLSearchParams(location.search).get('query');
+    window.addEventListener('popstate', function (e) {
+      if (e.state && e.state.html) {
+        // Restoring 'what the user was looking at' straight into the DOM.
+        document.getElementById('out').insertAdjacentHTML('beforeend', e.state.html);
+      }
+    });
+    if (seed !== null) {
+      history.replaceState({ html: seed }, '');
+      history.pushState({ html: null }, '');
+      setTimeout(function () { history.back(); }, 50);
+    }
+  </script>
+  </body></html>"
+end
+
+# Level 4: document.currentScript.src. The external script reads its *own*
+# URL for configuration — a real pattern for embeddable widget/tag scripts.
+Xssmaze.push("domsource-level4", "/domsource/level4/?query=a", "document.currentScript.src query parameter written via document.write",
+  vuln: "dom", sources: ["currentScript.src"], sinks: ["document.write"], delivery: ["query"],
+  note: "the server only reflects into the <script src> URL; the taint is read back out of document.currentScript.src by /domsource/level4/boot.js")
+maze_get "/domsource/level4/" do |env|
+  query = env.params.query.fetch("query", "")
+  src = "/domsource/level4/boot.js?msg=#{URI.encode_www_form(query)}"
+
+  "<html><body>
+  <h1>Embeddable Widget</h1>
+  <script src=\"#{src}\"></script>
+  </body></html>"
+end
+
+get "/domsource/level4/boot.js" do |env|
+  env.response.content_type = "application/javascript; charset=utf-8"
+  "// Widget bootstrap: configuration is carried on this script's own URL.
+var self = document.currentScript.src;
+var msg = new URL(self).searchParams.get('msg') || '';
+if (msg) { document.write(msg); }"
+end
+
+# Level 5: the sink is only reachable from a Permissions API promise
+# callback. Nothing in the synchronous body of the page touches it.
+Xssmaze.push("domsource-level5", "/domsource/level5/?query=a", "sink reached only inside a navigator.permissions callback",
+  vuln: "dom", sources: ["location.search", "permissions-api"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "the innerHTML assignment lives inside navigator.permissions.query().then(); no synchronous path reaches it")
+maze_get "/domsource/level5/" do |_env|
+  "<html><body>
+  <h1>Notification Settings</h1>
+  <div id='out'>checking permission...</div>
+  <script>
+    var msg = new URLSearchParams(location.search).get('query') || '';
+    navigator.permissions.query({ name: 'notifications' }).then(function (status) {
+      // Render the banner once the permission state is known.
+      document.getElementById('out').innerHTML =
+        '<span data-state=\"' + status.state + '\">' + msg + '</span>';
+    });
+  </script>
+  </body></html>"
+end
+
+# Level 6: a CSS custom property as the carrier. The value round-trips
+# through the CSSOM (setProperty -> getComputedStyle -> getPropertyValue)
+# before it reaches an HTML sink.
+Xssmaze.push("domsource-level6", "/domsource/level6/", "CSS custom property read back via getComputedStyle into insertAdjacentHTML", "GET", ["#hash"],
+  vuln: "dom", sources: ["css-custom-property", "location.hash"], sinks: ["insertAdjacentHTML"], delivery: ["fragment"],
+  note: "the value is stored in a --custom-property and read back through the CSSOM; avoid quotes and unbalanced brackets so it stays a valid declaration value")
+maze_get "/domsource/level6/" do |_env|
+  "<html><body>
+  <h1>Themed Banner</h1>
+  <div id='out'></div>
+  <script>
+    // Theme engine: stash the label on a custom property, read it back later.
+    var raw = decodeURIComponent(location.hash.slice(1));
+    if (raw) { document.documentElement.style.setProperty('--maze-label', raw); }
+    var label = getComputedStyle(document.documentElement)
+      .getPropertyValue('--maze-label').trim();
+    if (label) { document.getElementById('out').insertAdjacentHTML('beforeend', label); }
+  </script>
+  </body></html>"
+end
+
+# Level 7: a real same-origin WebSocket. Unlike the synthetic
+# `websocket-xss` / `stream` levels (which call onmessage by hand), this one
+# actually connects to /domsource/level7/echo and renders the frame the
+# server sends back.
+Xssmaze.push("domsource-level7", "/domsource/level7/?query=a", "real same-origin WebSocket echo frame reflected via innerHTML",
+  vuln: "dom", sources: ["websocket-message"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "a genuine WebSocket round-trip through /domsource/level7/echo, not a synthetic MessageEvent")
+maze_get "/domsource/level7/" do |_env|
+  "<html><body>
+  <h1>Live Feed</h1>
+  <div id='out'>connecting...</div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    var scheme = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    var socket = new WebSocket(scheme + '//' + location.host + '/domsource/level7/echo');
+    socket.onmessage = function (e) {
+      document.getElementById('out').innerHTML = e.data;
+    };
+    socket.onopen = function () { socket.send(q); };
+  </script>
+  </body></html>"
+end
+
+ws "/domsource/level7/echo" do |socket|
+  socket.on_message do |message|
+    socket.send(message)
+  end
+end

--- a/src/mazes/dragdrop_xss.cr
+++ b/src/mazes/dragdrop_xss.cr
@@ -1,6 +1,7 @@
 # Genuine drag-and-drop XSS: the channel is the sink, no shortcut path.
 
-Xssmaze.push("dragdrop-level1", "/dragdrop/level1/?query=a", "drop handler innerHTMLs dataTransfer.getData('text/html') (reflected prefix)")
+Xssmaze.push("dragdrop-level1", "/dragdrop/level1/?query=a", "drop handler innerHTMLs dataTransfer.getData('text/html') (reflected prefix)",
+  vuln: "dom", sources: ["dataTransfer"], sinks: ["innerHTML"], delivery: ["query"], note: "the reflected prefix only reaches innerHTML when the user drops content on the zone")
 maze_get "/dragdrop/level1/" do |env|
   query = env.params.query["query"]
   "<div id='zone' style='border:1px dashed #999;padding:30px'>drop here</div>
@@ -16,7 +17,8 @@ maze_get "/dragdrop/level1/" do |env|
    </script>"
 end
 
-Xssmaze.push("dragdrop-level2", "/dragdrop/level2/?query=a", "dragstart sets reflected text/html (XSS fires in target page)")
+Xssmaze.push("dragdrop-level2", "/dragdrop/level2/?query=a", "dragstart sets reflected text/html (XSS fires in target page)",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["dataTransfer.setData"], delivery: ["query"], note: "requires a user drag; execution happens in the drop-target page, not here")
 maze_get "/dragdrop/level2/" do |env|
   query = env.params.query["query"]
   "<div id='src' draggable='true' style='cursor:move;padding:8px;border:1px solid #ccc'>drag me</div>
@@ -28,7 +30,8 @@ maze_get "/dragdrop/level2/" do |env|
    </script>"
 end
 
-Xssmaze.push("dragdrop-level3", "/dragdrop/level3/?query=a", "drop builds <a href> from dropped text/uri-list (no escaping)")
+Xssmaze.push("dragdrop-level3", "/dragdrop/level3/?query=a", "drop builds <a href> from dropped text/uri-list (no escaping)",
+  vuln: "dom", sources: ["dataTransfer"], sinks: ["innerHTML"], delivery: ["query"], note: "requires a user drop; the dropped URI is concatenated into an unquoted <a href>")
 maze_get "/dragdrop/level3/" do |env|
   query = env.params.query["query"]
   "<div id='zone' style='padding:30px;border:1px solid #ccc'>drop link</div>
@@ -45,7 +48,8 @@ maze_get "/dragdrop/level3/" do |env|
    </script>"
 end
 
-Xssmaze.push("dragdrop-level4", "/dragdrop/level4/?query=a", "drop reads files[0] as text/html via FileReader.innerHTML")
+Xssmaze.push("dragdrop-level4", "/dragdrop/level4/?query=a", "drop reads files[0] as text/html via FileReader.innerHTML",
+  vuln: "dom", sources: ["dataTransfer"], sinks: ["innerHTML"], delivery: ["query"], note: "requires the user to drop a file; the FileReader result is concatenated into innerHTML")
 maze_get "/dragdrop/level4/" do |env|
   query = env.params.query["query"]
   "<div id='zone' style='padding:30px;border:1px solid #ccc'>drop file</div>

--- a/src/mazes/encoding_bypass_xss.cr
+++ b/src/mazes/encoding_bypass_xss.cr
@@ -45,14 +45,12 @@ end
 # Level 6: URL decode then strip < > (double URL encode bypass)
 Xssmaze.push("encoding-bypass-level6", "/encoding-bypass/level6/?query=a", "URL decode + angle strip (double encode bypass)")
 maze_get "/encoding-bypass/level6/" do |env|
-  begin
-    query = URI.decode(env.params.query["query"])
-    query = Filters.strip_angles(query)
+  query = URI.decode(env.params.query["query"])
+  query = Filters.strip_angles(query)
 
-    "<html><body>#{query}</body></html>"
-  rescue
-    "Decode Error"
-  end
+  "<html><body>#{query}</body></html>"
+rescue
+  "Decode Error"
 end
 
 # Level 7: Whitelist img/div/span tags, strip everything else

--- a/src/mazes/fragment_xss.cr
+++ b/src/mazes/fragment_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Reflection inside <select><option value="QUERY">
 # Bypass: close option and select tags, then inject HTML
 # e.g. "></option></select><script>alert(1)</script>
-Xssmaze.push("fragment-level1", "/fragment/level1/?query=a", "reflection in option value inside select (break out of option/select)")
+Xssmaze.push("fragment-level1", "/fragment/level1/?query=a", "reflection in option value inside select (break out of option/select)",
+  vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected into an <option value> attribute")
 maze_get "/fragment/level1/" do |env|
   query = env.params.query["query"]
 
@@ -12,7 +13,8 @@ end
 # Uses .sub (not .gsub), so only the first < and > are encoded.
 # Bypass: send dummy <> first to consume the .sub, then real payload
 # e.g. <> <script>alert(1)</script>
-Xssmaze.push("fragment-level2", "/fragment/level2/?query=a", "reflection in pre tag with .sub encoding (only first <> encoded)")
+Xssmaze.push("fragment-level2", "/fragment/level2/?query=a", "reflection in pre tag with .sub encoding (only first <> encoded)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; only the first < and > are entity-encoded")
 maze_get "/fragment/level2/" do |env|
   query = env.params.query["query"]
   filtered = query.sub("<", "&lt;").sub(">", "&gt;")
@@ -23,7 +25,8 @@ end
 # Level 3: Reflection inside <svg> tag as text node
 # Bypass: inject SVG event handlers or close svg and inject HTML
 # e.g. </svg><script>alert(1)</script> or <svg onload=alert(1)>
-Xssmaze.push("fragment-level3", "/fragment/level3/?query=a", "reflection inside svg tag as text node")
+Xssmaze.push("fragment-level3", "/fragment/level3/?query=a", "reflection inside svg tag as text node",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected as an <svg><text> node")
 maze_get "/fragment/level3/" do |env|
   query = env.params.query["query"]
 
@@ -33,7 +36,8 @@ end
 # Level 4: Reflection inside <math> tag
 # Bypass: close the math tag with </math> then inject HTML
 # e.g. </math><script>alert(1)</script>
-Xssmaze.push("fragment-level4", "/fragment/level4/?query=a", "reflection inside math tag (close tag escape)")
+Xssmaze.push("fragment-level4", "/fragment/level4/?query=a", "reflection inside math tag (close tag escape)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected inside <math><mi>")
 maze_get "/fragment/level4/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +47,8 @@ end
 # Level 5: Reflection inside <details><summary>QUERY</summary>
 # Bypass: close summary and details tags, then inject HTML
 # e.g. </summary></details><script>alert(1)</script>
-Xssmaze.push("fragment-level5", "/fragment/level5/?query=a", "reflection inside details/summary (break out and inject)")
+Xssmaze.push("fragment-level5", "/fragment/level5/?query=a", "reflection inside details/summary (break out and inject)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected inside <details><summary>")
 maze_get "/fragment/level5/" do |env|
   query = env.params.query["query"]
 
@@ -53,7 +58,8 @@ end
 # Level 6: Reflection inside <marquee> tag
 # Bypass: close the marquee tag with </marquee> then inject HTML
 # e.g. </marquee><script>alert(1)</script>
-Xssmaze.push("fragment-level6", "/fragment/level6/?query=a", "reflection inside marquee tag (close tag escape)")
+Xssmaze.push("fragment-level6", "/fragment/level6/?query=a", "reflection inside marquee tag (close tag escape)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected inside <marquee>")
 maze_get "/fragment/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/history_state_xss.cr
+++ b/src/mazes/history_state_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("history-state-level1", "/history-state/level1/?seed=a", "history.replaceState bootstrap + innerHTML", "GET", ["seed"])
+Xssmaze.push("history-state-level1", "/history-state/level1/?seed=a", "history.replaceState bootstrap + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["history.state"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/history-state/level1/" do |_|
   "<div id='output'></div>
   <script>
@@ -13,7 +14,8 @@ maze_get "/history-state/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("history-state-level2", "/history-state/level2/?seed=a", "history.replaceState object bootstrap + srcdoc sink", "GET", ["seed"])
+Xssmaze.push("history-state-level2", "/history-state/level2/?seed=a", "history.replaceState object bootstrap + srcdoc sink", "GET", ["seed"],
+  vuln: "dom", sources: ["history.state"], sinks: ["srcdoc"], delivery: ["query"])
 maze_get "/history-state/level2/" do |_|
   "<iframe id='preview'></iframe>
   <script>

--- a/src/mazes/iframe_srcdoc_xss.cr
+++ b/src/mazes/iframe_srcdoc_xss.cr
@@ -1,28 +1,33 @@
-Xssmaze.push("srcdoc-level1", "/srcdoc/level1/?query=a", "iframe srcdoc raw reflection")
+Xssmaze.push("srcdoc-level1", "/srcdoc/level1/?query=a", "iframe srcdoc raw reflection",
+  vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"])
 maze_get "/srcdoc/level1/" do |env|
   query = env.params.query["query"]
   "<iframe srcdoc=\"#{query}\"></iframe>"
 end
 
-Xssmaze.push("srcdoc-level2", "/srcdoc/level2/?query=a", "srcdoc with double-quote strip (single-quote bypass)")
+Xssmaze.push("srcdoc-level2", "/srcdoc/level2/?query=a", "srcdoc with double-quote strip (single-quote bypass)",
+  vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "double quotes stripped; use single quotes")
 maze_get "/srcdoc/level2/" do |env|
   query = env.params.query["query"].gsub("\"", "")
   "<iframe srcdoc=\"#{query}\"></iframe>"
 end
 
-Xssmaze.push("srcdoc-level3", "/srcdoc/level3/?query=a", "srcdoc HTML-encoded outside, parsed inside")
+Xssmaze.push("srcdoc-level3", "/srcdoc/level3/?query=a", "srcdoc HTML-encoded outside, parsed inside",
+  vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "entity-encoded in the outer document but decoded again when srcdoc is parsed")
 maze_get "/srcdoc/level3/" do |env|
   query = env.params.query["query"].gsub("\"", "&quot;")
   "<iframe srcdoc=\"<p>#{query}</p>\"></iframe>"
 end
 
-Xssmaze.push("srcdoc-level4", "/srcdoc/level4/?query=a", "srcdoc with sandbox=allow-scripts")
+Xssmaze.push("srcdoc-level4", "/srcdoc/level4/?query=a", "srcdoc with sandbox=allow-scripts",
+  vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "sandbox='allow-scripts' still permits script execution inside the frame")
 maze_get "/srcdoc/level4/" do |env|
   query = env.params.query["query"]
   "<iframe sandbox='allow-scripts' srcdoc=\"#{query}\"></iframe>"
 end
 
-Xssmaze.push("srcdoc-level5", "/srcdoc/level5/?query=a", "srcdoc built from concat, &lt;script&gt; stripped only")
+Xssmaze.push("srcdoc-level5", "/srcdoc/level5/?query=a", "srcdoc built from concat, &lt;script&gt; stripped only",
+  vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "<script> tags stripped; use an event handler")
 maze_get "/srcdoc/level5/" do |env|
   query = env.params.query["query"].gsub(/<script[^>]*>/i, "").gsub("</script>", "")
   "<iframe srcdoc=\"&lt;html&gt;&lt;body&gt;#{query}&lt;/body&gt;&lt;/html&gt;\"></iframe>"

--- a/src/mazes/jquery_sink_xss.cr
+++ b/src/mazes/jquery_sink_xss.cr
@@ -7,7 +7,8 @@
 # Level 1: $(htmlString) — a string starting with "<" makes jQuery build
 # DOM nodes instead of running a selector. Classic scroll-to / tab plugins
 # do $(location.hash.slice(1)), turning the fragment into live HTML.
-Xssmaze.push("jquery-level1", "/jquery/level1/", "jQuery $() selector turns location.hash into HTML (element creation)", "GET", ["#hash"])
+Xssmaze.push("jquery-level1", "/jquery/level1/", "jQuery $() selector turns location.hash into HTML (element creation)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["jquery.selector"], delivery: ["fragment"])
 maze_get "/jquery/level1/" do |_env|
   "<html><head><script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js'></script></head>
   <body>
@@ -24,7 +25,8 @@ end
 # Level 2: $.parseHTML() explicitly parses a string into DOM nodes. The
 # query lands in a single-quoted JS string and is then parsed + appended,
 # so <img onerror> fires without any quote breakout.
-Xssmaze.push("jquery-level2", "/jquery/level2/?query=a", "jQuery $.parseHTML() of reflected string then append")
+Xssmaze.push("jquery-level2", "/jquery/level2/?query=a", "jQuery $.parseHTML() of reflected string then append",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["jquery.parseHTML"], delivery: ["query"])
 maze_get "/jquery/level2/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -44,7 +46,8 @@ end
 # Level 3: .append() DOM-insertion sink fed from location.search read on
 # the client. Covers the whole .html/.append/.prepend/.before/.after/
 # .replaceWith family that all route through jQuery's HTML parser.
-Xssmaze.push("jquery-level3", "/jquery/level3/?query=a", "jQuery .append() of location.search value (DOM insertion)")
+Xssmaze.push("jquery-level3", "/jquery/level3/?query=a", "jQuery .append() of location.search value (DOM insertion)",
+  vuln: "dom", sources: ["location.search"], sinks: ["jquery.append"], delivery: ["query"])
 maze_get "/jquery/level3/" do |_env|
   "<html><head><script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js'></script></head>
   <body>
@@ -61,7 +64,8 @@ end
 # Level 4: .attr('href', ...) lets a javascript: URL reach a navigable
 # anchor. The query is reflected into a JS string and assigned as href;
 # clicking (or auto-trigger) runs the scheme.
-Xssmaze.push("jquery-level4", "/jquery/level4/?query=a", "jQuery .attr('href', ...) sets javascript: URL on an anchor")
+Xssmaze.push("jquery-level4", "/jquery/level4/?query=a", "jQuery .attr('href', ...) sets javascript: URL on an anchor",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["jquery.attr"], delivery: ["query"], note: "requires a user click on the anchor")
 maze_get "/jquery/level4/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -78,7 +82,8 @@ end
 
 # Level 5: $.globalEval() is jQuery's wrapper around eval in the global
 # scope. Reflected text handed straight to it executes as JavaScript.
-Xssmaze.push("jquery-level5", "/jquery/level5/?query=a", "jQuery $.globalEval() executes reflected string as JS")
+Xssmaze.push("jquery-level5", "/jquery/level5/?query=a", "jQuery $.globalEval() executes reflected string as JS",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["jquery.globalEval"], delivery: ["query"])
 maze_get "/jquery/level5/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -98,7 +103,8 @@ end
 # jQuery treats keys matching jQuery.fn methods specially. The `html` key
 # calls .html(value), so it becomes an innerHTML sink even though the
 # value looks like a harmless attribute map.
-Xssmaze.push("jquery-level6", "/jquery/level6/?query=a", "jQuery $('<tag>', {html: ...}) property-object innerHTML sink")
+Xssmaze.push("jquery-level6", "/jquery/level6/?query=a", "jQuery $('<tag>', {html: ...}) property-object innerHTML sink",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["jquery.html"], delivery: ["query"])
 maze_get "/jquery/level6/" do |env|
   query = env.params.query.fetch("query", "")
 

--- a/src/mazes/mutation_observer_xss.cr
+++ b/src/mazes/mutation_observer_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("mobserver-level1", "/mobserver/level1/?query=a", "MutationObserver re-applies textContent as innerHTML")
+Xssmaze.push("mobserver-level1", "/mobserver/level1/?query=a", "MutationObserver re-applies textContent as innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "a MutationObserver re-applies an added text node's textContent as innerHTML")
 maze_get "/mobserver/level1/" do |env|
   query = env.params.query["query"]
   "<div id='out'></div>
@@ -16,7 +17,8 @@ maze_get "/mobserver/level1/" do |env|
    </script>"
 end
 
-Xssmaze.push("mobserver-level2", "/mobserver/level2/?query=a", "observer copies attribute value into inline event handler-bearing element")
+Xssmaze.push("mobserver-level2", "/mobserver/level2/?query=a", "observer copies attribute value into inline event handler-bearing element",
+  vuln: "dom", sources: ["dataset"], sinks: ["innerHTML"], delivery: ["query"], note: "an attribute observer copies data-payload into a double-quoted title attribute; break out of the quote")
 maze_get "/mobserver/level2/" do |env|
   query = env.params.query["query"]
   "<div id='probe' data-payload='#{query}'></div>
@@ -31,7 +33,8 @@ maze_get "/mobserver/level2/" do |env|
    </script>"
 end
 
-Xssmaze.push("mobserver-level3", "/mobserver/level3/?query=a", "observer relays addedNodes innerHTML between containers")
+Xssmaze.push("mobserver-level3", "/mobserver/level3/?query=a", "observer relays addedNodes innerHTML between containers",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["insertAdjacentHTML", "innerHTML"], delivery: ["query"], note: "the observer relays addedNodes outerHTML into a second container")
 maze_get "/mobserver/level3/" do |env|
   query = env.params.query["query"]
   "<div id='src'></div><div id='out'></div>
@@ -47,7 +50,8 @@ maze_get "/mobserver/level3/" do |env|
    </script>"
 end
 
-Xssmaze.push("mobserver-level4", "/mobserver/level4/?query=a", "characterData observer re-emits data via document.write")
+Xssmaze.push("mobserver-level4", "/mobserver/level4/?query=a", "characterData observer re-emits data via document.write",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["document.write"], delivery: ["query"], note: "a characterData observer re-emits the node data through document.write")
 maze_get "/mobserver/level4/" do |env|
   query = env.params.query["query"]
   "<div id='src'>x</div>

--- a/src/mazes/mxss.cr
+++ b/src/mazes/mxss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("mxss-level1", "/mxss/level1/?query=a", "mutation XSS via innerHTML round-trip")
+Xssmaze.push("mxss-level1", "/mxss/level1/?query=a", "mutation XSS via innerHTML round-trip",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "innerHTML serialize/re-parse round-trip; needs a mutation vector rather than a plain tag")
 maze_get "/mxss/level1/" do |env|
   query = env.params.query["query"]
 
@@ -14,7 +15,8 @@ maze_get "/mxss/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("mxss-level2", "/mxss/level2/?query=a", "mutation XSS via DOMParser + innerHTML re-serialize")
+Xssmaze.push("mxss-level2", "/mxss/level2/?query=a", "mutation XSS via DOMParser + innerHTML re-serialize",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["DOMParser", "innerHTML"], delivery: ["query"], note: "DOMParser parse then re-serialize into innerHTML")
 maze_get "/mxss/level2/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +33,8 @@ maze_get "/mxss/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("mxss-level3", "/mxss/level3/?query=a", "mutation XSS via template + namespace confusion")
+Xssmaze.push("mxss-level3", "/mxss/level3/?query=a", "mutation XSS via template + namespace confusion",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["template.innerHTML", "innerHTML"], delivery: ["query"], note: "template context to document context namespace confusion")
 maze_get "/mxss/level3/" do |env|
   query = env.params.query["query"]
 
@@ -51,7 +54,8 @@ maze_get "/mxss/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("mxss-level4", "/mxss/level4/?query=a", "mutation XSS via SVG foreignObject namespace switch")
+Xssmaze.push("mxss-level4", "/mxss/level4/?query=a", "mutation XSS via SVG foreignObject namespace switch",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["DOMParser", "innerHTML"], delivery: ["query"], note: "SVG foreignObject namespace switch on re-serialization")
 maze_get "/mxss/level4/" do |env|
   query = env.params.query["query"]
 
@@ -71,7 +75,8 @@ maze_get "/mxss/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("mxss-level5", "/mxss/level5/?query=a", "mutation XSS via math/style element parsing differential")
+Xssmaze.push("mxss-level5", "/mxss/level5/?query=a", "mutation XSS via math/style element parsing differential",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "math/style parsing differential on re-serialization")
 maze_get "/mxss/level5/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/nav_sink_xss.cr
+++ b/src/mazes/nav_sink_xss.cr
@@ -10,7 +10,8 @@
 
 # Level 1: window.open(location.hash) — "open in new tab" helper. A
 # javascript: fragment runs in the freshly opened window.
-Xssmaze.push("navsink-level1", "/navsink/level1/", "window.open() of location.hash (javascript: scheme)", "GET", ["#hash"])
+Xssmaze.push("navsink-level1", "/navsink/level1/", "window.open() of location.hash (javascript: scheme)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["window.open"], delivery: ["fragment"])
 maze_get "/navsink/level1/" do |_env|
   "<html><body>
   <h1>Open Link</h1>
@@ -23,7 +24,8 @@ maze_get "/navsink/level1/" do |_env|
 end
 
 # Level 2: window.open() of a location.search value.
-Xssmaze.push("navsink-level2", "/navsink/level2/?query=a", "window.open() of a location.search value (javascript: scheme)")
+Xssmaze.push("navsink-level2", "/navsink/level2/?query=a", "window.open() of a location.search value (javascript: scheme)",
+  vuln: "dom", sources: ["location.search"], sinks: ["window.open"], delivery: ["query"])
 maze_get "/navsink/level2/" do |_env|
   "<html><body>
   <h1>Preview</h1>
@@ -36,7 +38,8 @@ end
 
 # Level 3: location.assign() — the method form of a same-frame navigation.
 # A javascript: URL executes in the current document.
-Xssmaze.push("navsink-level3", "/navsink/level3/?query=a", "location.assign() of a location.search value (javascript: scheme)")
+Xssmaze.push("navsink-level3", "/navsink/level3/?query=a", "location.assign() of a location.search value (javascript: scheme)",
+  vuln: "dom", sources: ["location.search"], sinks: ["location-nav"], delivery: ["query"])
 maze_get "/navsink/level3/" do |_env|
   "<html><body>
   <h1>Redirecting...</h1>
@@ -49,7 +52,8 @@ maze_get "/navsink/level3/" do |_env|
 end
 
 # Level 4: location.replace() of location.hash — SPA bounce/replace flow.
-Xssmaze.push("navsink-level4", "/navsink/level4/", "location.replace() of location.hash (javascript: scheme)", "GET", ["#hash"])
+Xssmaze.push("navsink-level4", "/navsink/level4/", "location.replace() of location.hash (javascript: scheme)", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["location-nav"], delivery: ["fragment"])
 maze_get "/navsink/level4/" do |_env|
   "<html><body>
   <h1>Loading route...</h1>
@@ -62,7 +66,8 @@ end
 
 # Level 5: window.open() with a server-reflected URL inlined into a JS string.
 # The reflection is visible in the served HTML source.
-Xssmaze.push("navsink-level5", "/navsink/level5/?query=a", "server-reflected URL passed to window.open()")
+Xssmaze.push("navsink-level5", "/navsink/level5/?query=a", "server-reflected URL passed to window.open()",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["window.open"], delivery: ["query"])
 maze_get "/navsink/level5/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -77,7 +82,8 @@ end
 
 # Level 6: location.assign() with a server-reflected URL inlined into a JS
 # string.
-Xssmaze.push("navsink-level6", "/navsink/level6/?query=a", "server-reflected URL passed to location.assign()")
+Xssmaze.push("navsink-level6", "/navsink/level6/?query=a", "server-reflected URL passed to location.assign()",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["location-nav"], delivery: ["query"])
 maze_get "/navsink/level6/" do |env|
   query = env.params.query.fetch("query", "")
 

--- a/src/mazes/opener_xss.cr
+++ b/src/mazes/opener_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("opener-level1", "/opener/level1/?seed=a", "window.opener bootstrap + innerHTML", "GET", ["seed"])
+Xssmaze.push("opener-level1", "/opener/level1/?seed=a", "window.opener bootstrap + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["window.opener", "window.name"], sinks: ["innerHTML"], delivery: ["query"], note: "the page opens a second window and the payload crosses via window.opener.name; the popup blocker must allow it")
 maze_get "/opener/level1/" do |_|
   "<div id='output'></div>
   <script>
@@ -13,7 +14,8 @@ maze_get "/opener/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("opener-level2", "/opener/level2/?seed=a", "window.opener object relay + srcdoc", "GET", ["seed"])
+Xssmaze.push("opener-level2", "/opener/level2/?seed=a", "window.opener object relay + srcdoc", "GET", ["seed"],
+  vuln: "dom", sources: ["window.opener"], sinks: ["srcdoc"], delivery: ["query"], note: "the page opens a second window and reads a property off window.opener; the popup blocker must allow it")
 maze_get "/opener/level2/" do |_|
   "<iframe id='preview'></iframe>
   <script>

--- a/src/mazes/polyglot_xss.cr
+++ b/src/mazes/polyglot_xss.cr
@@ -23,15 +23,13 @@ end
 
 Xssmaze.push("polyglot-level3", "/polyglot/level3/?query=a", "triple URL decode")
 maze_get "/polyglot/level3/" do |env|
-  begin
-    data = URI.decode(env.params.query["query"])
-    data = URI.decode(data)
-    if data.includes?("<")
-      "Detect Special Character"
-    else
-      URI.decode(data)
-    end
-  rescue
-    "Decode Error"
+  data = URI.decode(env.params.query["query"])
+  data = URI.decode(data)
+  if data.includes?("<")
+    "Detect Special Character"
+  else
+    URI.decode(data)
   end
+rescue
+  "Decode Error"
 end

--- a/src/mazes/prototype_pollution_xss.cr
+++ b/src/mazes/prototype_pollution_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("prototype-pollution-level1", "/prototype-pollution/level1/?query=a", "prototype pollution via __proto__ + innerHTML gadget")
+Xssmaze.push("prototype-pollution-level1", "/prototype-pollution/level1/?query=a", "prototype pollution via __proto__ + innerHTML gadget",
+  vuln: "prototype-pollution", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "JSON merged into Object.prototype; the polluted `html` key is the innerHTML gadget")
 maze_get "/prototype-pollution/level1/" do |env|
   query = env.params.query["query"]
 
@@ -34,7 +35,8 @@ maze_get "/prototype-pollution/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("prototype-pollution-level2", "/prototype-pollution/level2/?query=a", "prototype pollution via constructor.prototype + src gadget")
+Xssmaze.push("prototype-pollution-level2", "/prototype-pollution/level2/?query=a", "prototype pollution via constructor.prototype + src gadget",
+  vuln: "prototype-pollution", sources: ["server-reflected"], sinks: ["script.src"], delivery: ["query"], note: "the polluted `src` key becomes the src of a dynamically created <script>")
 maze_get "/prototype-pollution/level2/" do |env|
   query = env.params.query["query"]
 
@@ -69,7 +71,8 @@ maze_get "/prototype-pollution/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("prototype-pollution-level3", "/prototype-pollution/level3/?query=a", "prototype pollution via Object.assign + srcdoc gadget")
+Xssmaze.push("prototype-pollution-level3", "/prototype-pollution/level3/?query=a", "prototype pollution via Object.assign + srcdoc gadget",
+  vuln: "prototype-pollution", sources: ["server-reflected"], sinks: ["srcdoc"], delivery: ["query"], note: "the polluted `srcdoc` key reaches an iframe srcdoc")
 maze_get "/prototype-pollution/level3/" do |env|
   query = env.params.query["query"]
 
@@ -106,7 +109,8 @@ maze_get "/prototype-pollution/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("prototype-pollution-level4", "/prototype-pollution/level4/?query=a", "prototype pollution via URL hash JSON + eval gadget")
+Xssmaze.push("prototype-pollution-level4", "/prototype-pollution/level4/?query=a", "prototype pollution via URL hash JSON + eval gadget",
+  vuln: "prototype-pollution", sources: ["location.search"], sinks: ["Function"], delivery: ["query"], note: "the polluted `onInit` key is executed with new Function()")
 maze_get "/prototype-pollution/level4/" do |_|
   "<html><body>
   <h1>Prototype Pollution Level 4</h1>

--- a/src/mazes/prototype_xss.cr
+++ b/src/mazes/prototype_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: WordPress-style settings form — attribute breakout from input value
-Xssmaze.push("prototype-pattern-level1", "/prototype-pattern/level1/?query=a", "WordPress-style input value reflection")
+Xssmaze.push("prototype-pattern-level1", "/prototype-pattern/level1/?query=a", "WordPress-style input value reflection",
+  vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; WordPress-style input value")
 maze_get "/prototype-pattern/level1/" do |env|
   query = env.params.query["query"]
 
@@ -15,7 +16,8 @@ maze_get "/prototype-pattern/level1/" do |env|
 end
 
 # Level 2: PHP error-style — raw HTML injection in error message
-Xssmaze.push("prototype-pattern-level2", "/prototype-pattern/level2/?query=a", "PHP error message reflection (raw injection)")
+Xssmaze.push("prototype-pattern-level2", "/prototype-pattern/level2/?query=a", "PHP error message reflection (raw injection)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; PHP warning text")
 maze_get "/prototype-pattern/level2/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +29,8 @@ maze_get "/prototype-pattern/level2/" do |env|
 end
 
 # Level 3: ASP.NET-style error label — raw HTML injection in span
-Xssmaze.push("prototype-pattern-level3", "/prototype-pattern/level3/?query=a", "ASP.NET-style error label reflection")
+Xssmaze.push("prototype-pattern-level3", "/prototype-pattern/level3/?query=a", "ASP.NET-style error label reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; ASP.NET error label")
 maze_get "/prototype-pattern/level3/" do |env|
   query = env.params.query["query"]
 
@@ -44,7 +47,8 @@ maze_get "/prototype-pattern/level3/" do |env|
 end
 
 # Level 4: Angular-style template — raw HTML injection (server-side rendered)
-Xssmaze.push("prototype-pattern-level4", "/prototype-pattern/level4/?query=a", "Angular-style ng-app reflection (raw injection)")
+Xssmaze.push("prototype-pattern-level4", "/prototype-pattern/level4/?query=a", "Angular-style ng-app reflection (raw injection)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; Angular-shaped markup with no Angular loaded")
 maze_get "/prototype-pattern/level4/" do |env|
   query = env.params.query["query"]
 
@@ -59,7 +63,8 @@ maze_get "/prototype-pattern/level4/" do |env|
 end
 
 # Level 5: React-style server-rendered — raw HTML injection in data-reactroot div
-Xssmaze.push("prototype-pattern-level5", "/prototype-pattern/level5/?query=a", "React-style server-rendered reflection (raw injection)")
+Xssmaze.push("prototype-pattern-level5", "/prototype-pattern/level5/?query=a", "React-style server-rendered reflection (raw injection)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; React-shaped server-rendered markup")
 maze_get "/prototype-pattern/level5/" do |env|
   query = env.params.query["query"]
 
@@ -70,7 +75,8 @@ maze_get "/prototype-pattern/level5/" do |env|
 end
 
 # Level 6: Flask/Jinja-style — no template escaping, raw injection in welcome message
-Xssmaze.push("prototype-pattern-level6", "/prototype-pattern/level6/?query=a", "Flask/Jinja-style unescaped reflection")
+Xssmaze.push("prototype-pattern-level6", "/prototype-pattern/level6/?query=a", "Flask/Jinja-style unescaped reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; Flask/Jinja-shaped welcome message")
 maze_get "/prototype-pattern/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/realworld_encoding_xss.cr
+++ b/src/mazes/realworld_encoding_xss.cr
@@ -5,21 +5,19 @@ require "base64"
 # Requires triple URL-encoded payload (e.g., %25253Cscript%25253E...)
 Xssmaze.push("realworld-encoding-level1", "/realworld-encoding/level1/?query=a", "triple URL decode")
 maze_get "/realworld-encoding/level1/" do |env|
-  begin
-    data = URI.decode(env.params.query["query"])
+  data = URI.decode(env.params.query["query"])
+  if data.includes?("<") || data.includes?(">")
+    "Detect Special Character"
+  else
+    data = URI.decode(data)
     if data.includes?("<") || data.includes?(">")
       "Detect Special Character"
     else
-      data = URI.decode(data)
-      if data.includes?("<") || data.includes?(">")
-        "Detect Special Character"
-      else
-        URI.decode(data)
-      end
+      URI.decode(data)
     end
-  rescue
-    "Decode Error"
   end
+rescue
+  "Decode Error"
 end
 
 # Level 2: Unicode normalization (NFKC)
@@ -27,18 +25,16 @@ end
 # Server blocks literal < and > but normalizes Unicode before reflecting
 Xssmaze.push("realworld-encoding-level2", "/realworld-encoding/level2/?query=a", "Unicode NFKC normalization bypass")
 maze_get "/realworld-encoding/level2/" do |env|
-  begin
-    query = env.params.query["query"]
-    if query.includes?("<") || query.includes?(">")
-      "Detect Special Character"
-    else
-      # NFKC normalization: fullwidth chars become ASCII equivalents
-      normalized = query.unicode_normalize(:nfkc)
-      "<html><body><h1>Unicode Normalization Level</h1><div>#{normalized}</div></body></html>"
-    end
-  rescue
-    "Decode Error"
+  query = env.params.query["query"]
+  if query.includes?("<") || query.includes?(">")
+    "Detect Special Character"
+  else
+    # NFKC normalization: fullwidth chars become ASCII equivalents
+    normalized = query.unicode_normalize(:nfkc)
+    "<html><body><h1>Unicode Normalization Level</h1><div>#{normalized}</div></body></html>"
   end
+rescue
+  "Decode Error"
 end
 
 # Level 3: HTML entity double decode
@@ -47,30 +43,28 @@ end
 # e.g., &amp;lt; -> &lt; (server decode) -> < (browser decode)
 Xssmaze.push("realworld-encoding-level3", "/realworld-encoding/level3/?query=a", "HTML entity double decode")
 maze_get "/realworld-encoding/level3/" do |env|
-  begin
-    query = env.params.query["query"]
-    if query.includes?("<") || query.includes?(">")
-      "Detect Special Character"
-    else
-      # Decode common HTML entities one layer
-      decoded = query
-        .gsub("&amp;", "&")
-        .gsub("&lt;", "<")
-        .gsub("&gt;", ">")
-        .gsub("&quot;", "\"")
-        .gsub("&#39;", "'")
-        .gsub("&#x27;", "'")
-        .gsub("&#x3c;", "<")
-        .gsub("&#x3e;", ">")
-        .gsub("&#x3C;", "<")
-        .gsub("&#x3E;", ">")
-        .gsub("&#60;", "<")
-        .gsub("&#62;", ">")
-      "<html><body><h1>HTML Entity Double Decode Level</h1><div>#{decoded}</div></body></html>"
-    end
-  rescue
-    "Decode Error"
+  query = env.params.query["query"]
+  if query.includes?("<") || query.includes?(">")
+    "Detect Special Character"
+  else
+    # Decode common HTML entities one layer
+    decoded = query
+      .gsub("&amp;", "&")
+      .gsub("&lt;", "<")
+      .gsub("&gt;", ">")
+      .gsub("&quot;", "\"")
+      .gsub("&#39;", "'")
+      .gsub("&#x27;", "'")
+      .gsub("&#x3c;", "<")
+      .gsub("&#x3e;", ">")
+      .gsub("&#x3C;", "<")
+      .gsub("&#x3E;", ">")
+      .gsub("&#60;", "<")
+      .gsub("&#62;", ">")
+    "<html><body><h1>HTML Entity Double Decode Level</h1><div>#{decoded}</div></body></html>"
   end
+rescue
+  "Decode Error"
 end
 
 # Level 4: Mixed encoding chain (Base64 + URL)
@@ -78,13 +72,11 @@ end
 # To exploit: URL-encode your payload, then base64-encode that result
 Xssmaze.push("realworld-encoding-level4", "/realworld-encoding/level4/?query=a", "base64 then URL decode chain")
 maze_get "/realworld-encoding/level4/" do |env|
-  begin
-    data = Base64.decode_string(env.params.query["query"])
-    decoded = URI.decode(data)
-    "<html><body><h1>Mixed Encoding Chain Level</h1><div>#{decoded}</div></body></html>"
-  rescue
-    "Decode Error"
-  end
+  data = Base64.decode_string(env.params.query["query"])
+  decoded = URI.decode(data)
+  "<html><body><h1>Mixed Encoding Chain Level</h1><div>#{decoded}</div></body></html>"
+rescue
+  "Decode Error"
 end
 
 # Level 5: CSS style attribute injection
@@ -122,20 +114,18 @@ end
 # Requires URL-encoded SVG XSS payload (e.g., onload handler)
 Xssmaze.push("realworld-encoding-level7", "/realworld-encoding/level7/?query=a", "SVG with URL decode combo")
 maze_get "/realworld-encoding/level7/" do |env|
-  begin
-    query = env.params.query["query"]
-    if query.includes?("<") || query.includes?(">")
-      "Detect Special Character"
-    else
-      decoded = URI.decode(query)
-      "<html><body>
-      <h1>SVG + Encoding Combo Level</h1>
-      <svg><text>#{decoded}</text></svg>
-      </body></html>"
-    end
-  rescue
-    "Decode Error"
+  query = env.params.query["query"]
+  if query.includes?("<") || query.includes?(">")
+    "Detect Special Character"
+  else
+    decoded = URI.decode(query)
+    "<html><body>
+    <h1>SVG + Encoding Combo Level</h1>
+    <svg><text>#{decoded}</text></svg>
+    </body></html>"
   end
+rescue
+  "Decode Error"
 end
 
 # Level 8: JSON string escape bypass

--- a/src/mazes/referrer_xss.cr
+++ b/src/mazes/referrer_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("referrer-level1", "/referrer/level1/?seed=a", "document.referrer reparse + createContextualFragment", "GET", ["seed"])
+Xssmaze.push("referrer-level1", "/referrer/level1/?seed=a", "document.referrer reparse + createContextualFragment", "GET", ["seed"],
+  vuln: "dom", sources: ["document.referrer"], sinks: ["createContextualFragment"], delivery: ["referer"], note: "payload arrives as document.referrer: send a Referer header, or navigate here from a URL carrying seed=")
 maze_get "/referrer/level1/" do |_|
   "<div id='output'></div>
   <script>
@@ -11,7 +12,8 @@ maze_get "/referrer/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("referrer-level2", "/referrer/level2/?seed=a", "document.referrer reparse + template innerHTML clone", "GET", ["seed"])
+Xssmaze.push("referrer-level2", "/referrer/level2/?seed=a", "document.referrer reparse + template innerHTML clone", "GET", ["seed"],
+  vuln: "dom", sources: ["document.referrer"], sinks: ["template.innerHTML"], delivery: ["referer"], note: "payload arrives as document.referrer: send a Referer header, or navigate here from a URL carrying seed=")
 maze_get "/referrer/level2/" do |_|
   "<div id='output'></div>
   <script>

--- a/src/mazes/reparse_xss.cr
+++ b/src/mazes/reparse_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("reparse-level1", "/reparse/level1/?query=a", "URLSearchParams clone + synthetic URL reparse + innerHTML")
+Xssmaze.push("reparse-level1", "/reparse/level1/?query=a", "URLSearchParams clone + synthetic URL reparse + innerHTML",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "the query is round-tripped through URLSearchParams and a synthetic URL before the sink")
 maze_get "/reparse/level1/" do |_|
   "<div id='output'></div>
   <script>
@@ -10,7 +11,8 @@ maze_get "/reparse/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("reparse-level2", "/reparse/level2/?blob=query=a", "nested querystring reparse + template.content clone", "GET", ["blob"])
+Xssmaze.push("reparse-level2", "/reparse/level2/?blob=query=a", "nested querystring reparse + template.content clone", "GET", ["blob"],
+  vuln: "dom", sources: ["location.search"], sinks: ["template.innerHTML"], delivery: ["query"], note: "payload is nested one querystring deep inside the blob parameter")
 maze_get "/reparse/level2/" do |_|
   "<div id='output'></div>
   <template id='wrapper'></template>
@@ -25,7 +27,8 @@ maze_get "/reparse/level2/" do |_|
   </script>"
 end
 
-Xssmaze.push("reparse-level3", "/reparse/level3/?query=a", "URLSearchParams HTML wrapper + srcdoc reparse")
+Xssmaze.push("reparse-level3", "/reparse/level3/?query=a", "URLSearchParams HTML wrapper + srcdoc reparse",
+  vuln: "dom", sources: ["location.search"], sinks: ["srcdoc"], delivery: ["query"], note: "the value is staged through a second URLSearchParams before reaching srcdoc")
 maze_get "/reparse/level3/" do |_|
   "<iframe id='preview'></iframe>
   <script>
@@ -40,7 +43,8 @@ maze_get "/reparse/level3/" do |_|
   </script>"
 end
 
-Xssmaze.push("reparse-level4", "/reparse/level4/?blob=html=a", "nested blob reparse + srcdoc wrapper", "GET", ["blob"])
+Xssmaze.push("reparse-level4", "/reparse/level4/?blob=html=a", "nested blob reparse + srcdoc wrapper", "GET", ["blob"],
+  vuln: "dom", sources: ["location.search"], sinks: ["srcdoc"], delivery: ["query"], note: "payload is nested one querystring deep inside the blob parameter")
 maze_get "/reparse/level4/" do |_|
   "<iframe id='preview'></iframe>
   <script>
@@ -55,7 +59,8 @@ maze_get "/reparse/level4/" do |_|
   </script>"
 end
 
-Xssmaze.push("reparse-level5", "/reparse/level5/?blob=outer=query=a", "double nested querystring reparse + innerHTML", "GET", ["blob"])
+Xssmaze.push("reparse-level5", "/reparse/level5/?blob=outer=query=a", "double nested querystring reparse + innerHTML", "GET", ["blob"],
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "payload is nested two querystrings deep inside the blob parameter")
 maze_get "/reparse/level5/" do |_|
   "<div id='output'></div>
   <script>

--- a/src/mazes/script_gadget_xss.cr
+++ b/src/mazes/script_gadget_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query in JS object property value — close the string, close the script, inject HTML
-Xssmaze.push("scriptgadget-level1", "/scriptgadget/level1/?query=a", "query in JS object property value (close script to inject)")
+Xssmaze.push("scriptgadget-level1", "/scriptgadget/level1/?query=a", "query in JS object property value (close script to inject)",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/scriptgadget/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/scriptgadget/level1/" do |env|
 end
 
 # Level 2: Query in JS ternary expression — close the string, close the script, inject HTML
-Xssmaze.push("scriptgadget-level2", "/scriptgadget/level2/?query=a", "query in JS ternary expression (close script to inject)")
+Xssmaze.push("scriptgadget-level2", "/scriptgadget/level2/?query=a", "query in JS ternary expression (close script to inject)",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/scriptgadget/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ maze_get "/scriptgadget/level2/" do |env|
 end
 
 # Level 3: Query in JS string concatenation — close the string, close the script, inject HTML
-Xssmaze.push("scriptgadget-level3", "/scriptgadget/level3/?query=a", "query in JS string concatenation (close script to inject)")
+Xssmaze.push("scriptgadget-level3", "/scriptgadget/level3/?query=a", "query in JS string concatenation (close script to inject)",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/scriptgadget/level3/" do |env|
   query = env.params.query["query"]
 
@@ -32,7 +35,8 @@ maze_get "/scriptgadget/level3/" do |env|
 end
 
 # Level 4: Query in JS function call argument — close the string, close the script, inject HTML
-Xssmaze.push("scriptgadget-level4", "/scriptgadget/level4/?query=a", "query in JS function call arg (close script to inject)")
+Xssmaze.push("scriptgadget-level4", "/scriptgadget/level4/?query=a", "query in JS function call arg (close script to inject)",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/scriptgadget/level4/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +49,8 @@ end
 # Level 5: Query in inline event handler — break out of the event attribute with ') then inject new attribute
 # Angle brackets are stripped so you cannot close the tag and inject new tags
 # Must use event attribute injection: ') followed by onmouseover=alert(1) or similar
-Xssmaze.push("scriptgadget-level5", "/scriptgadget/level5/?query=a", "query in onclick handler attr (break out, add event attr)")
+Xssmaze.push("scriptgadget-level5", "/scriptgadget/level5/?query=a", "query in onclick handler attr (break out, add event attr)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped; break out of the onclick attribute instead of injecting a tag")
 maze_get "/scriptgadget/level5/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
 
@@ -55,7 +60,8 @@ maze_get "/scriptgadget/level5/" do |env|
 end
 
 # Level 6: Query in script with JS template literal — close the script, inject HTML
-Xssmaze.push("scriptgadget-level6", "/scriptgadget/level6/?query=a", "query in JS template literal inside script (close script to inject)")
+Xssmaze.push("scriptgadget-level6", "/scriptgadget/level6/?query=a", "query in JS template literal inside script (close script to inject)",
+  vuln: "reflected-js", delivery: ["query"], note: "lands inside a template literal; ${...} also evaluates")
 maze_get "/scriptgadget/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/service_worker_xss.cr
+++ b/src/mazes/service_worker_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("service-worker-level1", "/service-worker/level1/?seed=a", "ServiceWorker message bootstrap + innerHTML", "GET", ["seed"])
+Xssmaze.push("service-worker-level1", "/service-worker/level1/?seed=a", "ServiceWorker message bootstrap + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["serviceworker-message"], sinks: ["innerHTML"], delivery: ["query"], note: "dispatches a synthetic MessageEvent on navigator.serviceWorker; no real ServiceWorker is registered")
 maze_get "/service-worker/level1/" do |_|
   "<div id='output'></div>
   <script>
@@ -19,7 +20,8 @@ maze_get "/service-worker/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("service-worker-level2", "/service-worker/level2/?seed=a", "ServiceWorker message JSON relay + srcdoc", "GET", ["seed"])
+Xssmaze.push("service-worker-level2", "/service-worker/level2/?seed=a", "ServiceWorker message JSON relay + srcdoc", "GET", ["seed"],
+  vuln: "dom", sources: ["serviceworker-message"], sinks: ["srcdoc"], delivery: ["query"], note: "dispatches a synthetic MessageEvent on navigator.serviceWorker; no real ServiceWorker is registered")
 maze_get "/service-worker/level2/" do |_|
   "<iframe id='preview'></iframe>
   <script>

--- a/src/mazes/shadow_dom_xss.cr
+++ b/src/mazes/shadow_dom_xss.cr
@@ -64,7 +64,7 @@ maze_get "/shadow-dom/level4/" do |env|
 end
 
 Xssmaze.push("shadow-dom-level5", "/shadow-dom/level5/?query=a", "shadow DOM + adoptedStyleSheets CSS injection",
-  vuln: "non-xss-control", sources: ["server-reflected"], sinks: ["adoptedStyleSheets"], delivery: ["query"], exploitable: false, note: "CSSStyleSheet.replaceSync accepts CSS only and there is no script-executing CSS sink; this is a CSS-injection control, not XSS")
+  vuln: "reflected-js", sinks: ["adoptedStyleSheets"], delivery: ["query"], note: "the value is reflected raw into a single-quoted JS string argument, so it never has to be valid CSS: close the string and run code with ');alert(1)//")
 maze_get "/shadow-dom/level5/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/shadow_dom_xss.cr
+++ b/src/mazes/shadow_dom_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("shadow-dom-level1", "/shadow-dom/level1/?query=a", "open shadow root + innerHTML")
+Xssmaze.push("shadow-dom-level1", "/shadow-dom/level1/?query=a", "open shadow root + innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["attachShadow.innerHTML"], delivery: ["query"])
 maze_get "/shadow-dom/level1/" do |env|
   query = env.params.query["query"]
 
@@ -13,7 +14,8 @@ maze_get "/shadow-dom/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("shadow-dom-level2", "/shadow-dom/level2/?query=a", "closed shadow root + innerHTML via getter")
+Xssmaze.push("shadow-dom-level2", "/shadow-dom/level2/?query=a", "closed shadow root + innerHTML via getter",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["attachShadow.innerHTML"], delivery: ["query"], note: "closed shadow root: not inspectable from outside, but the injection still executes")
 maze_get "/shadow-dom/level2/" do |env|
   query = env.params.query["query"]
 
@@ -29,7 +31,8 @@ maze_get "/shadow-dom/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("shadow-dom-level3", "/shadow-dom/level3/?query=a", "shadow DOM + slot injection")
+Xssmaze.push("shadow-dom-level3", "/shadow-dom/level3/?query=a", "shadow DOM + slot injection",
+  vuln: "reflected-html", delivery: ["query"], note: "light-DOM reflection that is then slotted into the shadow root")
 maze_get "/shadow-dom/level3/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +48,8 @@ maze_get "/shadow-dom/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("shadow-dom-level4", "/shadow-dom/level4/?query=a", "shadow DOM + declarative shadow DOM")
+Xssmaze.push("shadow-dom-level4", "/shadow-dom/level4/?query=a", "shadow DOM + declarative shadow DOM",
+  vuln: "reflected-html", delivery: ["query"], note: "declarative shadow DOM (<template shadowrootmode>); modern browsers only")
 maze_get "/shadow-dom/level4/" do |env|
   query = env.params.query["query"]
 
@@ -59,7 +63,8 @@ maze_get "/shadow-dom/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("shadow-dom-level5", "/shadow-dom/level5/?query=a", "shadow DOM + adoptedStyleSheets CSS injection")
+Xssmaze.push("shadow-dom-level5", "/shadow-dom/level5/?query=a", "shadow DOM + adoptedStyleSheets CSS injection",
+  vuln: "non-xss-control", sources: ["server-reflected"], sinks: ["adoptedStyleSheets"], delivery: ["query"], exploitable: false, note: "CSSStyleSheet.replaceSync accepts CSS only and there is no script-executing CSS sink; this is a CSS-injection control, not XSS")
 maze_get "/shadow-dom/level5/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/sink_xss.cr
+++ b/src/mazes/sink_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflection in <a> href with onclick handler
-Xssmaze.push("sink-level1", "/sink/level1/?query=a", "href with onclick JS handler")
+Xssmaze.push("sink-level1", "/sink/level1/?query=a", "href with onclick JS handler",
+  vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; lands in the JS string of an onclick attribute")
 maze_get "/sink/level1/" do |env|
   query = env.params.query["query"]
 
@@ -7,7 +8,8 @@ maze_get "/sink/level1/" do |env|
 end
 
 # Level 2: window.location assignment in script (reflected XSS via redirect)
-Xssmaze.push("sink-level2", "/sink/level2/?query=a", "script location assignment")
+Xssmaze.push("sink-level2", "/sink/level2/?query=a", "script location assignment",
+  vuln: "reflected-js", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; double quotes are backslash-escaped, so close the <script> block")
 maze_get "/sink/level2/" do |env|
   query = env.params.query["query"]
   escaped = query.gsub("\"", "\\\"")
@@ -16,7 +18,8 @@ maze_get "/sink/level2/" do |env|
 end
 
 # Level 3: Reflection in form action attribute
-Xssmaze.push("sink-level3", "/sink/level3/?query=a", "form action attribute injection")
+Xssmaze.push("sink-level3", "/sink/level3/?query=a", "form action attribute injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; reflected into a form action attribute")
 maze_get "/sink/level3/" do |env|
   query = env.params.query["query"]
 
@@ -24,7 +27,8 @@ maze_get "/sink/level3/" do |env|
 end
 
 # Level 4: Reflection in embed src
-Xssmaze.push("sink-level4", "/sink/level4/?query=a", "embed src attribute injection")
+Xssmaze.push("sink-level4", "/sink/level4/?query=a", "embed src attribute injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; reflected into an embed src attribute")
 maze_get "/sink/level4/" do |env|
   query = env.params.query["query"]
 
@@ -32,7 +36,8 @@ maze_get "/sink/level4/" do |env|
 end
 
 # Level 5: Reflection in link tag href (stylesheet context)
-Xssmaze.push("sink-level5", "/sink/level5/?query=a", "link stylesheet href injection")
+Xssmaze.push("sink-level5", "/sink/level5/?query=a", "link stylesheet href injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; reflected into a <link> href, break out and add onload")
 maze_get "/sink/level5/" do |env|
   query = env.params.query["query"]
 
@@ -40,7 +45,8 @@ maze_get "/sink/level5/" do |env|
 end
 
 # Level 6: Reflection in data-* attribute (JS reads and uses innerHTML)
-Xssmaze.push("sink-level6", "/sink/level6/?query=a", "data attribute to innerHTML pipeline")
+Xssmaze.push("sink-level6", "/sink/level6/?query=a", "data attribute to innerHTML pipeline",
+  vuln: "dom", sources: ["dataset"], sinks: ["innerHTML"], delivery: ["query"], note: "the server reflects into data-content and client JS copies dataset.content into innerHTML — the only genuine DOM flow in this category")
 maze_get "/sink/level6/" do |env|
   query = env.params.query["query"]
 
@@ -53,7 +59,8 @@ maze_get "/sink/level6/" do |env|
 end
 
 # Level 7: Reflection in textarea + form submission XSS
-Xssmaze.push("sink-level7", "/sink/level7/?query=a", "textarea value with form action")
+Xssmaze.push("sink-level7", "/sink/level7/?query=a", "textarea value with form action",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; reflected inside <textarea>, close the tag first")
 maze_get "/sink/level7/" do |env|
   query = env.params.query["query"]
 
@@ -66,7 +73,8 @@ maze_get "/sink/level7/" do |env|
 end
 
 # Level 8: JSON response with Content-Type text/html (JSONP-like)
-Xssmaze.push("sink-level8", "/sink/level8/?callback=render", "JSONP-like with text/html content-type")
+Xssmaze.push("sink-level8", "/sink/level8/?callback=render", "JSONP-like with text/html content-type",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; JSONP-shaped body served as text/html. The injectable parameter is `callback`, not `query`")
 maze_get "/sink/level8/" do |env|
   callback = env.params.query.fetch("callback", "callback")
   env.response.content_type = "text/html"

--- a/src/mazes/slot_xss.cr
+++ b/src/mazes/slot_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("slot-level1", "/slot/level1/?query=a", "shadow DOM <slot> content unfiltered (light DOM reflection)")
+Xssmaze.push("slot-level1", "/slot/level1/?query=a", "shadow DOM <slot> content unfiltered (light DOM reflection)",
+  vuln: "reflected-html", delivery: ["query"], note: "light-DOM content slotted into an open shadow root")
 maze_get "/slot/level1/" do |env|
   query = env.params.query["query"]
   "<x-card>#{query}</x-card>
@@ -12,7 +13,8 @@ maze_get "/slot/level1/" do |env|
    </script>"
 end
 
-Xssmaze.push("slot-level2", "/slot/level2/?query=a", "named slot reflected into element attribute")
+Xssmaze.push("slot-level2", "/slot/level2/?query=a", "named slot reflected into element attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into a single-quoted slot= attribute")
 maze_get "/slot/level2/" do |env|
   query = env.params.query["query"]
   "<x-tab><span slot='#{query}'>tab body</span></x-tab>
@@ -26,7 +28,8 @@ maze_get "/slot/level2/" do |env|
    </script>"
 end
 
-Xssmaze.push("slot-level3", "/slot/level3/?query=a", "slotchange handler innerHTMLs assignedNodes")
+Xssmaze.push("slot-level3", "/slot/level3/?query=a", "slotchange handler innerHTMLs assignedNodes",
+  vuln: "reflected-html", sources: ["textContent"], sinks: ["innerHTML"], delivery: ["query"], note: "the light-DOM reflection already fires; a slotchange handler additionally relays textContent into shadow innerHTML")
 maze_get "/slot/level3/" do |env|
   query = env.params.query["query"]
   "<x-list>#{query}</x-list>
@@ -45,7 +48,8 @@ maze_get "/slot/level3/" do |env|
    </script>"
 end
 
-Xssmaze.push("slot-level4", "/slot/level4/?query=a", "shadow root opens with mode=open, host innerHTML sink")
+Xssmaze.push("slot-level4", "/slot/level4/?query=a", "shadow root opens with mode=open, host innerHTML sink",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["attachShadow.innerHTML"], delivery: ["query"], note: "query.to_json blocks JS-string breakout, but the value still reaches innerHTML as raw HTML")
 maze_get "/slot/level4/" do |env|
   query = env.params.query["query"]
   "<x-host></x-host>

--- a/src/mazes/storage_event_xss.cr
+++ b/src/mazes/storage_event_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("storage-event-level1", "/storage-event/level1/?seed=a", "storage event newValue + innerHTML", "GET", ["seed"])
+Xssmaze.push("storage-event-level1", "/storage-event/level1/?seed=a", "storage event newValue + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["storage-event"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/storage-event/level1/" do |_|
   "<div id='output'></div>
   <iframe id='listener' style='display:none'></iframe>
@@ -30,7 +31,8 @@ maze_get "/storage-event/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("storage-event-level2", "/storage-event/level2/?seed=a", "storage event oldValue + srcdoc", "GET", ["seed"])
+Xssmaze.push("storage-event-level2", "/storage-event/level2/?seed=a", "storage event oldValue + srcdoc", "GET", ["seed"],
+  vuln: "dom", sources: ["storage-event"], sinks: ["srcdoc"], delivery: ["query"])
 maze_get "/storage-event/level2/" do |_|
   "<iframe id='preview'></iframe>
   <iframe id='listener' style='display:none'></iframe>

--- a/src/mazes/stream_xss.cr
+++ b/src/mazes/stream_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("stream-level1", "/stream/level1/?seed=a", "EventSource message event + innerHTML", "GET", ["seed"])
+Xssmaze.push("stream-level1", "/stream/level1/?seed=a", "EventSource message event + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["eventsource-message"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/stream/level1/" do |_|
   "<div id='output'></div>
   <script>
@@ -16,7 +17,8 @@ maze_get "/stream/level1/" do |_|
   </script>"
 end
 
-Xssmaze.push("stream-level2", "/stream/level2/?seed=a", "WebSocket message event + JSON relay + srcdoc", "GET", ["seed"])
+Xssmaze.push("stream-level2", "/stream/level2/?seed=a", "WebSocket message event + JSON relay + srcdoc", "GET", ["seed"],
+  vuln: "dom", sources: ["websocket-message"], sinks: ["srcdoc"], delivery: ["query"])
 maze_get "/stream/level2/" do |_|
   "<iframe id='preview'></iframe>
   <script>
@@ -39,7 +41,8 @@ maze_get "/stream/level2/" do |_|
   </script>"
 end
 
-Xssmaze.push("stream-level3", "/stream/level3/?seed=a", "SharedWorker message relay + createContextualFragment", "GET", ["seed"])
+Xssmaze.push("stream-level3", "/stream/level3/?seed=a", "SharedWorker message relay + createContextualFragment", "GET", ["seed"],
+  vuln: "dom", sources: ["sharedworker-message"], sinks: ["createContextualFragment"], delivery: ["query"])
 maze_get "/stream/level3/" do |_|
   "<div id='output'></div>
   <script>

--- a/src/mazes/taint_flow_xss.cr
+++ b/src/mazes/taint_flow_xss.cr
@@ -1,0 +1,167 @@
+# Taint-propagation shapes, not new sources or sinks.
+#
+# Every level here is the same trivial flow — read a URL parameter, write it
+# to innerHTML — with one laundering step in between. The source and the sink
+# are both obvious; the question is whether an analyzer can still connect them
+# once the value has been round-tripped through a serializer, hidden behind a
+# Proxy trap or an accessor, or carried across an await / Promise boundary.
+#
+# A tool that reports every level in this category has real dataflow. A tool
+# that reports none of them is pattern-matching `innerHTML =` against a
+# literal `location.search` in the same expression.
+
+# Level 1: JSON.stringify / JSON.parse round-trip. The value leaves the JS
+# heap as text and comes back as a different object.
+Xssmaze.push("taintflow-level1", "/taintflow/level1/?query=a", "value laundered through a JSON.stringify/JSON.parse round-trip",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "taint crosses a serialize/deserialize boundary before the sink")
+maze_get "/taintflow/level1/" do |_env|
+  "<html><body>
+  <h1>Round-Tripped Draft</h1>
+  <div id='out'></div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    var restored = JSON.parse(JSON.stringify({ body: q }));
+    document.getElementById('out').innerHTML = restored.body;
+  </script>
+  </body></html>"
+end
+
+# Level 2: Proxy get trap. The property read that produces the tainted value
+# is a function call on a handler object, not a property access on the store.
+Xssmaze.push("taintflow-level2", "/taintflow/level2/", "value laundered through a Proxy get trap", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["innerHTML"], delivery: ["fragment"],
+  note: "the sink reads a property whose value is produced by a Proxy get trap")
+maze_get "/taintflow/level2/" do |_env|
+  "<html><body>
+  <h1>Proxied Store</h1>
+  <div id='out'></div>
+  <script>
+    var raw = decodeURIComponent(location.hash.slice(1));
+    var store = new Proxy({ body: raw }, {
+      get: function (target, prop) { return target[prop]; }
+    });
+    if (store.body) { document.getElementById('out').innerHTML = store.body; }
+  </script>
+  </body></html>"
+end
+
+# Level 3: class accessor. The taint is stashed on a private-ish field and
+# handed back out by a getter.
+Xssmaze.push("taintflow-level3", "/taintflow/level3/?query=a", "value laundered through a class getter",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "the sink reads an accessor property, not the field the value was written to")
+maze_get "/taintflow/level3/" do |_env|
+  "<html><body>
+  <h1>Model Accessor</h1>
+  <div id='out'></div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    class Message {
+      constructor(value) { this._value = value; }
+      get body() { return this._value; }
+    }
+    document.getElementById('out').innerHTML = new Message(q).body;
+  </script>
+  </body></html>"
+end
+
+# Level 4: async/await. The value crosses a microtask boundary through an
+# awaited async function rather than a .then() chain.
+Xssmaze.push("taintflow-level4", "/taintflow/level4/?query=a", "value laundered through an async/await boundary",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "taint crosses an await, not a .then() callback")
+maze_get "/taintflow/level4/" do |_env|
+  "<html><body>
+  <h1>Awaited Load</h1>
+  <div id='out'>loading...</div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    async function load(value) {
+      return await Promise.resolve(value);
+    }
+    (async function () {
+      var body = await load(q);
+      document.getElementById('out').innerHTML = body;
+    })();
+  </script>
+  </body></html>"
+end
+
+# Level 5: Promise.all. The value is one element of a settled-array
+# destructure, so it arrives by index rather than by name.
+Xssmaze.push("taintflow-level5", "/taintflow/level5/?query=a", "value laundered through a Promise.all result array",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "the tainted element is identified only by its index in the Promise.all result")
+maze_get "/taintflow/level5/" do |_env|
+  "<html><body>
+  <h1>Parallel Fetches</h1>
+  <div id='out'>loading...</div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    Promise.all([
+      Promise.resolve('<section>'),
+      Promise.resolve(q),
+      Promise.resolve('</section>')
+    ]).then(function (parts) {
+      document.getElementById('out').innerHTML = parts.join('');
+    });
+  </script>
+  </body></html>"
+end
+
+# Level 6: structuredClone. A structured deep copy across the same boundary
+# postMessage uses, but entirely in-process.
+Xssmaze.push("taintflow-level6", "/taintflow/level6/?query=a", "value laundered through structuredClone",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "structuredClone deep-copies the wrapper object; the sink reads the copy")
+maze_get "/taintflow/level6/" do |_env|
+  "<html><body>
+  <h1>Cloned State</h1>
+  <div id='out'></div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    var snapshot = structuredClone({ payload: { body: q } });
+    document.getElementById('out').innerHTML = snapshot.payload.body;
+  </script>
+  </body></html>"
+end
+
+# Level 7: tagged template. The value never appears in the template literal's
+# cooked string — it arrives as a positional argument to the tag function.
+Xssmaze.push("taintflow-level7", "/taintflow/level7/", "value laundered through a tagged template function", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["innerHTML"], delivery: ["fragment"],
+  note: "the interpolation is delivered as an argument to a tag function, not spliced into the literal")
+maze_get "/taintflow/level7/" do |_env|
+  "<html><body>
+  <h1>Tagged Template</h1>
+  <div id='out'></div>
+  <script>
+    var raw = decodeURIComponent(location.hash.slice(1));
+    function html(strings, value) {
+      return strings[0] + value + strings[1];
+    }
+    if (raw) {
+      document.getElementById('out').innerHTML = html`<article>${raw}</article>`;
+    }
+  </script>
+  </body></html>"
+end
+
+# Level 8: String.prototype.replace with a function replacer. The tainted
+# value is the *return value* of a callback, never an argument to replace().
+Xssmaze.push("taintflow-level8", "/taintflow/level8/?query=a", "value laundered through a String.replace replacer function",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"],
+  note: "the value is returned by the replacer callback; replace() itself never receives it")
+maze_get "/taintflow/level8/" do |_env|
+  "<html><body>
+  <h1>Template Filler</h1>
+  <div id='out'></div>
+  <script>
+    var q = new URLSearchParams(location.search).get('query') || '';
+    var template = '<p>Hello NAME_SLOT!</p>';
+    var rendered = template.replace('NAME_SLOT', function () { return q; });
+    document.getElementById('out').innerHTML = rendered;
+  </script>
+  </body></html>"
+end

--- a/src/mazes/template_tag_xss.cr
+++ b/src/mazes/template_tag_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("tplel-level1", "/tplel/level1/?query=a", "<template> content cloned into innerHTML")
+Xssmaze.push("tplel-level1", "/tplel/level1/?query=a", "<template> content cloned into innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "inert <template> content is read back out and re-injected with innerHTML, which activates it")
 maze_get "/tplel/level1/" do |env|
   query = env.params.query["query"]
   "<template id='t'>#{query}</template>
@@ -9,7 +10,8 @@ maze_get "/tplel/level1/" do |env|
    </script>"
 end
 
-Xssmaze.push("tplel-level2", "/tplel/level2/?query=a", "template.content.cloneNode then appendChild")
+Xssmaze.push("tplel-level2", "/tplel/level2/?query=a", "template.content.cloneNode then appendChild",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["template.content-clone"], delivery: ["query"], note: "template content is cloned and appended; cloned <script> stays inert, so use an event handler")
 maze_get "/tplel/level2/" do |env|
   query = env.params.query["query"]
   "<template id='t'><span>#{query}</span></template>
@@ -21,7 +23,8 @@ maze_get "/tplel/level2/" do |env|
    </script>"
 end
 
-Xssmaze.push("tplel-level3", "/tplel/level3/?query=a", "<template>'s inert script is reactivated by setHTML")
+Xssmaze.push("tplel-level3", "/tplel/level3/?query=a", "<template>'s inert script is reactivated by setHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/tplel/level3/" do |env|
   query = env.params.query["query"]
   "<template id='t'><img src=x><script>console.log('inert')</script></template>
@@ -33,7 +36,8 @@ maze_get "/tplel/level3/" do |env|
    </script>"
 end
 
-Xssmaze.push("tplel-level4", "/tplel/level4/?query=a", "<template> content concatenated into outer innerHTML")
+Xssmaze.push("tplel-level4", "/tplel/level4/?query=a", "<template> content concatenated into outer innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["template.innerHTML", "innerHTML"], delivery: ["query"])
 maze_get "/tplel/level4/" do |env|
   query = env.params.query["query"]
   "<div id='out'></div>

--- a/src/mazes/trusted_types_xss.cr
+++ b/src/mazes/trusted_types_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("trustedtypes-level1", "/trustedtypes/level1/?query=a", "Trusted Types report-only header, sink reachable")
+Xssmaze.push("trustedtypes-level1", "/trustedtypes/level1/?query=a", "Trusted Types report-only header, sink reachable",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "Trusted Types is sent report-only, so the sink is not blocked")
 maze_get "/trustedtypes/level1/" do |env|
   env.response.headers["Content-Security-Policy-Report-Only"] = "require-trusted-types-for 'script'"
   query = env.params.query["query"]
@@ -8,7 +9,8 @@ maze_get "/trustedtypes/level1/" do |env|
    </script>"
 end
 
-Xssmaze.push("trustedtypes-level2", "/trustedtypes/level2/?query=a", "TT enforced, but page exposes a permissive policy")
+Xssmaze.push("trustedtypes-level2", "/trustedtypes/level2/?query=a", "TT enforced, but page exposes a permissive policy",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "Trusted Types enforced, but the page installs a permissive 'default' policy")
 maze_get "/trustedtypes/level2/" do |env|
   env.response.headers["Content-Security-Policy"] = "require-trusted-types-for 'script'; trusted-types default"
   query = env.params.query["query"]
@@ -21,7 +23,8 @@ maze_get "/trustedtypes/level2/" do |env|
    </script>"
 end
 
-Xssmaze.push("trustedtypes-level3", "/trustedtypes/level3/?query=a", "TT policy that wraps but does not sanitize")
+Xssmaze.push("trustedtypes-level3", "/trustedtypes/level3/?query=a", "TT policy that wraps but does not sanitize",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["trustedtypes.createHTML", "innerHTML"], delivery: ["query"], note: "the Trusted Types policy wraps the value but does not sanitize it")
 maze_get "/trustedtypes/level3/" do |env|
   env.response.headers["Content-Security-Policy"] = "require-trusted-types-for 'script'; trusted-types loose"
   query = env.params.query["query"]
@@ -32,7 +35,8 @@ maze_get "/trustedtypes/level3/" do |env|
    </script>"
 end
 
-Xssmaze.push("trustedtypes-level4", "/trustedtypes/level4/?query=a", "TT only enforced for script, not innerHTML")
+Xssmaze.push("trustedtypes-level4", "/trustedtypes/level4/?query=a", "TT only enforced for script, not innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "no Trusted Types header is sent on this level at all")
 maze_get "/trustedtypes/level4/" do |env|
   query = env.params.query["query"]
   "<div id='out'></div>
@@ -41,7 +45,8 @@ maze_get "/trustedtypes/level4/" do |env|
    </script>"
 end
 
-Xssmaze.push("trustedtypes-level5", "/trustedtypes/level5/?query=a", "policy strips <script> only, allows event handlers")
+Xssmaze.push("trustedtypes-level5", "/trustedtypes/level5/?query=a", "policy strips <script> only, allows event handlers",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["trustedtypes.createHTML", "innerHTML"], delivery: ["query"], note: "the policy strips <script> only; event-handler attributes still fire")
 maze_get "/trustedtypes/level5/" do |env|
   env.response.headers["Content-Security-Policy"] = "require-trusted-types-for 'script'; trusted-types nso"
   query = env.params.query["query"]

--- a/src/mazes/websocket_xss.cr
+++ b/src/mazes/websocket_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("websocket-xss-level1", "/websocket/level1/?query=a", "WebSocket message XSS (basic)")
+Xssmaze.push("websocket-xss-level1", "/websocket/level1/?query=a", "WebSocket message XSS (basic)",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "simulated socket message: the value is server-inlined into a JS string, not received over a real WebSocket")
 maze_get "/websocket/level1/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +19,8 @@ maze_get "/websocket/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("websocket-xss-level2", "/websocket/level2/?query=a", "WebSocket JSON message XSS")
+Xssmaze.push("websocket-xss-level2", "/websocket/level2/?query=a", "WebSocket JSON message XSS",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "simulated socket message laundered through a JSON.parse round-trip")
 maze_get "/websocket/level2/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +41,8 @@ maze_get "/websocket/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("websocket-xss-level3", "/websocket/level3/?query=a", "WebSocket with HTML message rendering")
+Xssmaze.push("websocket-xss-level3", "/websocket/level3/?query=a", "WebSocket with HTML message rendering",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "simulated socket message concatenated into innerHTML")
 maze_get "/websocket/level3/" do |env|
   query = env.params.query["query"]
 
@@ -66,7 +69,8 @@ maze_get "/websocket/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("websocket-xss-level4", "/websocket/level4/?query=a", "WebSocket with eval-based message processing")
+Xssmaze.push("websocket-xss-level4", "/websocket/level4/?query=a", "WebSocket with eval-based message processing",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["eval", "innerHTML"], delivery: ["query"], note: "simulated socket command passed to eval")
 maze_get "/websocket/level4/" do |env|
   query = env.params.query["query"]
 
@@ -90,7 +94,8 @@ maze_get "/websocket/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("websocket-xss-level5", "/websocket/level5/?query=a", "WebSocket with DOM manipulation")
+Xssmaze.push("websocket-xss-level5", "/websocket/level5/?query=a", "WebSocket with DOM manipulation",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["setAttribute", "event-handler-attribute"], delivery: ["query"], note: "sets an onclick attribute from a JSON-parsed message; requires a user click")
 maze_get "/websocket/level5/" do |env|
   query = env.params.query["query"]
 
@@ -116,7 +121,8 @@ maze_get "/websocket/level5/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("websocket-xss-level6", "/websocket/level6/?seed=a", "WebSocket onmessage bootstrap + innerHTML", "GET", ["seed"])
+Xssmaze.push("websocket-xss-level6", "/websocket/level6/?seed=a", "WebSocket onmessage bootstrap + innerHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["websocket-message"], sinks: ["innerHTML"], delivery: ["query"], note: "onmessage is invoked synthetically; the socket itself never connects")
 maze_get "/websocket/level6/" do |_|
   "<html><body>
   <h1>WebSocket XSS Level 6</h1>
@@ -136,7 +142,8 @@ maze_get "/websocket/level6/" do |_|
   </body></html>"
 end
 
-Xssmaze.push("websocket-xss-level7", "/websocket/level7/?seed=a", "EventSource onmessage bootstrap + insertAdjacentHTML", "GET", ["seed"])
+Xssmaze.push("websocket-xss-level7", "/websocket/level7/?seed=a", "EventSource onmessage bootstrap + insertAdjacentHTML", "GET", ["seed"],
+  vuln: "dom", sources: ["eventsource-message"], sinks: ["insertAdjacentHTML"], delivery: ["query"], note: "onmessage is invoked synthetically; the EventSource stream is not a real SSE feed")
 maze_get "/websocket/level7/" do |_|
   "<html><body>
   <h1>WebSocket XSS Level 7</h1>

--- a/src/mazes/worker_xss.cr
+++ b/src/mazes/worker_xss.cr
@@ -2,7 +2,8 @@
 # the worker is a relay: attacker payload travels through the worker
 # boundary and the *page* unsafely consumes the worker's output.
 
-Xssmaze.push("worker-level1", "/worker/level1/?query=a", "page innerHTMLs whatever the worker postMessages back")
+Xssmaze.push("worker-level1", "/worker/level1/?query=a", "page innerHTMLs whatever the worker postMessages back",
+  vuln: "dom", sources: ["worker-message"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/worker/level1/" do |env|
   query = env.params.query["query"]
   "<div id='out'></div>
@@ -14,7 +15,8 @@ maze_get "/worker/level1/" do |env|
    </script>"
 end
 
-Xssmaze.push("worker-level2", "/worker/level2/?query=a", "Worker source built by string concat (untrusted code in worker)")
+Xssmaze.push("worker-level2", "/worker/level2/?query=a", "Worker source built by string concat (untrusted code in worker)",
+  vuln: "dom", sources: ["worker-message"], sinks: ["worker-source", "innerHTML"], delivery: ["query"], note: "the value is concatenated into the Worker source, so it also runs as JS inside the worker")
 maze_get "/worker/level2/" do |env|
   query = env.params.query["query"]
   "<div id='out'></div>
@@ -28,7 +30,8 @@ maze_get "/worker/level2/" do |env|
    </script>"
 end
 
-Xssmaze.push("worker-level3", "/worker/level3/?query=a", "importScripts() with attacker-controlled URL")
+Xssmaze.push("worker-level3", "/worker/level3/?query=a", "importScripts() with attacker-controlled URL",
+  vuln: "dom", sources: ["worker-message"], sinks: ["importScripts", "innerHTML"], delivery: ["query"], note: "the worker importScripts() an attacker URL; its postMessage output lands in page innerHTML")
 maze_get "/worker/level3/" do |env|
   query = env.params.query["query"]
   "<div id='out'></div>
@@ -42,7 +45,8 @@ maze_get "/worker/level3/" do |env|
    </script>"
 end
 
-Xssmaze.push("worker-level4", "/worker/level4/?query=a", "worker eval gadget: page posts query, worker eval()s, returns to innerHTML")
+Xssmaze.push("worker-level4", "/worker/level4/?query=a", "worker eval gadget: page posts query, worker eval()s, returns to innerHTML",
+  vuln: "dom", sources: ["worker-message"], sinks: ["eval", "innerHTML"], delivery: ["query"])
 maze_get "/worker/level4/" do |env|
   query = env.params.query["query"]
   "<div id='out'></div>

--- a/src/mazes/xsleak.cr
+++ b/src/mazes/xsleak.cr
@@ -62,7 +62,8 @@ maze_get "/xsleak/empty" do |env|
 end
 
 # Level 1: Body size oracle (admin vs guest)
-Xssmaze.push("xsleak-level1", "/xsleak/search?q=admin", "body size oracle (admin returns more results)", "GET", ["q"])
+Xssmaze.push("xsleak-level1", "/xsleak/search?q=admin", "body size oracle (admin returns more results)", "GET", ["q"],
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "cross-site leak, not XSS: a response-size oracle. There is no injection sink here, so reporting no XSS is the correct result")
 maze_get "/xsleak/search" do |env|
   xsleak_no_store(env)
   env.response.content_type = "text/html; charset=utf-8"
@@ -90,7 +91,8 @@ maze_get "/xsleak/search" do |env|
 end
 
 # Level 2: Frame-count oracle (admin includes more subframes)
-Xssmaze.push("xsleak-level2", "/xsleak/frame?q=admin", "frame-count oracle (admin includes more iframes)", "GET", ["q"])
+Xssmaze.push("xsleak-level2", "/xsleak/frame?q=admin", "frame-count oracle (admin includes more iframes)", "GET", ["q"],
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "cross-site leak, not XSS: a frame-count oracle. There is no injection sink here, so reporting no XSS is the correct result")
 maze_get "/xsleak/frame" do |env|
   xsleak_no_store(env)
   env.response.content_type = "text/html; charset=utf-8"
@@ -110,7 +112,8 @@ maze_get "/xsleak/frame" do |env|
 end
 
 # Level 3: Load/error oracle (image 200 vs 404)
-Xssmaze.push("xsleak-level3", "/xsleak/avatar.gif?q=admin", "image load oracle (admin returns valid image, guest 404)", "GET", ["q"])
+Xssmaze.push("xsleak-level3", "/xsleak/avatar.gif?q=admin", "image load oracle (admin returns valid image, guest 404)", "GET", ["q"],
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "cross-site leak, not XSS: an image load/error oracle. There is no injection sink here, so reporting no XSS is the correct result")
 maze_get "/xsleak/avatar.gif" do |env|
   xsleak_no_store(env)
   if xsleak_admin?(env)
@@ -125,7 +128,8 @@ maze_get "/xsleak/avatar.gif" do |env|
 end
 
 # Level 4: Timing oracle (guest path is slower)
-Xssmaze.push("xsleak-level4", "/xsleak/timing?q=admin", "timing oracle (guest responds slower)", "GET", ["q"])
+Xssmaze.push("xsleak-level4", "/xsleak/timing?q=admin", "timing oracle (guest responds slower)", "GET", ["q"],
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "cross-site leak, not XSS: a response-timing oracle. There is no injection sink here, so reporting no XSS is the correct result")
 maze_get "/xsleak/timing" do |env|
   xsleak_no_store(env)
   env.response.content_type = "text/plain; charset=utf-8"
@@ -136,7 +140,8 @@ maze_get "/xsleak/timing" do |env|
 end
 
 # Level 5: Redirect-chain oracle (admin has more hops)
-Xssmaze.push("xsleak-level5", "/xsleak/redirect?q=admin", "redirect-chain oracle (admin follows more redirects)", "GET", ["q"])
+Xssmaze.push("xsleak-level5", "/xsleak/redirect?q=admin", "redirect-chain oracle (admin follows more redirects)", "GET", ["q"],
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "cross-site leak, not XSS: a redirect-chain-length oracle. There is no injection sink here, so reporting no XSS is the correct result")
 maze_get "/xsleak/redirect" do |env|
   xsleak_no_store(env)
   hops = xsleak_admin?(env) ? 5 : 1

--- a/src/registry.cr
+++ b/src/registry.cr
@@ -10,10 +10,22 @@ module Xssmaze
   @@mazes = [] of Maze
   @@frozen = false
 
+  # `name`/`url`/`desc`/`method`/`params` are the original positional
+  # contract and must stay put — every existing call site depends on it.
+  # Everything after `params` is structured vulnerability metadata, passed
+  # by keyword; see `Maze` for the schema. Omitting them leaves the endpoint
+  # "unclassified" rather than silently guessing.
   def self.push(name : String, url : String, desc : String,
-                method : String = "GET", params : Array(String) = ["query"])
+                method : String = "GET", params : Array(String) = ["query"],
+                vuln : String = "unclassified",
+                sources : Array(String) = [] of String,
+                sinks : Array(String) = [] of String,
+                delivery : Array(String) = [] of String,
+                exploitable : Bool = true,
+                note : String? = nil)
     raise "maze list is frozen" if @@frozen
-    @@mazes << Maze.new(name, url, desc, method, params)
+    @@mazes << Maze.new(name, url, desc, method, params,
+      vuln, sources, sinks, delivery, exploitable, note)
   end
 
   def self.get : Array(Maze)

--- a/src/server.cr
+++ b/src/server.cr
@@ -106,7 +106,10 @@ module Xssmaze::Server
     get "/map/json" do |env|
       type = env.params.query["type"]?
       q = env.params.query["q"]?
-      if type.nil? && q.nil?
+      vuln = env.params.query["vuln"]?
+      reach = env.params.query["reach"]?
+      exploitable = env.params.query["exploitable"]?
+      if type.nil? && q.nil? && vuln.nil? && reach.nil? && exploitable.nil?
         next Xssmaze::Server.serve(env, map_json_entry, last_modified)
       end
 
@@ -125,6 +128,16 @@ module Xssmaze::Server
           maze = mazes[i]
           maze.name.downcase.includes?(n) || maze.desc.downcase.includes?(n)
         end
+      end
+      if v = vuln
+        filtered_idx = filtered_idx.select { |i| mazes[i].vuln == v }
+      end
+      if r = reach
+        filtered_idx = filtered_idx.select { |i| mazes[i].reach == r }
+      end
+      if e = exploitable
+        want = e != "false" && e != "0"
+        filtered_idx = filtered_idx.select { |i| mazes[i].exploitable == want }
       end
       filtered_objs = filtered_idx.map { |i| maze_json_objs[i] }
       {endpoints: filtered_objs, total: filtered_objs.size}.to_json

--- a/src/server.cr
+++ b/src/server.cr
@@ -43,6 +43,35 @@ module Xssmaze::Server
     end
   end
 
+  # Narrow the catalog by the /map/json filter params. Returns the surviving
+  # indices so the caller can reuse the pre-materialized JSON objects instead
+  # of rebuilding them.
+  def self.filter_indices(mazes : Array(Maze), env) : Array(Int32)
+    idx = (0...mazes.size).to_a
+    if type = env.params.query["type"]?
+      idx = idx.select { |i| mazes[i].type == type }
+    end
+    if needle = env.params.query["q"]?
+      n = needle.downcase
+      idx = idx.select do |i|
+        mazes[i].name.downcase.includes?(n) || mazes[i].desc.downcase.includes?(n)
+      end
+    end
+    if vuln = env.params.query["vuln"]?
+      idx = idx.select { |i| mazes[i].vuln == vuln }
+    end
+    if reach = env.params.query["reach"]?
+      idx = idx.select { |i| mazes[i].reach == reach }
+    end
+    if exploitable = env.params.query["exploitable"]?
+      want = exploitable != "false" && exploitable != "0"
+      idx = idx.select { |i| mazes[i].exploitable? == want }
+    end
+    idx
+  end
+
+  FILTER_PARAMS = %w[type q vuln reach exploitable]
+
   def self.json_no_store(env)
     env.response.content_type = "application/json"
     env.response.headers["Access-Control-Allow-Origin"] = "*"
@@ -104,12 +133,7 @@ module Xssmaze::Server
     # Filter the pre-materialized JSON objects rather than rebuilding tuples.
     map_json_entry = catalog["map_json"]
     get "/map/json" do |env|
-      type = env.params.query["type"]?
-      q = env.params.query["q"]?
-      vuln = env.params.query["vuln"]?
-      reach = env.params.query["reach"]?
-      exploitable = env.params.query["exploitable"]?
-      if type.nil? && q.nil? && vuln.nil? && reach.nil? && exploitable.nil?
+      if FILTER_PARAMS.none? { |p| env.params.query[p]? }
         next Xssmaze::Server.serve(env, map_json_entry, last_modified)
       end
 
@@ -118,28 +142,7 @@ module Xssmaze::Server
       env.response.headers["Cache-Control"] = "public, max-age=60"
       env.response.headers["Vary"] = "Accept-Encoding"
 
-      filtered_idx = (0...mazes.size).to_a
-      if t = type
-        filtered_idx = filtered_idx.select { |i| mazes[i].type == t }
-      end
-      if needle = q
-        n = needle.downcase
-        filtered_idx = filtered_idx.select do |i|
-          maze = mazes[i]
-          maze.name.downcase.includes?(n) || maze.desc.downcase.includes?(n)
-        end
-      end
-      if v = vuln
-        filtered_idx = filtered_idx.select { |i| mazes[i].vuln == v }
-      end
-      if r = reach
-        filtered_idx = filtered_idx.select { |i| mazes[i].reach == r }
-      end
-      if e = exploitable
-        want = e != "false" && e != "0"
-        filtered_idx = filtered_idx.select { |i| mazes[i].exploitable == want }
-      end
-      filtered_objs = filtered_idx.map { |i| maze_json_objs[i] }
+      filtered_objs = Xssmaze::Server.filter_indices(mazes, env).map { |i| maze_json_objs[i] }
       {endpoints: filtered_objs, total: filtered_objs.size}.to_json
     end
 


### PR DESCRIPTION
Came out of benchmarking dalfox's DOM-XSS recall against this lab. Two weaknesses in **xssmaze itself** showed up, and this fixes both.

## 1. `/map/json` had no machine-readable vulnerability metadata

Scoring a scanner per vulnerability class meant regex-classifying the served HTML, which mislabels things badly. Every endpoint now carries a `vuln` object:

```json
"vuln": {
  "class": "dom", "reach": "client", "delivery": ["fragment"],
  "sources": ["location.hash"], "sinks": ["innerHTML"],
  "exploitable": true, "note": null
}
```

`class` is a closed enum (`unclassified`, `reflected-html`, `reflected-attr`, `reflected-js`, `dom`, `stored`, `prototype-pollution`, `csti`, `non-xss-control`). `reach` is **derived** from `delivery` so it can never contradict it — `server` means an HTTP client can deliver the payload, `client` means it only exists browser-side.

**Classification rule** (recorded in `Maze`'s doc comment so it does not drift): classify by the **injection context** — where the bytes land — not by what the receiving API does with a well-formed argument. A value reflected raw into a JS string literal is `reflected-js` however inert the function it is passed to, because the breakout happens before that function is called.

**Backward compatible**: `Xssmaze.push` keeps its positional contract; the six new fields are optional keyword args. All 1036 pre-existing call sites compile untouched, and the 838 untriaged ones report `unclassified` / `unknown` — deliberately distinct from "reviewed and found safe".

Also exposed: `?vuln=` / `?reach=` / `?exploitable=` filters on `/map/json`; `Class`/`Reach`/`Sources`/`Sinks` columns in `/map/markdown`; class + reach histograms in `/map/categories` and `/stats`.

### Mislabels this fixes
- **`fragment` and `sink` are not DOM categories** — they are server-side HTML/attribute reflections. Now classified correctly, each with a note saying the category name is misleading.
- **`prototype-pattern` is not prototype pollution** — six framework-shaped server reflections. Only `prototype-pollution-*` carries that class, with the specific gadget key per note.
- **`csti-level3`/`csti-level5` are not template evaluation** — Vue `v-html` and jQuery `.html()`, i.e. innerHTML sinks.
- **Fragment-only vs query-driven is now explicit** — 20 endpoints are `reach: client`, which a request-only scanner physically cannot reach. Counting those as misses measures the wrong thing.

### Controls (`exploitable: false`, 6 total)
`xsleak-level1..5` are cross-site *leak* oracles with no injection sink, and `dom-level10` is `img.src = query` — no modern browser executes a `javascript:` URL from an image src. A scanner reporting nothing on these is correct. A spec enforces that controls carry an explanatory note and that `non-xss-control` and `exploitable: false` stay in sync.

### Existing docs this corrects
Three levels were documented as inert and are not — all re-verified in-browser: `dom-level9` (empty inline `<script>`, so mutating its text re-runs prepare-a-script), `slot-level4` (`to_json` blocks a JS breakout but the value still reaches `shadowRoot.innerHTML` as HTML), and `shadow-dom-level5` (reflected raw into a single-quoted JS string argument). `solutions/` updated accordingly.

## 2. Thin DOM source/sink coverage — 23 new levels

dalfox already found 80 of the 93 genuine DOM flows here, so the existing set no longer discriminates between tools. Absence was grep-verified before writing each level.

- **`domsource` (7)** — sources nothing else in the lab reads: IndexedDB, `new URLSearchParams(location.hash.slice(1))`, `popstate`+`history.state`, `document.currentScript.src`, a permissions-callback-only sink, a CSS custom property round-tripped through the CSSOM, and **a real same-origin WebSocket** (the first in the repo — the existing `websocket`/`stream` levels only dispatch synthetic `MessageEvent`s, which their notes now say). Sinks are deliberately boring so results speak about the source.
- **`domsink` (8)** — `createHTMLDocument`+`importNode`, `DOMParser`+`adoptNode`, `(0,eval)`, `Reflect.apply(eval,…)`, `Array.prototype.map(eval)`, `Object.assign(location,{href})`, `setAttributeNS('onclick')`+click, `form.action`+`submit()`. Levels 1–2 launder through a document with no browsing context: the `innerHTML` write is genuinely safe *where it happens*, and execution only starts when the nodes move into the live document.
- **`taintflow` (8)** — same `location.*` → `innerHTML` flow with one laundering step: JSON round-trip, Proxy `get` trap, class getter, `async`/`await`, `Promise.all` (tainted element identified only by index), `structuredClone`, tagged template (value never in the cooked strings), and `String.replace` with a replacer function (the value is the callback's *return*, never an argument). Both ends are obvious; the question is whether the analyzer connects them.

Each category gets a `solutions/*.md` guide plus routing specs.

## Verification

`shards build`, `crystal spec` (110 examples, 0 failures), `crystal tool format`, `ameba` (195 files, 0 failures), and a production boot with `/map/json`, `/map/categories`, `/map/openapi`, `/stats`, `/version`, `/health` all parsing.

Exploitability was checked **empirically, not asserted**: every new level and every disputed existing one was loaded in headless Chrome over the DevTools Protocol with `Page.javascriptDialogOpening` as the oracle. There are no unsolvable levels.

Endpoints 1036 → 1059, categories 171 → 174.

## Deliberately skipped
Web Animations / CSS-to-script-gadget (not achievable in a modern browser without a framework gadget — would have been unsolvable); a real registered ServiceWorker (registration is flaky headless, risking an intermittently unsolvable level); Cookie Store API (Chrome-only, and `document.cookie` is already covered); re-verifying all 1036 pre-existing endpoints in a browser (only disputed ones were probed — the remaining 838 are honestly marked `unclassified` rather than guessed at).