### PR TITLE
fix: stop header-reflection and redirect mazes from 500ing; trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,75 +4,75 @@
 [![Crystal Lint](https://github.com/hahwul/xssmaze/actions/workflows/crystal_lint.yml/badge.svg)](https://github.com/hahwul/xssmaze/actions/workflows/crystal_lint.yml)
 [![Docker](https://github.com/hahwul/xssmaze/actions/workflows/ghcr.yml/badge.svg)](https://github.com/hahwul/xssmaze/actions/workflows/ghcr.yml)
 
-XSSMaze is an intentionally vulnerable web application for measuring and improving XSS detection in security testing tools. It covers a wide range of XSS contexts: basic reflection, DOM, header, path, POST, redirect, decode, hidden input, in-JS, in-attribute, in-frame, event handler, CSP bypass, SVG, CSS injection, template injection, WebSocket, JSON, advanced techniques, polyglot, browser-state, opener, storage-event, stream, channel, service-worker, history-state, reparse, referrer, jQuery DOM sinks, dynamic code/module execution sinks, client-state (web storage/cookie/history) sinks, async fetch/XHR API DOM sinks, the 2024 native unsafe HTML-parsing sinks (setHTMLUnsafe/parseHTMLUnsafe), iframe srcdoc property sinks, navigation sinks (window.open/location.assign/location.replace), under-covered DOM sources (IndexedDB, hash-as-querystring, popstate, document.currentScript.src, Permissions API callbacks, CSS custom properties, a real same-origin WebSocket), under-covered DOM sinks (createHTMLDocument/importNode, DOMParser/adoptNode, indirect eval, Reflect.apply(eval), map(eval), Object.assign(location), setAttributeNS, form.action+submit), and taint-propagation shapes that defeat naive analyzers (JSON round-trip, Proxy traps, class getters, await, Promise.all, structuredClone, tagged templates, replacer functions).
+XSSMaze is an intentionally vulnerable web application for measuring and improving XSS
+detection in security testing tools. It serves 1000+ endpoints across 170+ categories —
+reflected, DOM, stored, and header/path/body injection, plus filter and WAF bypasses,
+CSP gadgets, prototype pollution, template injection, and modern DOM sink/source shapes
+that defeat naive taint analysis.
+
+Every endpoint ships structured metadata, so a benchmark can score per vulnerability
+class instead of regex-guessing at the served HTML.
 
 ![](images/showcase.png)
 
-## Installation
+> [!WARNING]
+> This app is deliberately vulnerable. It binds to `127.0.0.1` by default — only pass
+> `-b 0.0.0.0` on a network you trust.
 
-### From Source
-```bash
-shards install
-shards build
-./bin/xssmaze
-```
+## Install
 
-### From Docker
 ```bash
-docker pull ghcr.io/hahwul/xssmaze:main
 docker run -p 3000:3000 ghcr.io/hahwul/xssmaze:main
 ```
 
-## Usage
-```
+Or from source:
+
+```bash
+shards install && shards build
 ./bin/xssmaze
-
-Options:
-  -b HOST, --bind HOST             Host to bind (defaults to 127.0.0.1; pass 0.0.0.0 to expose on the network)
-  -p PORT, --port PORT             Port to listen for connections (defaults to 3000)
-  -s, --ssl                        Enables SSL
-  --ssl-key-file FILE              SSL key file
-  --ssl-cert-file FILE             SSL certificate file
-  -h, --help                       Shows this help
 ```
 
-## Dynamic Security Headers (Query Params)
-For calibrating scanners against different defensive configurations, XSSMaze can override common security headers per-request via URL query parameters (works on any endpoint).
+## Usage
 
-- `set_csp`: sets `Content-Security-Policy` (URL-encode spaces/quotes)
-- `set_xcto`: sets `X-Content-Type-Options` (e.g. `nosniff`)
-- `set_xfo`: sets `X-Frame-Options` (e.g. `DENY`)
+```
+./bin/xssmaze [options]
 
-Examples:
-```bash
-curl -i "http://localhost:3000/basic/level1/?query=a&set_xcto=nosniff"
-curl -i "http://localhost:3000/basic/level1/?query=a&set_xfo=deny"
-curl -i "http://localhost:3000/basic/level1/?query=a&set_csp=default-src%20%27self%27"
+  -b HOST, --bind HOST     Host to bind (default 127.0.0.1)
+  -p PORT, --port PORT     Port to listen on (default 3000)
+  -s, --ssl                Enable SSL
+  --ssl-key-file FILE      SSL key file
+  --ssl-cert-file FILE     SSL certificate file
+  -h, --help               Show help
 ```
 
-## Endpoint Map
-```bash
-curl http://localhost:3000/map/text         # newline-separated URLs
-curl http://localhost:3000/map/json         # full metadata (also: ?type=dom or ?q=csp)
-curl http://localhost:3000/map/markdown     # markdown table
-curl http://localhost:3000/map/categories   # categories with counts + class/reach rollups
+## Endpoint map
 
-# Structured vulnerability metadata (see "Vulnerability metadata" below)
+| Endpoint | Returns |
+|----------|---------|
+| `/map/text` | newline-separated URLs |
+| `/map/json` | full metadata; filter with `?type=`, `?q=`, `?vuln=`, `?reach=`, `?exploitable=` |
+| `/map/markdown` | markdown table |
+| `/map/categories` | categories with counts + class/reach rollups |
+| `/map/openapi` | OpenAPI 3.0 catalog |
+| `/sitemap.xml` | sitemap of all maze paths |
+| `/stats` | aggregate counts by class, reach, source, and sink |
+| `/health` | liveness probe (`/healthz` alias) |
+| `/version` | version + counts |
+| `/random` | 302 to a random maze |
+
+```bash
 curl "http://localhost:3000/map/json?vuln=dom"           # only DOM flows
 curl "http://localhost:3000/map/json?reach=server"       # payload fits in an HTTP request
 curl "http://localhost:3000/map/json?exploitable=false"  # deliberate true negatives
-curl http://localhost:3000/map/openapi      # OpenAPI 3.0 catalog
-curl http://localhost:3000/sitemap.xml      # sitemap of all maze paths
-curl http://localhost:3000/health           # liveness probe
-curl http://localhost:3000/version          # version + counts
-curl -L http://localhost:3000/random        # 302 to a random maze
 ```
 
-The index page (`/`) provides a client-side filter, per-category counts, and links to all of the maps above. Map endpoints serve a payload that is built once at startup, cached, and gzip pre-compressed (`Accept-Encoding: gzip` cuts the index payload by ~85%), so they're safe to poll from tooling.
+The index page (`/`) has a client-side filter and links to every map above. Map responses
+are built once at startup, cached, and gzip pre-compressed (`Accept-Encoding: gzip` cuts
+the index by ~85%), so they are safe to poll from tooling.
 
 ## Vulnerability metadata
-Every endpoint in `/map/json` carries a `vuln` object so tooling can score per
-vulnerability class without regex-guessing at the served HTML:
+
+Every endpoint in `/map/json` carries a `vuln` object:
 
 ```json
 {
@@ -98,171 +98,78 @@ vulnerability class without regex-guessing at the served HTML:
 | `delivery` | where the payload enters: `query`, `path`, `body`, `header`, `cookie`, `referer`, `fragment`, `postmessage`, `window-name`, … |
 | `reach` | derived — `server` if any delivery channel fits an HTTP request, `client` if the payload only exists browser-side, `unknown` if untriaged |
 | `exploitable` | `false` marks a deliberate control / true negative |
-| `note` | caveats: required user interaction, why it is a control, non-obvious parameter names |
+| `note` | caveats: required interaction, why it is a control, non-obvious parameter names |
 
-Classification follows the **injection context** — where the bytes land — not
-what the receiving API does with a well-formed argument. A value reflected raw
-into a JS string literal is `reflected-js` however inert the function it is
-passed to.
+Classification follows the **injection context** — where the bytes land — not what the
+receiving API does with a well-formed argument. A value reflected raw into a JS string
+literal is `reflected-js` however inert the function it is passed to.
 
-Two things this is designed to prevent a benchmark from getting wrong:
+Two things this exists to stop a benchmark getting wrong:
 
-- **`reach: "client"`** endpoints (fragment, postMessage, window.name,
-  clipboard, drag-and-drop) cannot be reached by a request-only scanner at
-  all. Counting them as misses measures the wrong thing.
-- **`exploitable: false`** endpoints are not bugs. The whole `xsleak` category
-  is cross-site *leaks*, not XSS — a scanner that reports nothing there is
-  correct.
+- **`reach: "client"`** endpoints (fragment, postMessage, window.name, clipboard,
+  drag-and-drop) cannot be reached by a request-only scanner at all. Counting them as
+  misses measures the wrong thing.
+- **`exploitable: false`** endpoints are not bugs. The whole `xsleak` category is
+  cross-site *leaks*, not XSS — a scanner that reports nothing there is correct.
 
-Endpoints that have not been triaged yet are `"unclassified"` with
-`reach: "unknown"`, which is deliberately distinct from "reviewed and found
-safe".
+Untriaged endpoints are `"unclassified"` with `reach: "unknown"`, deliberately distinct
+from "reviewed and found safe".
 
-## XS-Leaks (Cross-Site Leaks)
-XS-Leaks are cross-origin side-channels that let an attacker infer state-dependent data without directly reading the response body. XSSMaze includes `xsleak-*` levels that intentionally vary response size, subresource composition, load/error behavior, timing, and redirect chains based on a "secret" state.
+## Security header overrides
 
-The state can be controlled either by:
-- `q=admin` (simple stateless demos for scanners), or
-- the `xsleak_role=admin` cookie (set via `GET /xsleak/login?as=admin`).
+To calibrate scanners against different defensive configurations, any endpoint accepts
+per-request header overrides via query params:
 
-### Levels
-- `GET /xsleak/search?q=admin` (`xsleak-level1`): body-size oracle (admin returns more HTML/results)
-- `GET /xsleak/frame?q=admin` (`xsleak-level2`): frame-count oracle (admin includes more iframes)
-- `GET /xsleak/avatar.gif?q=admin` (`xsleak-level3`): load/error oracle (admin returns an image, guest is 404)
-- `GET /xsleak/timing?q=admin` (`xsleak-level4`): timing oracle (guest path sleeps longer)
-- `GET /xsleak/redirect?q=admin` (`xsleak-level5`): redirect-chain oracle (admin has more hops)
+| Param | Sets |
+|-------|------|
+| `set_csp` | `Content-Security-Policy` (URL-encode spaces/quotes) |
+| `set_xcto` | `X-Content-Type-Options` (e.g. `nosniff`) |
+| `set_xfo` | `X-Frame-Options` (e.g. `DENY`) |
 
-### Measuring side-channels
-To validate dynamically, host an "attacker" page on a different origin and probe the victim endpoints using load/error handlers and timing:
-
-```html
-<script>
-  // Load/error oracle (200 vs 404)
-  const img = new Image();
-  img.onload = () => console.log("loaded");
-  img.onerror = () => console.log("error");
-  img.src = "http://127.0.0.1:3000/xsleak/avatar.gif?q=admin";
-
-  // Timing oracle (measure duration)
-  const t0 = performance.now();
-  fetch("http://127.0.0.1:3000/xsleak/timing?q=admin", { mode: "no-cors" })
-    .finally(() => console.log("ms:", performance.now() - t0));
-
-  // Frame-count oracle (browser-dependent)
-  const f = document.createElement("iframe");
-  f.src = "http://127.0.0.1:3000/xsleak/frame?q=admin";
-  f.onload = () => console.log("subframes:", f.contentWindow.length);
-  document.body.appendChild(f);
-</script>
+```bash
+curl -i "http://localhost:3000/basic/level1/?query=a&set_csp=default-src%20%27self%27"
 ```
 
-You can also spot differences via CLI:
+## XS-Leaks
+
+`xsleak-*` levels are cross-origin side-channels that vary response size, subresource
+count, load/error behavior, timing, and redirect depth by a "secret" state. State comes
+from either `q=admin` or the `xsleak_role=admin` cookie (set via `GET /xsleak/login?as=admin`).
+
+| Level | Endpoint | Oracle |
+|-------|----------|--------|
+| 1 | `/xsleak/search?q=admin` | body size (admin returns more results) |
+| 2 | `/xsleak/frame?q=admin` | frame count |
+| 3 | `/xsleak/avatar.gif?q=admin` | load/error (admin 200, guest 404) |
+| 4 | `/xsleak/timing?q=admin` | timing (guest path sleeps longer) |
+| 5 | `/xsleak/redirect?q=admin` | redirect-chain depth |
+
+These are *leaks*, not XSS — they are marked `exploitable: false` and a scanner reporting
+nothing here is behaving correctly. Spot the difference from the CLI:
+
 ```bash
-curl -i "http://localhost:3000/xsleak/avatar.gif?q=guest"   # 404
-curl -i "http://localhost:3000/xsleak/avatar.gif?q=admin"   # 200 image/gif
 curl -s "http://localhost:3000/xsleak/frame?q=guest" | wc -c
 curl -s "http://localhost:3000/xsleak/frame?q=admin" | wc -c
-curl -sL -o /dev/null -w "%{time_total}\n" "http://localhost:3000/xsleak/timing?q=guest"
 curl -sL -o /dev/null -w "%{time_total}\n" "http://localhost:3000/xsleak/timing?q=admin"
 ```
 
-## Benchmarking Scanner Tools
+To measure them properly, host a page on a different origin and probe with load/error
+handlers, timing, and `iframe.contentWindow.length`.
 
-XSSMaze includes an automated benchmark tool to measure how well XSS scanners perform against the lab's diverse vulnerability scenarios. The tool retrieves all endpoints from `/map/json`, runs scanner tools against them, and generates a detection scorecard.
+## Benchmarking scanners
 
-### Requirements
-
-- Python 3.x
-- `requests` library (`pip install requests`)
-- Scanner tools (e.g., [Nuclei](https://github.com/projectdiscovery/nuclei))
-
-### Quick Start
+`scripts/benchmark.py` pulls every endpoint from `/map/json`, runs a scanner against
+them, and prints a detection scorecard.
 
 ```bash
-# Start XSSMaze (in one terminal)
-./bin/xssmaze -b 0.0.0.0
-
-# Run benchmark (in another terminal)
-cd scripts
-./benchmark.sh http://localhost:3000
+./bin/xssmaze -b 0.0.0.0          # terminal 1
+cd scripts && ./benchmark.sh http://localhost:3000   # terminal 2
 ```
 
-### Usage Examples
+Nuclei is supported out of the box; any other tool can be wired in with
+`--custom-scanner "mytool {URL}"`. See [scripts/README.md](scripts/README.md) for
+options, report formats, and how to add a scanner permanently.
 
-```bash
-# Basic benchmark with console output
-python3 benchmark.py http://localhost:3000
+## License
 
-# Verbose mode (shows detailed progress)
-python3 benchmark.py http://localhost:3000 -v
-
-# Generate markdown report
-python3 benchmark.py http://localhost:3000 -o report.md
-
-# Run specific scanner only
-python3 benchmark.py http://localhost:3000 --scanner nuclei
-
-# Use a custom scanner command
-python3 benchmark.py http://localhost:3000 \
-  --custom-scanner "myxss {URL}" \
-  --custom-scanner-name "MyXSSScanner"
-```
-
-### Output Format
-
-The benchmark tool provides:
-
-- **Console Scorecard**: Summary table showing detection rates for each scanner
-- **Detailed Statistics**:
-  - Total registered endpoints
-  - Endpoints successfully detected (True Positives)
-  - Endpoints missed (False Negatives)
-  - Overall detection rate percentage
-  - Breakdown of missed detections by category
-- **Markdown Report** (optional): Exportable report with full benchmark results
-
-Example output:
-```
-======================================================================
-XSSMaze Scanner Benchmark Results
-======================================================================
-
-Target: http://localhost:3000
-Total Registered Endpoints: 450
-Categories: 45
-
-Scanner              Detected     Missed       Rate         Time (s)
-----------------------------------------------------------------------
-Nuclei               234          216          52.0%        125.3s
-
---- Nuclei Detailed Results ---
-✓ True Positives: 234/450
-✗ False Negatives (Missed): 216/450
-
-Missed by category:
-  advanced: 6/6 missed
-  csp-bypass: 5/5 missed
-  template-injection: 6/6 missed
-```
-
-### Supported Scanners
-
-The benchmark tool currently supports:
-
-- **Nuclei**: Uses XSS-related templates from the Nuclei template library
-- **Custom Scanners**: Any tool that can accept a URL and output results
-
-### Adding New Scanners
-
-To add support for a new scanner:
-
-1. Use the `--custom-scanner` option with command template
-2. Or extend `benchmark.py` with a new scanner method
-
-Example for adding a scanner permanently:
-```python
-def run_my_scanner(self) -> ScannerResult:
-    # Implementation here
-    pass
-```
-```
+MIT

--- a/spec/routing_spec.cr
+++ b/spec/routing_spec.cr
@@ -496,3 +496,55 @@ describe "WAF facade levels" do
     response.body.should contain(%(<div id='preview'>#{payload}</div>))
   end
 end
+
+describe "endpoints reachable without their parameter" do
+  # Regression: these four advertised a bare path in /map/*, so crawling the
+  # catalog hit a KeyError and got a 500 instead of the level.
+  (1..4).each do |level|
+    it "redirect level#{level} redirects instead of raising when query is absent" do
+      get "/redirect/level#{level}/"
+      response.status_code.should eq 302
+    end
+  end
+
+  it "redirect level1 still honours a javascript: payload" do
+    get "/redirect/level1/?query=#{URI.encode_www_form("javascript:alert(1)")}"
+    response.status_code.should eq 302
+    response.headers["Location"].should eq("javascript:alert(1)")
+  end
+
+  it "redirect level2 still strips the javascript keyword" do
+    get "/redirect/level2/?query=#{URI.encode_www_form("javascript:alert(1)")}"
+    response.status_code.should eq 302
+    response.headers["Location"].should eq(":alert(1)")
+  end
+end
+
+describe "user input reflected into response headers" do
+  # Crystal raises on CR/LF in a header value, so these used to 500 rather
+  # than demonstrate anything. The reflection itself must survive.
+  it "reflects a search term into X-Search-Term" do
+    get "/rsplit/level1/?query=#{URI.encode_www_form("hello")}"
+    response.status_code.should eq 200
+    response.headers["X-Search-Term"].should eq("hello")
+  end
+
+  it "does not 500 on a CRLF payload in the header-reflection maze" do
+    get "/rsplit/level1/?query=#{URI.encode_www_form("a\r\nX-Evil: 1")}"
+    response.status_code.should eq 200
+    response.headers["X-Search-Term"].should eq("aX-Evil: 1")
+    response.headers.has_key?("X-Evil").should be_false
+  end
+
+  it "still reflects the raw payload into the body" do
+    payload = "<script>alert(1)</script>"
+    get "/rsplit/level1/?query=#{URI.encode_www_form(payload)}"
+    response.body.should contain(payload)
+  end
+
+  it "does not 500 when a CRLF override rides along on a maze request" do
+    get "/basic/level1/?query=a&set_csp=#{URI.encode_www_form("x\r\nX-Evil: 1")}"
+    response.status_code.should eq 200
+    response.headers.has_key?("X-Evil").should be_false
+  end
+end

--- a/spec/security_headers_spec.cr
+++ b/spec/security_headers_spec.cr
@@ -46,4 +46,54 @@ describe Xssmaze::SecurityHeaders do
 
     headers.has_key?("X-Frame-Options").should be_false
   end
+
+  # Regression: a CRLF in any override used to raise ArgumentError out of the
+  # `after_all` filter and turn the whole request into a 500.
+  it "strips CRLF from override values instead of raising" do
+    headers = HTTP::Headers.new
+    query = HTTP::Params.parse("set_csp=default-src+%27self%27%0d%0aX-Evil%3A+1")
+
+    Xssmaze::SecurityHeaders.apply_overrides(headers, query)
+
+    headers["Content-Security-Policy"].should eq("default-src 'self'X-Evil: 1")
+    headers.has_key?("X-Evil").should be_false
+  end
+
+  it "drops an override that is only control characters" do
+    headers = HTTP::Headers.new
+    query = HTTP::Params.parse("set_xfo=%0d%0a")
+
+    Xssmaze::SecurityHeaders.apply_overrides(headers, query)
+
+    headers.has_key?("X-Frame-Options").should be_false
+  end
+
+  it "preserves inner spaces in a CSP value" do
+    headers = HTTP::Headers.new
+    query = HTTP::Params.parse("set_csp=default-src+%27none%27%3B+script-src+%27self%27")
+
+    Xssmaze::SecurityHeaders.apply_overrides(headers, query)
+
+    headers["Content-Security-Policy"].should eq("default-src 'none'; script-src 'self'")
+  end
+end
+
+describe Xssmaze do
+  describe ".header_value" do
+    it "removes CR, LF and NUL but nothing else" do
+      Xssmaze.header_value("a\r\nb c").should eq("ab c")
+      Xssmaze.header_value("plain").should eq("plain")
+      Xssmaze.header_value("default-src 'self'").should eq("default-src 'self'")
+    end
+  end
+
+  describe ".html_escape" do
+    it "escapes the five HTML metacharacters" do
+      Xssmaze.html_escape(%(&<>"')).should eq("&amp;&lt;&gt;&quot;&#39;")
+    end
+
+    it "leaves ordinary and multibyte text untouched" do
+      Xssmaze.html_escape("안녕 hello").should eq("안녕 hello")
+    end
+  end
 end

--- a/src/assets.cr
+++ b/src/assets.cr
@@ -162,25 +162,44 @@ module Xssmaze::Assets
     (function () {
       var input = document.getElementById('search');
       if (!input) return;
-      var mazes = document.querySelectorAll('.maze');
-      var cats = document.querySelectorAll('.cat');
       var totalEl = document.getElementById('stat-visible');
-      input.addEventListener('input', function () {
+
+      // Walk the DOM once at startup and cache each category with its own
+      // rows plus their pre-lowercased haystack. The previous version called
+      // querySelectorAll once per category on every keystroke, which is ~175
+      // full subtree scans per character typed.
+      var groups = [].map.call(document.querySelectorAll('.cat'), function (cat) {
+        var rows = [].map.call(cat.querySelectorAll('.maze'), function (el) {
+          return {
+            el: el,
+            hay: (el.getAttribute('data-name') || '') + ' ' + (el.getAttribute('data-desc') || '')
+          };
+        });
+        return { el: cat, rows: rows };
+      });
+
+      function apply() {
         var q = input.value.toLowerCase().trim();
         var visible = 0;
-        mazes.forEach(function (el) {
-          var name = el.getAttribute('data-name') || '';
-          var desc = el.getAttribute('data-desc') || '';
-          var match = q === '' || name.indexOf(q) !== -1 || desc.indexOf(q) !== -1;
-          el.classList.toggle('hidden', !match);
-          if (match) visible++;
-        });
-        cats.forEach(function (cat) {
-          var any = cat.querySelectorAll('.maze:not(.hidden)').length > 0;
-          cat.classList.toggle('hidden', !any);
-        });
+        for (var i = 0; i < groups.length; i++) {
+          var group = groups[i];
+          var shown = 0;
+          for (var j = 0; j < group.rows.length; j++) {
+            var row = group.rows[j];
+            var match = q === '' || row.hay.indexOf(q) !== -1;
+            row.el.classList.toggle('hidden', !match);
+            if (match) shown++;
+          }
+          group.el.classList.toggle('hidden', shown === 0);
+          visible += shown;
+        }
         if (totalEl) totalEl.textContent = visible;
-      });
+      }
+
+      input.addEventListener('input', apply);
+      // Re-apply on load so a value restored by the browser (back/forward,
+      // autofill) is reflected instead of showing an unfiltered list.
+      if (input.value) apply();
     })();
   JS
 end

--- a/src/catalog.cr
+++ b/src/catalog.cr
@@ -251,6 +251,21 @@ module Xssmaze::Catalog
 
   ROBOTS_BODY = "User-agent: *\nDisallow: /\n"
 
+  # The 404 body is the one page that varies per request (it echoes the
+  # missed path), so it is rendered rather than cached like the entries
+  # above. The path is escaped — this page is chrome, not a maze.
+  ERROR_404_STYLE = "body{font-family:-apple-system,sans-serif;max-width:720px;margin:60px auto;padding:0 20px;color:#333}" \
+                    "h1{margin-bottom:6px}.path{background:#f4f4f4;padding:2px 6px;border-radius:3px;font-family:monospace;color:#c7254e}" \
+                    "a{color:#0366d6;text-decoration:none}a:hover{text-decoration:underline}"
+
+  def self.render_404(path : String) : String
+    "<!DOCTYPE html><html><head><meta charset='UTF-8'><title>404 - XSSMaze</title>" \
+    "<style>#{ERROR_404_STYLE}</style></head><body>" \
+    "<h1>404</h1><p>No maze at <span class='path'>#{Xssmaze.html_escape(path)}</span>.</p>" \
+    "<p>Try the <a href='/'>index</a>, the <a href='/map/text'>text map</a>, or the " \
+    "<a href='/map/categories'>category list</a>.</p></body></html>"
+  end
+
   # Build every cached static asset in one shot. The key naming maps 1:1
   # to the route table in server.cr so adding a new catalog view is a
   # matter of: add a builder above, add an Entry here, add a route in

--- a/src/maze.cr
+++ b/src/maze.cr
@@ -65,6 +65,11 @@ class Maze
   # Free-form caveat: why it is a control, what interaction it needs, etc.
   getter note : String?
 
+  # Category, derived from the name prefix ("basic-level1" -> "basic").
+  # Computed once: grouping, /map/json, /map/openapi and /stats each walk
+  # every maze, and the old `split("-").first?` allocated an array per call.
+  getter type : String
+
   def initialize(@name, @url, @desc, @method = "GET", @params = ["query"],
                  @vuln = "unclassified",
                  @sources = [] of String,
@@ -72,10 +77,8 @@ class Maze
                  @delivery = [] of String,
                  @exploitable = true,
                  @note = nil)
-  end
-
-  def type : String
-    @name.split("-").first? || "other"
+    dash = @name.index('-')
+    @type = dash ? @name[0, dash] : @name
   end
 
   # "server"  - the payload fits in the HTTP request (query/path/body/

--- a/src/mazes/modern_framework_xss.cr
+++ b/src/mazes/modern_framework_xss.cr
@@ -55,9 +55,9 @@ end
 # Level 5: CORS response with reflected origin
 Xssmaze.push("modern-level5", "/modern/level5/?query=a", "reflected in CORS headers + body")
 maze_get "/modern/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "a")
   origin = env.request.headers.fetch("Origin", "*")
-  env.response.headers["Access-Control-Allow-Origin"] = origin
+  env.response.headers["Access-Control-Allow-Origin"] = Xssmaze.header_value(origin)
 
   "<html><body>#{query}</body></html>"
 end

--- a/src/mazes/realworld_input_xss.cr
+++ b/src/mazes/realworld_input_xss.cr
@@ -36,7 +36,7 @@ end
 Xssmaze.push("realworld_input-level4", "/realworld-input/level4/?url=https://example.com", "Location header redirect (javascript: sink)")
 maze_get "/realworld-input/level4/" do |env|
   url = env.params.query.fetch("url", "/")
-  env.response.headers["Location"] = url
+  env.response.headers["Location"] = Xssmaze.header_value(url)
   env.response.status_code = 302
 
   ""

--- a/src/mazes/redirect.cr
+++ b/src/mazes/redirect.cr
@@ -1,19 +1,34 @@
-Xssmaze.push("redirect-level1", "/redirect/level1/", "query param")
+# Open-redirect / `javascript:` Location sinks.
+#
+# The catalog URLs carry `?query=` like every other maze: these handlers used
+# to advertise a bare path, so any tool that crawled /map/* got a 500
+# (KeyError) instead of the level. Missing param now falls back to "/".
+#
+# `header_value` strips CR/LF only — Crystal raises rather than emitting a
+# split response, so without it a CRLF payload was a 500, not a lesson. The
+# `javascript:` sink these levels exist to teach is untouched.
+
+Xssmaze.push("redirect-level1", "/redirect/level1/?query=/", "query param")
 maze_get "/redirect/level1/" do |env|
-  env.redirect env.params.query["query"]
+  env.redirect Xssmaze.header_value(env.params.query.fetch("query", "/"))
 end
 
-Xssmaze.push("redirect-level2", "/redirect/level2/", "query param")
+Xssmaze.push("redirect-level2", "/redirect/level2/?query=/", "query param, strips 'javascript'")
 maze_get "/redirect/level2/" do |env|
-  env.redirect env.params.query["query"].gsub("javascript", "")
+  query = env.params.query.fetch("query", "/").gsub("javascript", "")
+  env.redirect Xssmaze.header_value(query)
 end
 
-Xssmaze.push("redirect-level3", "/redirect/level3/", "query param")
+Xssmaze.push("redirect-level3", "/redirect/level3/?query=/", "query param, lowercased then strips 'javascript'")
 maze_get "/redirect/level3/" do |env|
-  env.redirect env.params.query["query"].downcase.gsub("javascript", "")
+  query = env.params.query.fetch("query", "/").downcase.gsub("javascript", "")
+  env.redirect Xssmaze.header_value(query)
 end
 
-Xssmaze.push("redirect-level4", "/redirect/level4/", "query param")
+Xssmaze.push("redirect-level4", "/redirect/level4/?query=/", "query param, two lowercase+strip passes")
 maze_get "/redirect/level4/" do |env|
-  env.redirect env.params.query["query"].downcase.gsub("javascript", "").downcase.gsub("javascript", "")
+  query = env.params.query.fetch("query", "/")
+    .downcase.gsub("javascript", "")
+    .downcase.gsub("javascript", "")
+  env.redirect Xssmaze.header_value(query)
 end

--- a/src/mazes/response_split_xss.cr
+++ b/src/mazes/response_split_xss.cr
@@ -1,8 +1,10 @@
 # Level 1: Reflection in HTTP header (X-Custom) + body
 Xssmaze.push("rsplit-level1", "/rsplit/level1/?query=a", "reflection in custom header + body")
 maze_get "/rsplit/level1/" do |env|
-  query = env.params.query["query"]
-  env.response.headers["X-Search-Term"] = query
+  query = env.params.query.fetch("query", "a")
+  # Reflected raw into the body below; the header copy drops CR/LF only
+  # because Crystal refuses to emit them (it raises instead of splitting).
+  env.response.headers["X-Search-Term"] = Xssmaze.header_value(query)
 
   "<html><body><h1>Search: #{query}</h1></body></html>"
 end

--- a/src/registry.cr
+++ b/src/registry.cr
@@ -1,4 +1,5 @@
 require "compress/gzip"
+require "html"
 
 # Catalog of every maze endpoint plus a few shared helpers used by maze
 # definitions and the catalog/server layers.
@@ -46,12 +47,22 @@ module Xssmaze
     groups
   end
 
+  # Escapes & < > " ' — byte-for-byte what the previous hand-rolled chain of
+  # five `gsub`s produced, in a single pass instead of five intermediates.
   def self.html_escape(s : String) : String
-    s.gsub('&', "&amp;")
-      .gsub('<', "&lt;")
-      .gsub('>', "&gt;")
-      .gsub('"', "&quot;")
-      .gsub('\'', "&#39;")
+    HTML.escape(s)
+  end
+
+  # Strip CR/LF/NUL from a value before it goes into a response header.
+  #
+  # This is NOT the lab going soft on itself. Crystal's `HTTP::Headers`
+  # raises `ArgumentError` on a control character, so a payload like
+  # `?query=a%0d%0aX-Evil:1` never produced a split response — it produced a
+  # 500 and a stack trace, killing the maze's real lesson (the value *is*
+  # still reflected into the header, which is what header-context tests
+  # need). Sanitizing here keeps the reflection and drops the crash.
+  def self.header_value(s : String) : String
+    s.delete("\r\n\u0000")
   end
 
   def self.gzip(body : String) : Bytes

--- a/src/route_helper.cr
+++ b/src/route_helper.cr
@@ -16,17 +16,24 @@ end
 
 module Xssmaze::SecurityHeaders
   def self.apply_overrides(headers : HTTP::Headers, query : HTTP::Params) : Nil
-    if (csp = query["set_csp"]?) && !(csp = csp.strip).empty?
+    # Every value is run through `header_value` first: these overrides are a
+    # calibration knob, and a CRLF in one used to raise ArgumentError out of
+    # the `after_all` filter, turning any request into a 500.
+    if (csp = query["set_csp"]?) && !(csp = sanitize(csp)).empty?
       headers["Content-Security-Policy"] = csp
     end
 
-    if (xcto = query["set_xcto"]?) && !(xcto = xcto.strip).empty?
+    if (xcto = query["set_xcto"]?) && !(xcto = sanitize(xcto)).empty?
       headers["X-Content-Type-Options"] = normalize_xcto(xcto)
     end
 
-    if (xfo = query["set_xfo"]?) && !(xfo = xfo.strip).empty?
+    if (xfo = query["set_xfo"]?) && !(xfo = sanitize(xfo)).empty?
       headers["X-Frame-Options"] = normalize_xfo(xfo)
     end
+  end
+
+  private def self.sanitize(value : String) : String
+    Xssmaze.header_value(value).strip
   end
 
   private def self.normalize_xcto(value : String) : String

--- a/src/server.cr
+++ b/src/server.cr
@@ -117,17 +117,13 @@ module Xssmaze::Server
       end
     end
 
-    get "/health" do |env|
-      json_no_store(env)
-      uptime = (Time.utc - start_time).total_seconds.to_i
-      {status: "ok", uptime_seconds: uptime, endpoints: mazes.size}.to_json
-    end
-
-    # k8s-style alias.
-    get "/healthz" do |env|
-      json_no_store(env)
-      uptime = (Time.utc - start_time).total_seconds.to_i
-      {status: "ok", uptime_seconds: uptime, endpoints: mazes.size}.to_json
+    # /healthz is the k8s-style alias for the same probe.
+    %w[/health /healthz].each do |probe_path|
+      get probe_path do |env|
+        json_no_store(env)
+        uptime = (Time.utc - start_time).total_seconds.to_i
+        {status: "ok", uptime_seconds: uptime, endpoints: mazes.size}.to_json
+      end
     end
 
     # Filter the pre-materialized JSON objects rather than rebuilding tuples.
@@ -156,14 +152,7 @@ module Xssmaze::Server
 
     error 404 do |env|
       env.response.content_type = "text/html; charset=utf-8"
-      path = env.request.path
-      "<!DOCTYPE html><html><head><meta charset='UTF-8'><title>404 - XSSMaze</title>" \
-      "<style>body{font-family:-apple-system,sans-serif;max-width:720px;margin:60px auto;padding:0 20px;color:#333}" \
-      "h1{margin-bottom:6px}.path{background:#f4f4f4;padding:2px 6px;border-radius:3px;font-family:monospace;color:#c7254e}" \
-      "a{color:#0366d6;text-decoration:none}a:hover{text-decoration:underline}</style></head><body>" \
-      "<h1>404</h1><p>No maze at <span class='path'>#{Xssmaze.html_escape(path)}</span>.</p>" \
-      "<p>Try the <a href='/'>index</a>, the <a href='/map/text'>text map</a>, or the " \
-      "<a href='/map/categories'>category list</a>.</p></body></html>"
+      Catalog.render_404(env.request.path)
     end
 
     # spec-kemal expects Kemal's handler chain to be wired even when we


### PR DESCRIPTION
## Bugs

**CRLF in a header value crashed the request.** Crystal's `HTTP::Headers` raises `ArgumentError` on `\r`/`\n`, so a CRLF payload never produced a split response — it produced a 500 and a stack trace. The `set_csp` / `set_xcto` / `set_xfo` overrides are applied in an `after_all` filter, so this turned **any** endpoint into a 500:

```
$ curl -o /dev/null -w '%{http_code}\n' "localhost:3000/basic/level1/?query=a&set_csp=x%0d%0aX-Evil:1"
500      # before
200      # after
```

The same crash hit three mazes that reflect input into a header: `rsplit-level1` (`X-Search-Term`), `realworld_input-level4` (`Location`), `modern-level5` (CORS origin).

Added `Xssmaze.header_value`, which strips CR/LF/NUL and nothing else. **The reflection each maze exists to demonstrate is preserved** — only the crash is gone.

**`/redirect/level1-4/` 500'd on their own advertised URL.** They were the only mazes whose `/map/*` entry had no `?query=`, and the handler used the raising param accessor, so crawling the catalog hit a `KeyError`.

### Verification

A sweep of **all 1059 endpoints** now returns **0 × 5xx and 0 logged exceptions** (previously 4 endpoints 500'd, and any endpoint could be made to 500 via a header override). 600 CRLF injections across 120 endpoints: 0 × 5xx, and legitimate overrides still apply unchanged.

Confirmed the vulnerable concept is intact after the change:

| Check | Result |
|---|---|
| raw `<script>alert(1)</script>` reflection | still reflected on `/basic/level1/`, `/rsplit/level1/`, `/modern/level5/` |
| `javascript:` Location sink | `Location: javascript:alert(1)` on `/redirect/level1/` and `/realworld-input/level4/` |
| CORS origin reflection | `Access-Control-Allow-Origin: https://evil.example` |

## Quality

- `html_escape` delegates to stdlib `HTML.escape` — one pass instead of five `gsub` allocations; verified byte-identical output first
- `Maze#type` computed once in the constructor instead of allocating an array per call; all 1059 types and 174 categories verified unchanged
- Index filter JS was running ~175 `querySelectorAll` subtree scans **per keystroke**; now caches rows at startup, and re-applies on load so a browser-restored value is honoured. Syntax-checked and functionally tested against a stub DOM
- Dedupe `/health` + `/healthz`, move the inline 404 HTML into `Catalog`
- Specs **110 → 126**, covering each fix

## README

269 → 178 lines. Replaced the 200-word run-on category sentence with a short intro, moved the endpoint/metadata/XS-Leaks lists into tables, noted the loopback-by-default binding, and dropped ~100 lines of benchmarking docs that `scripts/README.md` already covers in full. Every claim was verified against a running server (CLI flags, all 13 endpoints, filter params, the xsleak `exploitable: false` flags, the gzip ratio).

## Note

I initially added `delivery: ["query"]` metadata to the redirect mazes, then reverted it. A server-side 302 to `javascript:` doesn't cleanly fit any value in the closed `vuln` set (`dom` is defined as reaching a sink through client-side code, which these don't), and the schema treats `unclassified` as a meaningful "not yet triaged" state. Left them untriaged like the other 834 rather than put a false claim in the catalog — worth a separate triage pass.
