### PR TITLE
fix(mazes): keep cookie reflections out of HTTP::Cookie's validator, add catalog smoke spec

### DIFF
--- a/spec/smoke_spec.cr
+++ b/spec/smoke_spec.cr
@@ -1,0 +1,178 @@
+require "./spec_helper"
+
+# The catalog is ~1000 hand-written handlers and nothing else walks all of
+# them, so a maze that crashes on the exact payload it advertises can sit
+# there for releases — three of them did, all dying inside `HTTP::Cookie`.
+#
+# The assertion is deliberately only "not 5xx". 403/406 (the `waf-facade`
+# and `modern-bypass` WAF levels), 302/404 (`redirect-*` pointing at a path
+# that does not exist) and 400 are correct answers here; pinning 200 would
+# turn this into a tripwire for every intentional behaviour in the lab.
+module SmokeSpec
+  # Small on purpose: this runs against every parameter of every endpoint,
+  # so each extra payload costs a full sweep. These five cover the contexts
+  # that break server-side — HTML breakout, JS-string breakout, and the
+  # `;` `"` that RFC 6265 bans from a cookie value.
+  PAYLOADS = [
+    "\"><script>alert(1)</script>",
+    "';alert(1);//",
+    "a;b",
+    "\"x\"",
+    "<img src=x onerror=alert(1)>",
+  ]
+
+  # How many offenders to spell out before summarising; a broken shared
+  # helper can fail hundreds of endpoints at once.
+  MAX_REPORTED = 25
+
+  # Params a plain HTTP request cannot carry: fragments (`#hash`), the path
+  # placeholder the catalog URL already spells out (`:path`), and browser-only
+  # channels (`document.cookie`, `window.name`, `postMessage`).
+  def self.carriable?(param : String) : Bool
+    return false if param.starts_with?('#') || param.starts_with?(':')
+    return false if param.starts_with?("document.") || param.starts_with?("window.")
+    param != "postMessage"
+  end
+
+  # `params` is hand-maintained and drifts: 25 catalog entries advertise a URL
+  # whose real parameter is not in the list — `rsplit-level4` says `query`
+  # while the sink is `pref`. Two of the three cookie 500s this spec exists
+  # for hid behind exactly that gap, so sweep the union of what the maze
+  # declares and what its advertised URL actually spells out.
+  def self.params_for(maze : Maze) : Array(String)
+    names = [] of String
+    _, _, query = maze.url.partition('?')
+    HTTP::Params.parse(query).each { |name, _| names << name }
+    (names + maze.params).uniq.select { |param| carriable?(param) }
+  end
+
+  # A catalog param spelled in Header-Case names an HTTP header rather than a
+  # query parameter — `User-Agent`, `Referer`, `X-Forwarded-For` and friends.
+  def self.header_param?(param : String) : Bool
+    param[0].ascii_uppercase?
+  end
+
+  def self.with_query(url : String, param : String, value : String) : String
+    path, _, query = url.partition('?')
+    params = HTTP::Params.parse(query)
+    params[param] = value
+    "#{path}?#{params}"
+  end
+
+  def self.mazes : Array(Maze)
+    Xssmaze.get.select { |maze| maze.method == "GET" }
+  end
+
+  # Records the maze name, the status and the exact URL (plus the header, when
+  # the payload rode in one) so a CI log alone is enough to reproduce.
+  def self.check(failures : Array(String), maze : Maze, url : String,
+                 header : String? = nil, payload : String? = nil) : Nil
+    headers = nil
+    if header && payload
+      headers = HTTP::Headers.new
+      headers[header] = payload
+    end
+
+    get url, headers: headers
+    status = response.status_code
+    return if status < 500
+
+    via = header ? " (#{header}: #{payload})" : ""
+    failures << "#{maze.name}: HTTP #{status} for #{url}#{via}"
+  end
+
+  def self.report(failures : Array(String)) : Nil
+    return if failures.empty?
+
+    fail(String.build do |io|
+      io << failures.size << " endpoint(s) answered 5xx:\n"
+      failures.first(MAX_REPORTED).each { |line| io << "  " << line << '\n' }
+      if (extra = failures.size - MAX_REPORTED) > 0
+        io << "  ...and " << extra << " more\n"
+      end
+    end)
+  end
+end
+
+describe "catalog smoke test" do
+  it "answers every advertised GET URL without a 5xx" do
+    failures = [] of String
+    SmokeSpec.mazes.each do |maze|
+      SmokeSpec.check(failures, maze, maze.url)
+    end
+    SmokeSpec.report(failures)
+  end
+
+  it "survives the canonical payloads on every GET parameter" do
+    failures = [] of String
+
+    SmokeSpec.mazes.each do |maze|
+      SmokeSpec.params_for(maze).each do |param|
+        SmokeSpec::PAYLOADS.each do |payload|
+          if SmokeSpec.header_param?(param)
+            SmokeSpec.check(failures, maze, maze.url, header: param, payload: payload)
+          else
+            SmokeSpec.check(failures, maze, SmokeSpec.with_query(maze.url, param, payload))
+          end
+        end
+      end
+    end
+
+    SmokeSpec.report(failures)
+  end
+end
+
+# The sweep above only asserts "not 5xx", which a future refactor could
+# satisfy by dropping the cookie altogether — and the cookie *is* the maze.
+# These pin the other half of the contract: sanitized value in `Set-Cookie`,
+# untouched payload in the body.
+describe "Xssmaze.cookie_value" do
+  it "removes exactly the characters HTTP::Cookie refuses" do
+    ((0..0x7f).map(&.chr) + ['한', 'é', '\u{1f4a9}']).each do |char|
+      accepted =
+        begin
+          HTTP::Cookie.new("probe", char.to_s)
+          true
+        rescue IO::Error
+          false
+        end
+
+      Xssmaze.cookie_value(char.to_s).should eq(accepted ? char.to_s : "")
+    end
+  end
+end
+
+describe "mazes that reflect into Set-Cookie" do
+  payload = "\"><script>alert(1)</script>"
+  # `"` is the only byte RFC 6265 bans in the payload above.
+  in_cookie = "><script>alert(1)</script>"
+
+  it "respheader level4 keeps both cookies and the raw body reflection" do
+    get "/respheader/level4/?query=#{URI.encode_www_form(payload)}"
+    response.status_code.should eq 200
+    response.cookies["session_data"].value.should eq(in_cookie)
+    response.cookies["user_pref"].value.should eq(in_cookie)
+    response.body.should contain(payload)
+  end
+
+  it "rsplit level4 survives the splitting characters it exists to reflect" do
+    get "/rsplit/level4/?pref=#{URI.encode_www_form(%("x"))}"
+    response.status_code.should eq 200
+    response.cookies["pref"].value.should eq("x")
+    response.body.should contain(%(Preference: "x"))
+  end
+
+  it "rsplit level4 drops CR/LF instead of splitting the response" do
+    get "/rsplit/level4/?pref=#{URI.encode_www_form("a\r\nX-Evil: 1")}"
+    response.status_code.should eq 200
+    response.cookies["pref"].value.should eq("aX-Evil: 1")
+    response.headers.has_key?("X-Evil").should be_false
+  end
+
+  it "realworld-input level6 stores the language and reflects it raw" do
+    get "/realworld-input/level6/?lang=#{URI.encode_www_form(payload)}"
+    response.status_code.should eq 200
+    response.cookies["lang"].value.should eq(in_cookie)
+    response.body.should contain("Current language: #{payload}")
+  end
+end

