### PR TITLE
feat: bound stored-maze state and add a /reset hook

### DIFF
--- a/spec/store_spec.cr
+++ b/spec/store_spec.cr
@@ -1,0 +1,192 @@
+require "./spec_helper"
+
+# Post a single form field, the way every stored maze's own form does.
+private def post_entry(path : String, field : String, value : String)
+  post path,
+    headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"},
+    body: "#{field}=#{URI.encode_www_form(value)}"
+end
+
+private def count_of(haystack : String, needle : String) : Int32
+  haystack.split(needle).size - 1
+end
+
+describe Xssmaze::Store do
+  cap = Xssmaze::Store::MAX_ENTRIES
+
+  before_each { Xssmaze::Store.reset_all }
+
+  describe "the cap" do
+    it "keeps only the most recent MAX_ENTRIES entries" do
+      (cap + 5).times { |i| post_entry "/stored/level1/", "query", "entry-#{i}" }
+
+      get "/stored/level1/"
+      count_of(response.body, "<li>").should eq cap
+      # The five oldest were dropped; the newest survived.
+      response.body.should_not contain "entry-0"
+      response.body.should_not contain "entry-4"
+      response.body.should contain "entry-5"
+      response.body.should contain "entry-#{cap + 4}"
+    end
+
+    it "bounds the callback log group by key as well as by entry" do
+      log = Xssmaze::Store.group("headless-generator/level5")
+
+      (cap + 5).times { |i| log.push("id-#{i}", "hit") }
+      log.size.should eq cap
+
+      (cap + 5).times { |i| log.push("one-id", "hit-#{i}") }
+      log["one-id"].size.should eq cap
+      log["one-id"].first.should eq "hit-5"
+    end
+  end
+
+  describe ".reset_all" do
+    it "empties every collection" do
+      post_entry "/stored/level1/", "query", "a"
+      post_entry "/storedpat/level1/", "body", "b"
+      post_entry "/storedpat/level5/", "subject", "c"
+      Xssmaze::Store.total.should eq 3
+
+      cleared = Xssmaze::Store.reset_all
+      cleared["stored/level1"].should eq 1
+      cleared["storedpat/level1"].should eq 1
+      cleared["storedpat/level5"].should eq 1
+      Xssmaze::Store.total.should eq 0
+    end
+  end
+
+  describe ".reset" do
+    it "clears only the named collection" do
+      post_entry "/stored/level1/", "query", "a"
+      post_entry "/stored/level2/", "query", "b"
+
+      Xssmaze::Store.reset("stored/level1").should eq 1
+      Xssmaze::Store.sizes["stored/level1"].should eq 0
+      Xssmaze::Store.sizes["stored/level2"].should eq 1
+    end
+
+    it "reports nil for a name nobody registered" do
+      Xssmaze::Store.reset("stored/level99").should be_nil
+    end
+  end
+
+  describe "GET /reset" do
+    it "reports sizes without mutating them" do
+      post_entry "/stored/level1/", "query", "a"
+
+      get "/reset"
+      response.status_code.should eq 200
+      response.headers["Cache-Control"]?.should eq "no-store"
+      response.headers["Access-Control-Allow-Origin"]?.should eq "*"
+
+      body = JSON.parse(response.body)
+      body["max_entries"].as_i.should eq cap
+      body["total"].as_i.should eq 1
+      body["collections"]["stored/level1"].as_i.should eq 1
+
+      # The status view is the one a crawler hits; it must leave the lab alone.
+      Xssmaze::Store.sizes["stored/level1"].should eq 1
+    end
+
+    it "lists untouched collections too, not just the ones with entries" do
+      get "/reset"
+      names = JSON.parse(response.body)["collections"].as_h.keys
+      names.should contain "stored/level4"
+      names.should contain "storedpat/level6"
+      names.should contain "headless-generator/level5"
+    end
+  end
+
+  describe "POST /reset" do
+    it "clears everything and reports what went away" do
+      post_entry "/stored/level1/", "query", "a"
+      post_entry "/storedpat/level4/", "msg", "b"
+
+      post "/reset"
+      response.status_code.should eq 200
+      response.headers["Cache-Control"]?.should eq "no-store"
+
+      body = JSON.parse(response.body)
+      body["reset"].as_s.should eq "all"
+      body["total"].as_i.should eq 2
+      body["cleared"]["stored/level1"].as_i.should eq 1
+
+      get "/stored/level1/"
+      response.body.should_not contain "<li>"
+    end
+
+    it "clears one collection with ?scope=" do
+      post_entry "/stored/level1/", "query", "a"
+      post_entry "/stored/level2/", "query", "b"
+
+      post "/reset?scope=stored/level1"
+      response.status_code.should eq 200
+      JSON.parse(response.body)["reset"].as_s.should eq "stored/level1"
+
+      Xssmaze::Store.sizes["stored/level1"].should eq 0
+      Xssmaze::Store.sizes["stored/level2"].should eq 1
+    end
+
+    it "rejects an unknown scope and names the ones it knows" do
+      post "/reset?scope=nope"
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["error"].as_s.should eq "unknown scope"
+      body["known"].as_a.map(&.as_s).should contain "stored/level1"
+    end
+  end
+
+  # The regression that matters most: bounding the stores must not have
+  # escaped anything on the way in or out. These are the vulnerabilities
+  # the lab exists to serve.
+  describe "stored mazes still reflect raw payloads" do
+    payload = "<script>alert(1)</script>"
+
+    it "reflects raw in /stored/level1/ on POST and on the follow-up GET" do
+      post_entry "/stored/level1/", "query", payload
+      response.body.should contain "<li>#{payload}</li>"
+
+      get "/stored/level1/"
+      response.body.should contain "<li>#{payload}</li>"
+    end
+
+    it "reflects raw into the /stored/level3/ title attribute" do
+      post_entry "/stored/level3/", "query", payload
+      response.body.should contain %(<div title="#{payload}">)
+    end
+
+    it "serves raw entries from the /stored/level4/ JSON API" do
+      post_entry "/stored/level4/", "query", payload
+      get "/stored/level4/api"
+      JSON.parse(response.body)["entries"].as_a.map(&.as_s).should eq [payload]
+    end
+
+    it "reflects raw into the /storedpat/level1/ title attribute" do
+      post_entry "/storedpat/level1/", "body", payload
+      response.body.should contain %(<li title="#{payload}">)
+
+      get "/storedpat/level1/"
+      response.body.should contain %(<li title="#{payload}">)
+    end
+
+    it "reflects raw into the /storedpat/level3/ meta content" do
+      post_entry "/storedpat/level3/", "review", payload
+      get "/storedpat/level3/"
+      response.body.should contain %(content="#{payload}")
+    end
+
+    it "reflects raw into the /storedpat/level5/ title and h1" do
+      post_entry "/storedpat/level5/", "subject", payload
+      get "/storedpat/level5/"
+      response.body.should contain "<title>Ticket — #{payload}</title>"
+      response.body.should contain "<h1>#{payload}</h1>"
+    end
+
+    it "serves the raw /storedpat/level6/ note from its JSON API" do
+      post_entry "/storedpat/level6/", "note", payload
+      get "/storedpat/level6/api"
+      JSON.parse(response.body)["note"].as_s.should eq payload
+    end
+  end
+end

--- a/src/mazes/headless_generator_xss.cr
+++ b/src/mazes/headless_generator_xss.cr
@@ -7,8 +7,11 @@
 # where user-supplied HTML/SVG is processed by a headless browser, potentially
 # executing JavaScript in a server-side context.
 
-# Storage for simulating webhook callbacks and execution logs
-HEADLESS_CALLBACK_LOG = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
+# Storage for simulating webhook callbacks and execution logs. The keys are
+# callback ids the maze itself invents, one per Level 5 form render, so this
+# is the store that grew fastest under a fuzzer — `Store::Group` caps both the
+# id set and each id's log, and `POST /reset` empties it.
+headless_callback_log = Xssmaze::Store.group("headless-generator/level5")
 
 # Level 1: Basic HTML to PDF - No Filtering
 # Accepts HTML input and simulates PDF generation with no sanitization
@@ -155,15 +158,15 @@ maze_post "/headless-generator/level5/" do |env|
     # Extract callback URL if present
     if match = html_input.match(/(?:fetch\s*\(|\.open\s*\([^,]*,)\s*["']([^"']+)["']/)
       callback_url = match[1]
-      HEADLESS_CALLBACK_LOG[callback_id] << "JavaScript fetch/XHR detected: #{callback_url}"
+      headless_callback_log.push(callback_id, "JavaScript fetch/XHR detected: #{callback_url}")
     else
-      HEADLESS_CALLBACK_LOG[callback_id] << "JavaScript execution detected"
+      headless_callback_log.push(callback_id, "JavaScript execution detected")
     end
   end
 
   # Check for image beacons
   if html_input =~ /<img[^>]+src=["']https?:\/\/[^"']+/
-    HEADLESS_CALLBACK_LOG[callback_id] << "Image beacon detected in HTML"
+    headless_callback_log.push(callback_id, "Image beacon detected in HTML")
   end
 
   rendered_output = %(<div class="pdf-preview">
@@ -182,7 +185,7 @@ end
 # Callback log viewer for Level 5
 maze_get "/headless-generator/level5/callback/:id" do |env|
   callback_id = env.params.url["id"]
-  logs = HEADLESS_CALLBACK_LOG[callback_id]? || [] of String
+  logs = headless_callback_log[callback_id]
 
   %(<div class="callback-log">
     <h3>Callback Log for ID: #{HTML.escape(callback_id)}</h3>

--- a/src/mazes/stored_pattern_xss.cr
+++ b/src/mazes/stored_pattern_xss.cr
@@ -5,15 +5,27 @@
 # separate GET still detect the issue. Patterns are picked from
 # recurring bug-bounty reports (comment systems, profile bios, product
 # reviews, support tickets, admin notes).
-store = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
-single = Hash(String, String).new("")
+#
+# The stores live in `Xssmaze::Store`, so they are capped and clearable
+# via `POST /reset`: a level that never forgets hands the next scanner
+# run the previous run's payloads as a finding of its own.
+store = {
+  "lvl1" => Xssmaze::Store.list("storedpat/level1"),
+  "lvl4" => Xssmaze::Store.list("storedpat/level4"),
+}
+single = {
+  "lvl2" => Xssmaze::Store.single("storedpat/level2"),
+  "lvl3" => Xssmaze::Store.single("storedpat/level3"),
+  "lvl5" => Xssmaze::Store.single("storedpat/level5"),
+  "lvl6" => Xssmaze::Store.single("storedpat/level6"),
+}
 
 # Level 1: comment system storing into attribute context
 # Real shape: comment body escaped for body display but reused
 # *raw* inside an attribute (`title=`, `data-*`). Reviews-style.
 Xssmaze.push("storedpat-level1", "/storedpat/level1/", "comment stored in body (escaped) + title attr (raw)", "POST")
 maze_get "/storedpat/level1/" do |_|
-  items = store["lvl1"].map do |c|
+  items = store["lvl1"].entries.map do |c|
     "<li title=\"#{c}\">#{Xssmaze.html_escape(c)}</li>"
   end.join
   "<!doctype html><html><body>
@@ -25,7 +37,7 @@ end
 maze_post "/storedpat/level1/" do |env|
   body = env.params.body.fetch("body", "")
   store["lvl1"] << body
-  items = store["lvl1"].map do |c|
+  items = store["lvl1"].entries.map do |c|
     "<li title=\"#{c}\">#{Xssmaze.html_escape(c)}</li>"
   end.join
   "<!doctype html><html><body>
@@ -41,7 +53,7 @@ end
 # renderer trusts the saved markdown.
 Xssmaze.push("storedpat-level2", "/storedpat/level2/", "profile bio markdown render (HTML pass-through)", "POST")
 maze_get "/storedpat/level2/" do |_|
-  bio = single["lvl2"]
+  bio = single["lvl2"].value
   rendered = bio.gsub(/\*\*([^*]+)\*\*/) { "<strong>#{$1}</strong>" }
     .gsub(/\*([^*]+)\*/) { "<em>#{$1}</em>" }
   "<!doctype html><html><body>
@@ -52,7 +64,7 @@ maze_get "/storedpat/level2/" do |_|
 end
 maze_post "/storedpat/level2/" do |env|
   bio = env.params.body.fetch("bio", "")
-  single["lvl2"] = bio
+  single["lvl2"].value = bio
   rendered = bio.gsub(/\*\*([^*]+)\*\*/) { "<strong>#{$1}</strong>" }
     .gsub(/\*([^*]+)\*/) { "<em>#{$1}</em>" }
   "<!doctype html><html><body>
@@ -68,7 +80,7 @@ end
 # context — escapes quotes only.
 Xssmaze.push("storedpat-level3", "/storedpat/level3/", "product review stored into <meta og:description>", "POST")
 maze_get "/storedpat/level3/" do |_|
-  last = single["lvl3"]
+  last = single["lvl3"].value
   "<!doctype html><html><head>
   <meta property=\"og:description\" content=\"#{last}\">
   </head><body>
@@ -79,7 +91,7 @@ maze_get "/storedpat/level3/" do |_|
 end
 maze_post "/storedpat/level3/" do |env|
   review = env.params.body.fetch("review", "")
-  single["lvl3"] = review
+  single["lvl3"].value = review
   "<!doctype html><html><head>
   <meta property=\"og:description\" content=\"#{review}\">
   </head><body>
@@ -94,7 +106,7 @@ end
 # appended and the entire thread re-rendered, raw.
 Xssmaze.push("storedpat-level4", "/storedpat/level4/", "chat message thread (raw render)", "POST")
 maze_get "/storedpat/level4/" do |_|
-  msgs = store["lvl4"].map { |m| "<div class='msg'>#{m}</div>" }.join
+  msgs = store["lvl4"].entries.map { |m| "<div class='msg'>#{m}</div>" }.join
   "<!doctype html><html><body>
   <h1>Chat</h1>
   <form method='post'><input name='msg' value='hello'><button>Send</button></form>
@@ -104,7 +116,7 @@ end
 maze_post "/storedpat/level4/" do |env|
   msg = env.params.body.fetch("msg", "")
   store["lvl4"] << msg
-  msgs = store["lvl4"].map { |m| "<div class='msg'>#{m}</div>" }.join
+  msgs = store["lvl4"].entries.map { |m| "<div class='msg'>#{m}</div>" }.join
   "<!doctype html><html><body>
   <h1>Chat</h1>
   <form method='post'><input name='msg' value='hello'><button>Send</button></form>
@@ -118,7 +130,7 @@ end
 # response also shows the stored subject for scanner detection.
 Xssmaze.push("storedpat-level5", "/storedpat/level5/", "ticket subject stored into <title> and <h1>", "POST")
 maze_get "/storedpat/level5/" do |_|
-  subj = single["lvl5"]
+  subj = single["lvl5"].value
   "<!doctype html><html><head>
   <title>Ticket — #{subj}</title>
   </head><body>
@@ -128,7 +140,7 @@ maze_get "/storedpat/level5/" do |_|
 end
 maze_post "/storedpat/level5/" do |env|
   subj = env.params.body.fetch("subject", "")
-  single["lvl5"] = subj
+  single["lvl5"].value = subj
   "<!doctype html><html><head>
   <title>Ticket — #{subj}</title>
   </head><body>
@@ -156,7 +168,7 @@ maze_get "/storedpat/level6/" do |_|
 end
 maze_post "/storedpat/level6/" do |env|
   note = env.params.body.fetch("note", "")
-  single["lvl6"] = note
+  single["lvl6"].value = note
   "<!doctype html><html><body>
   <h1>Admin notes</h1>
   <form method='post'><input name='note' value='ok'><button>Save</button></form>
@@ -170,5 +182,5 @@ maze_post "/storedpat/level6/" do |env|
 end
 get "/storedpat/level6/api" do |env|
   env.response.content_type = "application/json"
-  {note: single["lvl6"]}.to_json
+  {note: single["lvl6"].value}.to_json
 end

--- a/src/mazes/stored_xss.cr
+++ b/src/mazes/stored_xss.cr
@@ -1,9 +1,15 @@
-# In-memory store for stored XSS scenarios
-stored_data = Hash(String, Array(String)).new { |hash, key| hash[key] = [] of String }
+# In-memory store for stored XSS scenarios. Registered up front rather than
+# on first POST so an idle lab still reports all four levels on `GET /reset`.
+stored_data = {
+  "level1" => Xssmaze::Store.list("stored/level1"),
+  "level2" => Xssmaze::Store.list("stored/level2"),
+  "level3" => Xssmaze::Store.list("stored/level3"),
+  "level4" => Xssmaze::Store.list("stored/level4"),
+}
 
 Xssmaze.push("stored-level1", "/stored/level1/", "stored XSS via guestbook (no filter)", "POST")
 maze_get "/stored/level1/" do |_|
-  entries = stored_data["level1"].map { |e| "<li>#{e}</li>" }.join
+  entries = stored_data["level1"].entries.map { |e| "<li>#{e}</li>" }.join
   "<html><body>
   <h1>Stored XSS Level 1</h1>
   <form method='post'><input name='query' value='a'><input type='submit' value='Post'></form>
@@ -13,7 +19,7 @@ end
 maze_post "/stored/level1/" do |env|
   query = env.params.body["query"].as(String)
   stored_data["level1"] << query
-  entries = stored_data["level1"].map { |e| "<li>#{e}</li>" }.join
+  entries = stored_data["level1"].entries.map { |e| "<li>#{e}</li>" }.join
   "<html><body>
   <h1>Stored XSS Level 1</h1>
   <form method='post'><input name='query' value='a'><input type='submit' value='Post'></form>
@@ -23,7 +29,7 @@ end
 
 Xssmaze.push("stored-level2", "/stored/level2/", "stored XSS with angle bracket filter", "POST")
 maze_get "/stored/level2/" do |_|
-  entries = stored_data["level2"].map { |e| "<li>#{e}</li>" }.join
+  entries = stored_data["level2"].entries.map { |e| "<li>#{e}</li>" }.join
   "<html><body>
   <h1>Stored XSS Level 2</h1>
   <form method='post'><input name='query' value='a'><input type='submit' value='Post'></form>
@@ -33,7 +39,7 @@ end
 maze_post "/stored/level2/" do |env|
   query = Filters.strip_angles(env.params.body["query"].as(String))
   stored_data["level2"] << query
-  entries = stored_data["level2"].map { |e| "<li>#{e}</li>" }.join
+  entries = stored_data["level2"].entries.map { |e| "<li>#{e}</li>" }.join
   "<html><body>
   <h1>Stored XSS Level 2</h1>
   <form method='post'><input name='query' value='a'><input type='submit' value='Post'></form>
@@ -43,7 +49,7 @@ end
 
 Xssmaze.push("stored-level3", "/stored/level3/", "stored XSS in attribute context", "POST")
 maze_get "/stored/level3/" do |_|
-  entries = stored_data["level3"].map { |e| "<div title=\"#{e}\">#{Filters.encode_angles(e)}</div>" }.join
+  entries = stored_data["level3"].entries.map { |e| "<div title=\"#{e}\">#{Filters.encode_angles(e)}</div>" }.join
   "<html><body>
   <h1>Stored XSS Level 3</h1>
   <form method='post'><input name='query' value='a'><input type='submit' value='Post'></form>
@@ -53,7 +59,7 @@ end
 maze_post "/stored/level3/" do |env|
   query = env.params.body["query"].as(String)
   stored_data["level3"] << query
-  entries = stored_data["level3"].map { |e| "<div title=\"#{e}\">#{Filters.encode_angles(e)}</div>" }.join
+  entries = stored_data["level3"].entries.map { |e| "<div title=\"#{e}\">#{Filters.encode_angles(e)}</div>" }.join
   "<html><body>
   <h1>Stored XSS Level 3</h1>
   <form method='post'><input name='query' value='a'><input type='submit' value='Post'></form>
@@ -90,5 +96,5 @@ maze_post "/stored/level4/" do |env|
 end
 get "/stored/level4/api" do |env|
   env.response.content_type = "application/json"
-  {entries: stored_data["level4"]}.to_json
+  {entries: stored_data["level4"].entries}.to_json
 end

--- a/src/store.cr
+++ b/src/store.cr
@@ -1,0 +1,189 @@
+require "json"
+
+# Central registry for the state the stored mazes accumulate.
+#
+# Stored mazes are the one part of the lab that remembers a scanner run, and
+# they used to remember it forever: a second run read the first run's payloads
+# back out and reported them as its own finding, two tools pointed at one
+# instance contaminated each other, and a long fuzz grew the process without
+# bound. Every collection is capped and reachable by name from here, so a
+# harness can wipe the lab between runs (`POST /reset`) instead of restarting
+# it.
+#
+# The vulnerabilities themselves are untouched — the cap and the reset are the
+# only new behaviour.
+module Xssmaze::Store
+  # How many entries a bounded collection keeps. Deep enough that a scanner
+  # posting a handful of payloads still watches a list build up, shallow
+  # enough that a fuzzer cannot grow the process.
+  MAX_ENTRIES = 20
+
+  abstract class Collection
+    getter name : String
+
+    def initialize(@name : String)
+    end
+
+    abstract def size : Int32
+    abstract def clear : Nil
+  end
+
+  # The most recent `MAX_ENTRIES` values, oldest dropped first.
+  class List < Collection
+    getter entries = [] of String
+
+    def <<(value : String) : Nil
+      @entries << value
+      @entries.shift if @entries.size > MAX_ENTRIES
+    end
+
+    def size : Int32
+      @entries.size
+    end
+
+    def clear : Nil
+      @entries.clear
+    end
+  end
+
+  # A single value that every POST overwrites. Bounded by construction; it is
+  # registered here so that "clear everything" really does mean everything.
+  class Single < Collection
+    property value = ""
+
+    def size : Int32
+      @value.empty? ? 0 : 1
+    end
+
+    def clear : Nil
+      @value = ""
+    end
+  end
+
+  # A bounded map of key -> bounded list, for the store whose keys the maze
+  # invents at runtime (a random callback id). Capping only the lists would
+  # still leak one key per request forever, so the key set is capped too —
+  # Hash keeps insertion order, so the oldest key is always `first_key`.
+  class Group < Collection
+    @lists = {} of String => Array(String)
+
+    def push(key : String, value : String) : Nil
+      list = @lists[key]?
+      unless list
+        list = @lists[key] = [] of String
+        @lists.delete(@lists.first_key) if @lists.size > MAX_ENTRIES
+      end
+      list << value
+      list.shift if list.size > MAX_ENTRIES
+    end
+
+    def [](key : String) : Array(String)
+      @lists[key]? || [] of String
+    end
+
+    def size : Int32
+      @lists.values.sum(&.size)
+    end
+
+    def clear : Nil
+      @lists.clear
+    end
+  end
+
+  @@collections = {} of String => Collection
+
+  # Register-or-fetch. Maze files call these at require time, so every
+  # collection shows up in `sizes` before the first request rather than
+  # appearing halfway through a run.
+  def self.list(name : String) : List
+    (@@collections[name] ||= List.new(name)).as(List)
+  end
+
+  def self.single(name : String) : Single
+    (@@collections[name] ||= Single.new(name)).as(Single)
+  end
+
+  def self.group(name : String) : Group
+    (@@collections[name] ||= Group.new(name)).as(Group)
+  end
+
+  def self.names : Array(String)
+    @@collections.keys.sort!
+  end
+
+  def self.sizes : Hash(String, Int32)
+    names.each_with_object({} of String => Int32) do |name, acc|
+      acc[name] = @@collections[name].size
+    end
+  end
+
+  def self.total : Int32
+    @@collections.values.sum(&.size)
+  end
+
+  # Clears one collection and reports how many entries went away, or nil when
+  # nothing is registered under that name — the route answers 400 for that.
+  def self.reset(name : String) : Int32?
+    collection = @@collections[name]?
+    return unless collection
+    cleared = collection.size
+    collection.clear
+    cleared
+  end
+
+  def self.reset_all : Hash(String, Int32)
+    names.each_with_object({} of String => Int32) do |name, acc|
+      collection = @@collections[name]
+      acc[name] = collection.size
+      collection.clear
+    end
+  end
+
+  # Same headers as `Xssmaze::Server.json_no_store`, spelled out rather than
+  # called: the store is required before the server and has no business
+  # reaching up into the HTTP layer for three header assignments.
+  def self.json_no_store(env) : Nil
+    env.response.content_type = "application/json"
+    env.response.headers["Access-Control-Allow-Origin"] = "*"
+    env.response.headers["Cache-Control"] = "no-store"
+  end
+end
+
+# `/reset` is lab infrastructure, not a maze, so it is deliberately absent
+# from `Xssmaze.push`: /map/json, /stats and every benchmark denominator
+# should count vulnerabilities, not the plumbing that clears them.
+#
+#   GET  /reset               current size of every collection. Read-only, so
+#                             a crawler following links — or a scanner that
+#                             GETs every route it discovers — can never wipe
+#                             the lab out from under a run in progress.
+#   POST /reset               clear everything.
+#   POST /reset?scope=<name>  clear one collection, named as `GET /reset`
+#                             reports it (e.g. `stored/level1`).
+get "/reset" do |env|
+  Xssmaze::Store.json_no_store(env)
+  {
+    collections: Xssmaze::Store.sizes,
+    total:       Xssmaze::Store.total,
+    max_entries: Xssmaze::Store::MAX_ENTRIES,
+  }.to_json
+end
+
+post "/reset" do |env|
+  Xssmaze::Store.json_no_store(env)
+
+  if scope = env.params.query["scope"]?
+    cleared = Xssmaze::Store.reset(scope)
+    if cleared.nil?
+      # 400, not 404: Kemal hands any 404 to the `error 404` handler, which
+      # would replace this JSON with the lab's HTML not-found page. The route
+      # exists — the scope is what's wrong — so 400 is the honest answer.
+      env.response.status_code = 400
+      next {error: "unknown scope", scope: scope, known: Xssmaze::Store.names}.to_json
+    end
+    {reset: scope, cleared: {scope => cleared}, total: cleared}.to_json
+  else
+    cleared = Xssmaze::Store.reset_all
+    {reset: "all", cleared: cleared, total: cleared.values.sum}.to_json
+  end
+end

--- a/src/xssmaze.cr
+++ b/src/xssmaze.cr
@@ -11,6 +11,7 @@ require "./assets"
 require "./catalog"
 require "./ui"
 require "./banner"
+require "./store"
 require "./mazes/**"
 require "./server"
 


### PR DESCRIPTION
## What changed

Stored mazes accumulated state forever, with no cap and no way to clear it. For a benchmark lab that means a second scanner run reads the first run's payloads back out and reports them as its own finding, two tools pointed at one instance contaminate each other, and a long fuzz grows the process without bound.

**`src/store.cr` (new) — `Xssmaze::Store`**, a registry of named collections:

- `Store::List` — the most recent `MAX_ENTRIES` (= 20) values, oldest dropped first.
- `Store::Single` — one value, overwritten per POST.
- `Store::Group` — a bounded map of key → bounded list. This is for `headless-generator/level5`, whose keys are callback ids *the maze itself invents* (one per form render). Capping only the lists would still leak a key per request forever, so the key set is capped too.
- `Store.reset_all`, `Store.reset(name)`, `Store.sizes`, `Store.total`, `Store.names`.

Maze files call `Store.list/single/group` at require time, so all 11 collections show up in the status view before any traffic arrives rather than appearing halfway through a run.

**Migrated the three unbounded stores** (`stored_xss.cr`, `stored_pattern_xss.cr`, `headless_generator_xss.cr`). Same HTML, same reflection, same vulnerabilities — the cap and the reset are the only new behaviour.

**HTTP routes, registered in `src/store.cr` itself** (not `src/server.cr`), following the maze-file convention of registering at require time:

| | |
|---|---|
| `GET /reset` | current size of every collection + `max_entries`. **Read-only** — a crawler following links, or a scanner GETting every route it discovers, can never wipe the lab out from under a run in progress. |
| `POST /reset` | clear everything; answers with what was cleared, per collection. |
| `POST /reset?scope=<name>` | clear one collection, named as `GET /reset` reports it (e.g. `stored/level1`). |

`Cache-Control: no-store` + `Access-Control-Allow-Origin: *`, matching `Xssmaze::Server.json_no_store`'s shape. It is spelled out rather than called: `src/store.cr` is required before `src/server.cr` and shouldn't reach up into the HTTP layer for three header assignments.

`/reset` is deliberately **not** passed to `Xssmaze.push` — it's infrastructure, not a maze, so it never lands in `/map/json`, `/stats` or a benchmark denominator.

`src/xssmaze.cr` gets one line: `require "./store"` before `require "./mazes/**"`.

## Verification

**`crystal spec`** — 154 examples (22 new), 0 failures:

```
..........................................................................................................................................................

Finished in 104.61 milliseconds
154 examples, 0 failures, 0 errors, 0 pending
```

**`crystal tool format --check`** → clean. **ameba** (`crystal run lib/ameba/bin/ameba.cr -- src/ spec/`) → `201 inspected, 0 failures`.

**Manual round-trip** against a real build (`shards build && ./bin/xssmaze -p 3517 -q --no-banner`):

```
== 1. fresh status ==
$ curl -s localhost:3517/reset
{
    "collections": {
        "headless-generator/level5": 0, "stored/level1": 0, "stored/level2": 0,
        "stored/level3": 0, "stored/level4": 0, "storedpat/level1": 0,
        "storedpat/level2": 0, "storedpat/level3": 0, "storedpat/level4": 0,
        "storedpat/level5": 0, "storedpat/level6": 0
    },
    "total": 0,
    "max_entries": 20
}

== 2. POST 25 payloads to /stored/level1/ ==
<li> entries served: 20
oldest (entry-1) present? 0
newest (entry-25) present? 1
first surviving: entry-6
last surviving:  entry-25

== 3. XSS still works (raw reflection) ==
$ curl -X POST --data-urlencode 'query=<script>alert(1)</script>' .../stored/level1/
<li><script>alert(1)</script></li>
$ curl -X POST --data-urlencode 'review=<svg onload=alert(1)>' .../storedpat/level3/
content="<svg onload=alert(1)>"

== 4. scoped reset ==
before: total 23  {'stored/level1': 20, 'storedpat/level1': 1, 'storedpat/level3': 1, 'storedpat/level5': 1}
$ curl -i -X POST '.../reset?scope=stored/level1'
HTTP/1.1 200 OK
Content-Type: application/json
Access-Control-Allow-Origin: *
Cache-Control: no-store
{"reset":"stored/level1","cleared":{"stored/level1":20},"total":20}
after:  total 3   {'storedpat/level1': 1, 'storedpat/level3': 1, 'storedpat/level5': 1}

== 5. unknown scope ==
status 400
unknown scope | nope | known: 11

== 6. POST /reset clears everything ==
{"reset": "all", "cleared": {... "storedpat/level1": 1, "storedpat/level3": 1, "storedpat/level5": 1 ...}, "total": 3}
total after reset: 0
<li> entries served after reset: 0
storedpat/level5 title after reset: <title>Ticket — </title>

== 7. GET /reset is non-destructive ==
after 3 x GET /reset, stored/level1 size: 1
>keepme<

== 8. headless callback log still records, and resets ==
<li>JavaScript fetch/XHR detected: https://evil.example/x</li>
group size: 1
(after POST /reset) No callbacks received yet

== 9. /reset stays out of the catalog ==
map/json hits for reset: 0
map/text hits for reset: 0
sitemap hits for reset:  0
stats total: 1064
endpoints reported by /health: 1064
```

## For the reviewer

- **`400`, not `404`, for an unknown `?scope=`.** Kemal routes any 404 to the `error 404` handler in `src/server.cr`, which replaces the body with the lab's HTML not-found page — the JSON never survives. The route exists and the scope is what's wrong, so 400 is both honest and the only shape that works without touching `src/server.cr`. Flagged because the obvious first instinct is 404. Spec: `spec/store_spec.cr:131`.
- **`MAX_ENTRIES = 20` is one constant** in `src/store.cr:19` and governs list depth, group key count, and per-key log depth alike. If a scenario ever wants a different depth, that's the place.
- **`Store::Group` eviction relies on Crystal's `Hash` preserving insertion order** (`@lists.first_key` is the oldest key). Correct today; worth knowing it's load-bearing.
- **`Single#size` is 0 or 1**, treating `""` as empty. A POST that stores an empty string therefore reports size 0. Fine for a status view, but it is a choice.
- **Reset is process-global and unauthenticated.** That matches the lab's threat model (loopback-bound, intentionally vulnerable), but two harnesses sharing one instance can now clear each other's state mid-run as well as contaminate it. Scoped reset narrows that.
- **Docs not touched** per the parallel-work brief — README/CHANGELOG/AGENTS.md are the orchestrator's. `/reset` is a new user-facing endpoint and wants a line in the README's endpoint list.