--- a/src/mazes/realworld_input_xss.cr
+++ b/src/mazes/realworld_input_xss.cr
@@ -58,7 +58,9 @@ maze_get "/realworld-input/level6/" do |env|
   lang_param = env.params.query.fetch("lang", "")
 
   unless lang_param.empty?
-    env.response.cookies << HTTP::Cookie.new("lang", lang_param, path: "/realworld-input/level6/")
+    # Stored in the cookie minus the bytes RFC 6265 forbids; `display`
+    # below still reflects the untouched parameter.
+    env.response.cookies << HTTP::Cookie.new("lang", Xssmaze.cookie_value(lang_param), path: "/realworld-input/level6/")
   end
 
   lang_cookie = ""

--- a/src/mazes/response_header_xss.cr
+++ b/src/mazes/response_header_xss.cr
@@ -48,8 +48,10 @@ Xssmaze.push("respheader-level4", "/respheader/level4/?query=a", "query in Set-C
 maze_get "/respheader/level4/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
-  env.response.cookies << HTTP::Cookie.new("session_data", query, path: "/respheader/level4/")
-  env.response.cookies << HTTP::Cookie.new("user_pref", query, path: "/respheader/level4/")
+  # The cookie copies drop the bytes RFC 6265 forbids because Crystal
+  # refuses to emit them; the body reflection below stays raw.
+  env.response.cookies << HTTP::Cookie.new("session_data", Xssmaze.cookie_value(query), path: "/respheader/level4/")
+  env.response.cookies << HTTP::Cookie.new("user_pref", Xssmaze.cookie_value(query), path: "/respheader/level4/")
 
   "<html><body>
   <h1>Response Header XSS Level 4</h1>

--- a/src/mazes/response_split_xss.cr
+++ b/src/mazes/response_split_xss.cr
@@ -30,7 +30,9 @@ end
 Xssmaze.push("rsplit-level4", "/rsplit/level4/?pref=a", "set-cookie + body reflection")
 maze_get "/rsplit/level4/" do |env|
   pref = env.params.query.fetch("pref", "default")
-  env.response.cookies << HTTP::Cookie.new("pref", pref, path: "/rsplit/level4/")
+  # Splitting characters are exactly what this level is about, so the cookie
+  # copy keeps everything RFC 6265 lets through and the body keeps the rest.
+  env.response.cookies << HTTP::Cookie.new("pref", Xssmaze.cookie_value(pref), path: "/rsplit/level4/")
 
   "<html><body><div>Preference: #{pref}</div></body></html>"
 end

--- a/src/registry.cr
+++ b/src/registry.cr
@@ -65,6 +65,19 @@ module Xssmaze
     s.delete("\r\n\u0000")
   end
 
+  # Same bargain as `header_value`, one layer down, for `Set-Cookie`.
+  #
+  # `HTTP::Cookie` enforces RFC 6265 4.1.1 and raises `IO::Error` on any
+  # byte outside 0x20..0x7e plus `"` `,` `;` `\`, so the cookie mazes
+  # answered 500 on precisely the payloads they exist to reflect — a
+  # `?pref="x"` never reached `Set-Cookie` at all, and `rsplit-level4` died
+  # on the very characters a response-splitting test is made of. Dropping
+  # those bytes keeps the value in the header where the lesson is; the body
+  # reflection alongside it stays raw.
+  def self.cookie_value(s : String) : String
+    s.delete { |char| !char.in?(' '..'~') || char.in?('"', ',', ';', '\\') }
+  end
+
   def self.gzip(body : String) : Bytes
     io = IO::Memory.new
     Compress::Gzip::Writer.open(io, level: Compress::Gzip::BEST_COMPRESSION) do |writer|


### PR DESCRIPTION
## What changed

Crystal's `HTTP::Cookie` enforces RFC 6265 §4.1.1 and raises `IO::Error("Invalid cookie value")` for any byte outside `0x20..0x7e` plus `"` `,` `;` `\`. Three mazes pushed a raw user-controlled value into `Set-Cookie`, so they answered **500 on exactly the payload they exist to reflect** — including `rsplit-level4`, a *response splitting* level that died on the splitting characters themselves.

- **`src/registry.cr`** — new `Xssmaze.cookie_value(s : String) : String`, a sibling of the existing `Xssmaze.header_value`, removing exactly the bytes the validator rejects. Same philosophy as `header_value`: keep the reflection, drop the crash.
- **`src/mazes/response_header_xss.cr`** (`respheader-level4`), **`src/mazes/response_split_xss.cr`** (`rsplit-level4`), **`src/mazes/realworld_input_xss.cr`** (`realworld-input-level6`) — applied at the three call sites. The **body** reflection in all three is untouched and still raw.
- **`spec/smoke_spec.cr`** (new) — walks the whole live catalog and asserts no endpoint answers 5xx, plus contract tests pinning that the value still lands in `Set-Cookie`.

### The two other call sites: inspected, deliberately unchanged

- **`src/mazes/modern_realworld_bypass_xss.cr:14`** — `session_id` comes from a *request* cookie. Crystal's own request-side parser builds those with the same `Cookie.new`, and its `CookieOctet` regex (`/[!#-+\--:<-\[\]-~ ]/`) is exactly the RFC 6265 valid set, so the value is already truncated at the first forbidden byte before the handler ever sees it. Verified against the running server:

  ```
  session_id="a"b"     -> 200  Set-Cookie: session_id=a; path=/modern-bypass/level1/
  session_id=a\b       -> 200  Set-Cookie: session_id=a; path=/modern-bypass/level1/
  session_id=aaa,bbb   -> 200  Set-Cookie: session_id=aaa; path=/modern-bypass/level1/
  session_id=한글       -> 200  Set-Cookie: session_id=; path=/modern-bypass/level1/
  ```

  Wrapping it would be dead code: if a hostile value *could* survive the parser, `parse_cookies` would already have raised before the handler ran.

- **`src/mazes/xsleak.cr:46`** — `role` is `as_param == "admin" ? "admin" : "guest"`, two literals; line 53 writes `""`. `GET /xsleak/login?as="><script>alert(1)</script>` -> 302, no change needed.

## Verification

All commands run in this worktree; output pasted verbatim.

### 1. The three repro URLs — `shards build`, server on port 39311

Before the fix:

```
$ curl -sD- -o /dev/null -G .../respheader/level4/     --data-urlencode 'query="><script>alert(1)</script>'  -> HTTP/1.1 500 Internal Server Error
$ curl -sD- -o /dev/null -G .../rsplit/level4/         --data-urlencode 'pref="x"'                           -> HTTP/1.1 500 Internal Server Error
$ curl -sD- -o /dev/null -G .../realworld-input/level6/ --data-urlencode 'lang="><script>alert(1)</script>'  -> HTTP/1.1 500 Internal Server Error
```

After (`./bin/xssmaze -p 39311 -q --no-banner`, filtered to status / `Set-Cookie` / the reflection line):

```
### 1) respheader-level4
HTTP/1.1 200 OK
Set-Cookie: session_data=><script>alert(1)</script>; path=/respheader/level4/
Set-Cookie: user_pref=><script>alert(1)</script>; path=/respheader/level4/
  <div>Your preference: "><script>alert(1)</script></div>

### 2) rsplit-level4
HTTP/1.1 200 OK
Set-Cookie: pref=x; path=/rsplit/level4/
<html><body><div>Preference: "x"</div></body></html>

### 3) realworld-input-level6
HTTP/1.1 200 OK
Set-Cookie: lang=><script>alert(1)</script>; path=/realworld-input/level6/
<html><body><div>Current language: "><script>alert(1)</script></div></body></html>
```

200, payload still raw in the body, payload still in `Set-Cookie` minus only the bytes RFC 6265 bans.

Edge cases through `rsplit-level4` — note CR/LF is dropped without splitting the response:

```
a;b                  HTTP/1.1 200 OK | Set-Cookie: pref=ab; path=/rsplit/level4/
a\b                  HTTP/1.1 200 OK | Set-Cookie: pref=ab; path=/rsplit/level4/
a,b                  HTTP/1.1 200 OK | Set-Cookie: pref=ab; path=/rsplit/level4/
한글                  HTTP/1.1 200 OK | Set-Cookie: pref=; path=/rsplit/level4/
a\r\nX-Evil: 1       HTTP/1.1 200 OK | Set-Cookie: pref=aX-Evil: 1; path=/rsplit/level4/   (no X-Evil header)
```

### 2. `crystal spec` green

```
$ crystal spec
................................................................................................................................................

Finished in 1.54 seconds
144 examples, 0 failures, 0 errors, 0 pending
```

### 3. `crystal tool format --check` clean, ameba clean

```
$ crystal tool format --check && echo "FORMAT OK"
FORMAT OK

$ ./lib/ameba/bin/ameba
Finished in 305.72 milliseconds
200 inspected, 0 failures
```

### 4. The smoke spec really fails when the fix is reverted

`git checkout -- src/`, then `crystal spec spec/smoke_spec.cr`:

```
  1) catalog smoke test survives the canonical payloads on every GET parameter
     Failure/Error: fail(String.build do |io|

       12 endpoint(s) answered 5xx:
         realworld_input-level6: HTTP 500 for /realworld-input/level6/?lang=%22%3E%3Cscript%3Ealert%281%29%3C%2Fscript%3E
         realworld_input-level6: HTTP 500 for /realworld-input/level6/?lang=%27%3Balert%281%29%3B%2F%2F
         realworld_input-level6: HTTP 500 for /realworld-input/level6/?lang=a%3Bb
         realworld_input-level6: HTTP 500 for /realworld-input/level6/?lang=%22x%22
         respheader-level4: HTTP 500 for /respheader/level4/?query=%22%3E%3Cscript%3Ealert%281%29%3C%2Fscript%3E
         respheader-level4: HTTP 500 for /respheader/level4/?query=%27%3Balert%281%29%3B%2F%2F
         respheader-level4: HTTP 500 for /respheader/level4/?query=a%3Bb
         respheader-level4: HTTP 500 for /respheader/level4/?query=%22x%22
         rsplit-level4: HTTP 500 for /rsplit/level4/?pref=%22%3E%3Cscript%3Ealert%281%29%3C%2Fscript%3E
         rsplit-level4: HTTP 500 for /rsplit/level4/?pref=%27%3Balert%281%29%3B%2F%2F
         rsplit-level4: HTTP 500 for /rsplit/level4/?pref=a%3Bb
         rsplit-level4: HTTP 500 for /rsplit/level4/?pref=%22x%22
```

All three regressions, named with the exact URL. The fix was then re-applied and the suite re-run green (above).

## About the spec

1033 GET mazes x 1043 carriable parameter slots x 5 payloads = **6,248 in-process requests in ~1.6s** (of which ~1.25s is `xsleak-level4`'s deliberate 250ms sleep). Full catalog coverage, no sampling.

- Asserts **not 5xx**, never `== 200` — 403/406 (`waf-facade`, `modern-bypass` WAF levels), 302/404 (`redirect-*`) and 400 stay legal.
- Skips `:path`, `#hash`/`#msg`, `document.*`, `window.name`, `postMessage`.
- Catalog params spelled in Header-Case (`User-Agent`, `Referer`, `X-Forwarded-For`, `X-Debug`, `Cookie`, ...) are delivered as request headers rather than query params.
- Failures accumulate and are reported together (capped at 25 + a count), each line naming the maze, the status and the exact URL.

## For the reviewer

**Please double-check these two:**

1. **The spec sweeps the union of `maze.params` and the params in `maze.url`, not `maze.params` alone.** This is load-bearing: with `maze.params` alone it only caught `respheader-level4`. **25 catalog entries advertise a URL whose real parameter is not in their `params` list** — `rsplit-level4` declares `["query"]` while its sink is `pref`, `realworld_input-level6` declares `["query"]` while its sink is `lang`. That metadata drift is a real defect in its own right (a scanner reading `/map/json` is told to fuzz the wrong parameter), but it spans files I do not own here — `callback_*`, `hpp_*`, `edge_*`, `sink_*`, `realworld_*`, `bugbounty_*`, `ctype_*`, `modern_*`, `multicontext_*`, `headerinj_*`. **I did not touch any `params:` metadata; leaving that to the orchestrator.** Full list:

   ```
   bugbounty-level2        params ['error_description']  url also carries: error
   callback-level1..4      params ['query']              url carries: callback / fn / handler
   ctype-level4            params ['query']              url carries: callback
   edge-level5, edge-level7                              url carries: q1,q2 / a,b,c
   headerinj-level6        params ['X-Debug']            url carries: debug
   hpp-level2/3/4          params ['query']              url carries: q / items[] / config.theme
   modern-level6           params ['query']              url carries: wsurl
   multicontext-level6     params ['query']              url carries: q1, q2
   realworld-level2/4/5    params ['query']              url carries: debug / tag,attr / search
   realworld_input-level4/5/6/8                          url carries: url / url / lang / callback
   rsplit-level2/3/4       params ['query']              url carries: name,color / page / pref
   sink-level8             params ['query']              url carries: callback
   ```

2. **`cookie_value` filters by codepoint, not by byte.** This is byte-exact for the validator's rule: any char above U+007E encodes to bytes >= 0x80, all of which the validator rejects anyway, and chars below U+0020 are single bytes. `spec/smoke_spec.cr` pins the equivalence directly — for every char in `0x00..0x7f` plus `한`, `é`, `U+1F4A9`, `cookie_value(c)` is empty iff `HTTP::Cookie.new("probe", c)` raises.

No `README.md` / `CHANGELOG.md` / `AGENTS.md` changes, per the parallel-work brief.
