### PR TITLE
feat(beacon): add an execution oracle so a benchmark can prove a payload ran

### DIFF
--- a/spec/beacon_spec.cr
+++ b/spec/beacon_spec.cr
@@ -1,0 +1,276 @@
+require "./spec_helper"
+
+private def fire(token : String, referer : String? = nil, user_agent : String? = nil)
+  headers = HTTP::Headers.new
+  headers["Referer"] = referer if referer
+  headers["User-Agent"] = user_agent if user_agent
+  get "/beacon/#{token}", headers: headers
+end
+
+private def read_log(token : String? = nil) : JSON::Any
+  get(token ? "/beacon/log?token=#{token}" : "/beacon/log")
+  JSON.parse(response.body)
+end
+
+describe Xssmaze::Beacon do
+  before_each { Xssmaze::Beacon.clear }
+
+  describe "firing" do
+    it "records a hit and reports it in the log" do
+      fire("run1")
+      response.status_code.should eq 200
+
+      log = read_log("run1")
+      log["token"].as_s.should eq "run1"
+      log["fired"].as_bool.should be_true
+      log["count"].as_i.should eq 1
+      log["first"].as_s.should_not be_empty
+      log["last"].as_s.should eq log["first"].as_s
+    end
+
+    it "records the Referer, which names the maze page that executed" do
+      page = "http://127.0.0.1:3000/basic/level1/?query=%3Cimg%20src=/beacon/run1%3E"
+      fire("run1", referer: page, user_agent: "HeadlessChrome/1.0")
+
+      log = read_log("run1")
+      log["referers"].as_a.map(&.as_s).should eq [page]
+      log["user_agents"].as_a.map(&.as_s).should eq ["HeadlessChrome/1.0"]
+      log["hits"].as_a.first["referer"].as_s.should eq page
+      log["hits"].as_a.first["method"].as_s.should eq "GET"
+    end
+
+    it "increments the count on a second fire and keeps both Referers" do
+      fire("run1", referer: "http://host/a")
+      first = read_log("run1")["first"].as_s
+      fire("run1", referer: "http://host/b")
+
+      log = read_log("run1")
+      log["count"].as_i.should eq 2
+      log["first"].as_s.should eq first
+      log["referers"].as_a.map(&.as_s).should eq ["http://host/a", "http://host/b"]
+    end
+
+    it "reports a token that never fired instead of erroring" do
+      log = read_log("never")
+      response.status_code.should eq 200
+      log["fired"].as_bool.should be_false
+      log["count"].as_i.should eq 0
+      log["first"].raw.should be_nil
+      log["hits"].as_a.should be_empty
+    end
+
+    it "keeps tokens apart and lists them all when no token is given" do
+      fire("run1")
+      fire("run2")
+      fire("run2")
+
+      log = read_log
+      log["tokens"].as_i.should eq 2
+      log["total_hits"].as_i.should eq 3
+      log["logs"].as_a.map(&.["token"].as_s).sort!.should eq ["run1", "run2"]
+    end
+
+    it "records fires from methods other than GET, so fetch() works" do
+      post "/beacon/run1"
+      response.status_code.should eq 200
+      delete "/beacon/run1"
+      put "/beacon/run1"
+
+      log = read_log("run1")
+      log["count"].as_i.should eq 3
+      log["hits"].as_a.map(&.["method"].as_s).should eq ["POST", "DELETE", "PUT"]
+    end
+
+    it "answers a CORS preflight without counting it as a fire" do
+      options "/beacon/run1"
+      response.status_code.should eq 204
+      response.headers["Access-Control-Allow-Origin"]?.should eq "*"
+      response.headers["Access-Control-Allow-Methods"]?.should eq "*"
+
+      read_log("run1")["fired"].as_bool.should be_false
+    end
+  end
+
+  describe "the GIF response" do
+    it "is served as image/gif so <img src> triggers a load" do
+      fire("run1")
+      response.headers["Content-Type"]?.should eq "image/gif"
+    end
+
+    it "is a valid 43-byte transparent GIF" do
+      fire("run1")
+      body = response.body.to_slice
+
+      body.size.should eq Xssmaze::Beacon::GIF_1X1.size
+      body.should eq Xssmaze::Beacon::GIF_1X1
+      String.new(body[0, 6]).should eq "GIF89a"
+      body[-1].should eq 0x3B_u8 # GIF trailer
+      # Logical screen descriptor: 1x1, little-endian.
+      body[6].should eq 0x01_u8
+      body[8].should eq 0x01_u8
+      # Graphic control extension with the transparent-colour flag set.
+      body[19].should eq 0x21_u8
+      body[22].should eq 0x01_u8
+    end
+
+    it "is never cached, because a cached beacon is a lost signal" do
+      fire("run1")
+      response.headers["Cache-Control"]?.should eq "no-store"
+      response.headers["Access-Control-Allow-Origin"]?.should eq "*"
+    end
+  end
+
+  describe "clearing" do
+    it "empties the log via DELETE /beacon/log" do
+      fire("run1")
+      fire("run2")
+
+      delete "/beacon/log"
+      response.status_code.should eq 200
+      cleared = JSON.parse(response.body)
+      cleared["cleared"].as_bool.should be_true
+      cleared["tokens"].as_i.should eq 2
+      cleared["hits"].as_i.should eq 2
+
+      log = read_log
+      log["tokens"].as_i.should eq 0
+      log["total_hits"].as_i.should eq 0
+      log["logs"].as_a.should be_empty
+      read_log("run1")["fired"].as_bool.should be_false
+    end
+
+    it "empties the log via POST /beacon/log/clear" do
+      fire("run1")
+      post "/beacon/log/clear"
+      response.status_code.should eq 200
+      JSON.parse(response.body)["tokens"].as_i.should eq 1
+
+      read_log["tokens"].as_i.should eq 0
+    end
+  end
+
+  describe "token validation" do
+    it "rejects a token outside [A-Za-z0-9_-] with 400" do
+      # Kemal URL-decodes path params, so an encoded slash or NUL is decoded
+      # into the token and has to be caught by the pattern, not by the router.
+      {"a.b", "a%20b", "a%2Fb", "a%00", "%3Cscript%3E", "tok:1", "a+b"}.each do |token|
+        fire(token)
+        response.status_code.should eq 400
+      end
+    end
+
+    it "never reaches the beacon at all when the token spans path segments" do
+      fire("a/b")
+      response.status_code.should eq 404
+      get "/beacon/"
+      response.status_code.should eq 404
+    end
+
+    it "rejects a token longer than 64 characters with 400" do
+      fire("a" * 64)
+      response.status_code.should eq 200
+      fire("a" * 65)
+      response.status_code.should eq 400
+    end
+
+    it "rejects the reserved `log` token, which the log API already owns" do
+      post "/beacon/log"
+      response.status_code.should eq 400
+      Xssmaze::Beacon.valid_token?("log").should be_false
+    end
+
+    it "rejects an invalid token on the log endpoint too" do
+      get "/beacon/log?token=a.b"
+      response.status_code.should eq 400
+    end
+
+    it "records nothing for a rejected token" do
+      fire("a.b")
+      read_log["tokens"].as_i.should eq 0
+    end
+
+    it "answers a rejection as JSON without echoing the token" do
+      fire("%3Cscript%3Ealert(1)%3C%2Fscript%3E")
+      response.status_code.should eq 400
+      response.headers["Content-Type"]?.should eq "application/json"
+      response.body.should_not contain "script"
+      JSON.parse(response.body)["error"].as_s.should eq "invalid token"
+    end
+  end
+
+  describe "not injectable" do
+    it "hands back a recorded Referer as JSON data, never as markup" do
+      payload = %(http://host/"><script>alert(1)</script>)
+      fire("run1", referer: payload, user_agent: payload)
+
+      response.headers["Content-Type"]?.should eq "image/gif"
+
+      log = read_log("run1")
+      response.headers["Content-Type"]?.should eq "application/json"
+      response.headers["X-Content-Type-Options"]?.should eq "nosniff"
+      log["referers"].as_a.first.as_s.should eq payload
+      # The quote that would break out of an attribute is escaped in transit.
+      response.body.should contain %(\\"><script>)
+    end
+
+    it "stays out of the catalog, so benchmark denominators are untouched" do
+      Xssmaze.get.any?(&.url.starts_with?("/beacon")).should be_false
+      Xssmaze.get.any?(&.name.includes?("beacon")).should be_false
+    end
+
+    it "does not let /beacon/log be swallowed by the token route" do
+      fire("run1")
+      get "/beacon/log"
+      response.headers["Content-Type"]?.should eq "application/json"
+      JSON.parse(response.body)["tokens"].as_i.should eq 1
+    end
+  end
+
+  describe "caps" do
+    it "stops storing hits past MAX_HITS but keeps counting them" do
+      (Xssmaze::Beacon::MAX_HITS + 5).times { fire("run1") }
+
+      log = read_log("run1")
+      log["count"].as_i.should eq Xssmaze::Beacon::MAX_HITS + 5
+      log["hits"].as_a.size.should eq Xssmaze::Beacon::MAX_HITS
+      log["truncated"].as_bool.should be_true
+    end
+
+    it "refuses new tokens past MAX_TOKENS and reports the drops" do
+      Xssmaze::Beacon::MAX_TOKENS.times do |i|
+        Xssmaze::Beacon.record("t#{i}", "GET", nil, nil).should be_true
+      end
+      Xssmaze::Beacon.record("overflow", "GET", nil, nil).should be_false
+
+      log = read_log
+      log["tokens"].as_i.should eq Xssmaze::Beacon::MAX_TOKENS
+      log["dropped_tokens"].as_i.should eq 1
+      read_log("overflow")["fired"].as_bool.should be_false
+    end
+
+    it "keeps recording a known token after the token cap is reached" do
+      Xssmaze::Beacon::MAX_TOKENS.times { |i| Xssmaze::Beacon.record("t#{i}", "GET", nil, nil) }
+      Xssmaze::Beacon.record("t0", "GET", nil, nil).should be_true
+
+      read_log("t0")["count"].as_i.should eq 2
+    end
+
+    it "clips an oversized Referer instead of storing it whole" do
+      fire("run1", referer: "http://host/#{"a" * 4096}")
+
+      stored = read_log("run1")["referers"].as_a.first.as_s
+      stored.size.should eq Xssmaze::Beacon::MAX_VALUE
+    end
+
+    it "tells the caller when a fire was dropped" do
+      Xssmaze::Beacon::MAX_TOKENS.times { |i| Xssmaze::Beacon.record("t#{i}", "GET", nil, nil) }
+
+      fire("overflow")
+      response.status_code.should eq 200
+      response.headers["X-Beacon-Log"]?.should eq "full"
+
+      fire("t0")
+      response.headers["X-Beacon-Log"]?.should be_nil
+    end
+  end
+end

--- a/src/mazes/beacon.cr
+++ b/src/mazes/beacon.cr
@@ -1,0 +1,257 @@
+# Execution oracle.
+#
+# Every scoring path in this lab measures *reflection*: a scanner asks whether
+# its string came back in the HTML and calls that a finding. That is a proxy,
+# and a poor one — it scores a harmlessly-escaped echo as a hit, and it is
+# blind to the ~160 `dom` endpoints where the payload never reaches the server
+# response at all. The beacon replaces the proxy with proof: a payload has to
+# actually *run* to reach `/beacon/<token>`, so a hit in the log is a true
+# positive that no amount of string matching can fake.
+#
+#   /basic/level1/?query=<img src=/beacon/run1 onerror=fetch('/beacon/run1')>
+#   then: GET /beacon/log?token=run1
+#
+# The recorded `Referer` is the payoff — it names the maze page that executed,
+# so a headless harness can fire one token for a whole sweep and still
+# attribute every hit to the endpoint that produced it.
+#
+# Routes:
+#   ANY    /beacon/<token>       record a fire, answer with a 1x1 GIF
+#   GET    /beacon/log           the whole log
+#   GET    /beacon/log?token=t   one token
+#   DELETE /beacon/log           clear it, so consecutive runs are isolated
+#   POST   /beacon/log/clear     the same reset for clients that cannot DELETE
+#
+# This is instrumentation, not a maze, and it is deliberately boring: it never
+# calls `Xssmaze.push` (the catalog is a benchmark denominator and must not
+# grow a non-maze entry), it answers only `image/gif` and `application/json`,
+# and nothing it records is ever echoed into an HTML response.
+module Xssmaze::Beacon
+  # The canonical 43-byte transparent 1x1 GIF: the smallest thing an
+  # `<img src=...>` can load without drawing anything on the page under test.
+  GIF_1X1 = Bytes[
+    0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0x21, 0xF9, 0x04, 0x01, 0x00, 0x00, 0x00,
+    0x00, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02,
+    0x44, 0x01, 0x00, 0x3B,
+  ]
+
+  TOKEN_PATTERN = /\A[A-Za-z0-9_-]{1,64}\z/
+
+  # `/beacon/log` is the log API for every verb, so a token by that name could
+  # never be read back. Refusing it up front beats letting a benchmark discover
+  # the collision from a permanently empty result.
+  RESERVED_TOKENS = %w[log]
+
+  # A fuzzer pointing at `/beacon/<random>` must not be able to exhaust memory,
+  # so the log is bounded on all three axes it can grow along: distinct tokens,
+  # stored hits per token, and the length kept from each attacker-set header.
+  MAX_TOKENS = 1000
+  MAX_HITS   =  100
+  MAX_VALUE  =  256
+
+  record Hit,
+    at : Time,
+    method : String,
+    referer : String?,
+    user_agent : String?
+
+  # One token's history. `count` keeps counting past `MAX_HITS` while `hits`
+  # stops growing, so even a capped entry reports the true number of fires.
+  class Entry
+    getter count : Int32
+    getter first_at : Time
+    getter last_at : Time
+    getter hits : Array(Hit)
+
+    def initialize(hit : Hit)
+      @count = 1
+      @first_at = hit.at
+      @last_at = hit.at
+      @hits = [hit]
+    end
+
+    def add(hit : Hit) : Nil
+      @count += 1
+      @last_at = hit.at
+      @hits << hit if @hits.size < MAX_HITS
+    end
+
+    def truncated? : Bool
+      @count > @hits.size
+    end
+  end
+
+  @@lock = Mutex.new
+  @@log = {} of String => Entry
+  @@dropped_tokens = 0
+
+  def self.valid_token?(token : String) : Bool
+    TOKEN_PATTERN.matches?(token) && !RESERVED_TOKENS.includes?(token)
+  end
+
+  # Returns false only when the token cap refused a brand new token. Tokens
+  # already in the log keep recording, so a benchmark run in flight is never
+  # cut off by someone else fuzzing the beacon.
+  def self.record(token : String, method : String,
+                  referer : String?, user_agent : String?) : Bool
+    hit = Hit.new(Time.utc, method, clip(referer), clip(user_agent))
+
+    @@lock.synchronize do
+      if entry = @@log[token]?
+        entry.add(hit)
+        true
+      elsif @@log.size >= MAX_TOKENS
+        @@dropped_tokens += 1
+        false
+      else
+        @@log[token] = Entry.new(hit)
+        true
+      end
+    end
+  end
+
+  def self.token_json(token : String)
+    @@lock.synchronize { entry_json(token, @@log[token]?) }
+  end
+
+  def self.log_json
+    @@lock.synchronize do
+      entries = @@log.map { |token, entry| entry_json(token, entry) }
+      {
+        tokens:         entries.size,
+        total_hits:     @@log.each_value.sum(&.count),
+        dropped_tokens: @@dropped_tokens,
+        logs:           entries,
+      }
+    end
+  end
+
+  def self.clear
+    @@lock.synchronize do
+      tokens = @@log.size
+      hits = @@log.each_value.sum(&.count)
+      @@log.clear
+      @@dropped_tokens = 0
+      {cleared: true, tokens: tokens, hits: hits}
+    end
+  end
+
+  # An unknown token is reported rather than 404'd: "this token never fired" is
+  # the answer a harness asked for, not an error.
+  private def self.entry_json(token : String, entry : Entry?)
+    hits = entry.try(&.hits) || [] of Hit
+    {
+      token:       token,
+      fired:       !entry.nil?,
+      count:       entry.try(&.count) || 0,
+      first:       entry.try(&.first_at.to_rfc3339(fraction_digits: 3)),
+      last:        entry.try(&.last_at.to_rfc3339(fraction_digits: 3)),
+      referers:    hits.compact_map(&.referer).uniq!,
+      user_agents: hits.compact_map(&.user_agent).uniq!,
+      truncated:   entry.try(&.truncated?) || false,
+      hits:        hits.map do |hit|
+        {
+          at:         hit.at.to_rfc3339(fraction_digits: 3),
+          method:     hit.method,
+          referer:    hit.referer,
+          user_agent: hit.user_agent,
+        }
+      end,
+    }
+  end
+
+  private def self.clip(value : String?) : String?
+    return unless value
+    value.size > MAX_VALUE ? value[0, MAX_VALUE] : value
+  end
+
+  # `no-store` because a cached beacon is a silently lost signal, and the
+  # wildcard CORS header because the payload firing it may well be running on
+  # another origin. `nosniff` keeps a browser from ever second-guessing the
+  # JSON content type and parsing a recorded Referer as markup.
+  def self.headers(env) : Nil
+    env.response.headers["Access-Control-Allow-Origin"] = "*"
+    env.response.headers["Cache-Control"] = "no-store"
+    env.response.headers["X-Content-Type-Options"] = "nosniff"
+  end
+
+  def self.json(env) : Nil
+    env.response.content_type = "application/json"
+    headers(env)
+  end
+
+  def self.reject(env) : String
+    env.response.status_code = 400
+    json(env)
+    {error: "invalid token", pattern: "[A-Za-z0-9_-]{1,64}", reserved: RESERVED_TOKENS}.to_json
+  end
+
+  def self.preflight(env) : String
+    env.response.status_code = 204
+    json(env)
+    env.response.headers["Access-Control-Allow-Methods"] = "*"
+    env.response.headers["Access-Control-Allow-Headers"] = "*"
+    ""
+  end
+
+  def self.hit(env) : String
+    token = env.params.url["token"]
+    return reject(env) unless valid_token?(token)
+
+    stored = record(token, env.request.method,
+      env.request.headers["Referer"]?.presence,
+      env.request.headers["User-Agent"]?.presence)
+
+    env.response.content_type = "image/gif"
+    headers(env)
+    # A refused token looks exactly like "the payload never ran", so say it out
+    # loud instead of letting the harness read a false negative off an empty log.
+    env.response.headers["X-Beacon-Log"] = "full" unless stored
+    env.response.write(GIF_1X1)
+    ""
+  end
+end
+
+# Kemal's own verb list, so the beacon keeps accepting everything the router
+# can route: `<img src>` and `<script src>` send GET, `fetch()` sends whatever
+# the payload asked for. HEAD falls back to the GET route inside Kemal.
+{% for method in HTTP_METHODS %}
+  {% unless method == "options" %}
+    {{ method.id }} "/beacon/:token" do |env|
+      Xssmaze::Beacon.hit(env)
+    end
+  {% end %}
+{% end %}
+
+# A preflight is the browser asking permission, not the payload firing —
+# recording it would double-count every `fetch` that is not CORS-simple.
+options "/beacon/:token" do |env|
+  Xssmaze::Beacon.preflight(env)
+end
+
+options "/beacon/log" do |env|
+  Xssmaze::Beacon.preflight(env)
+end
+
+get "/beacon/log" do |env|
+  Xssmaze::Beacon.json(env)
+  if token = env.params.query["token"]?
+    next Xssmaze::Beacon.reject(env) unless Xssmaze::Beacon.valid_token?(token)
+    Xssmaze::Beacon.token_json(token).to_json
+  else
+    Xssmaze::Beacon.log_json.to_json
+  end
+end
+
+delete "/beacon/log" do |env|
+  Xssmaze::Beacon.json(env)
+  Xssmaze::Beacon.clear.to_json
+end
+
+# DELETE is not a CORS-simple method, so a harness page driving the lab from
+# another origin would need a preflight to reset between runs. POST does not.
+post "/beacon/log/clear" do |env|
+  Xssmaze::Beacon.json(env)
+  Xssmaze::Beacon.clear.to_json
+end


### PR DESCRIPTION
## What changed

Two new files, nothing else in the diff:

- `src/mazes/beacon.cr` (auto-required by `require "./mazes/**"`)
- `spec/beacon_spec.cr`

Every scoring path in this repo measures **reflection** — "did my string come back in the HTML?" — which conflates reflection with execution and is blind to the ~160 `dom` endpoints where the payload never reaches the server response at all. The beacon is an execution oracle: a payload has to actually run to reach `/beacon/<token>`, so a hit is a true positive that string matching cannot fake.

| Route | Behaviour |
|---|---|
| `ANY /beacon/<token>` | records a fire, answers `image/gif` with a 43-byte transparent 1x1 GIF |
| `GET /beacon/log` | the whole log |
| `GET /beacon/log?token=t` | one token: `fired`, `count`, `first`, `last`, `referers`, `user_agents`, `truncated`, `hits[]` |
| `DELETE /beacon/log` | **clear** — this is the documented reset |
| `POST /beacon/log/clear` | the same reset, for clients that cannot send DELETE (it is not CORS-simple) |
| `OPTIONS /beacon/*` | 204 CORS preflight |

Per hit it records timestamp, request method, `Referer` and `User-Agent`. The `Referer` is the valuable one — it names the maze page that executed, so a harness can fire one token for a whole sweep and still attribute every hit.

### Constraints, and how each is met

- **Not injectable.** Tokens are `[A-Za-z0-9_-]{1,64}` or `400`. Nothing recorded is ever echoed into HTML: responses are only `image/gif` and `application/json`, everything echoed goes out `.to_json`-encoded, and every response carries `X-Content-Type-Options: nosniff` so a browser cannot sniff the log into markup.
- **No `Xssmaze.push`.** `/map/json`, `/stats` and `/sitemap.xml` are unchanged — verified below.
- **Bounded, in-memory only.** 1000 distinct tokens, 100 stored hits per token, 256 chars kept per `Referer`/`User-Agent`. `count` keeps counting past the hit cap so a capped entry still reports the true number of fires, with `truncated: true` to say so.
- **`Cache-Control: no-store`** and **`Access-Control-Allow-Origin: *`** on every beacon response.
- Routes are registered in `src/mazes/beacon.cr`. `src/server.cr` and `src/catalog.cr` are untouched.

### Three judgement calls worth a look

1. **`OPTIONS` is answered but not recorded.** A preflight is the browser asking permission, not the payload firing; counting it would double-count every `fetch` that is not CORS-simple. Every other verb Kemal routes (`GET POST PUT PATCH DELETE QUERY`, plus `HEAD` via Kemal's GET fallback) records normally — the route loop iterates Kemal's own `HTTP_METHODS`, so a future verb is picked up for free.
2. **`log` is a reserved token (400).** `/beacon/log` is the log API for every verb, so a token named `log` could never be read back. Refusing it up front beats letting a benchmark discover the collision from a permanently empty result.
3. **A token refused by the 1000-token cap still gets the GIF**, so the page under test behaves identically — but the response carries `X-Beacon-Log: full` and the whole-log JSON exposes `dropped_tokens`. That failure mode otherwise looks exactly like "the payload never ran", i.e. a silent false negative.

## How I verified it

### `crystal spec` — 27 new examples, whole suite green

```
$ crystal spec
....................................................................................................................................................................

Finished in 136.0 milliseconds
164 examples, 0 failures, 0 errors, 0 pending
```

### `crystal tool format` and ameba

```
$ crystal tool format --check && echo "FORMAT OK"
FORMAT OK

$ ameba
Finished in 322.04 milliseconds
201 inspected, 0 failures
```

### Manual round trip against a running server

`./bin/xssmaze -p 3117 -q --no-banner`

**1. Fire it with a `Referer`:**

```
$ curl -s -D - -o /tmp/beacon.gif \
    -H 'Referer: http://127.0.0.1:3117/basic/level1/?query=<img src=/beacon/run1 onerror=fetch("/beacon/run1")>' \
    -H 'User-Agent: HeadlessChrome/128.0' \
    "http://127.0.0.1:3117/beacon/run1"
HTTP/1.1 200 OK
Content-Type: image/gif
Server: XSSMaze/0.3.0
Access-Control-Allow-Origin: *
Cache-Control: no-store
X-Content-Type-Options: nosniff
Content-Length: 43

$ file /tmp/beacon.gif
/tmp/beacon.gif: GIF image data, version 89a, 1 x 1
```

**2. Two more fires from a different page, one of them a POST, then read the log:**

```
$ curl -s "http://127.0.0.1:3117/beacon/log?token=run1"
{
    "token": "run1",
    "fired": true,
    "count": 3,
    "first": "2026-08-29T13:45:43.696Z",
    "last": "2026-08-29T13:45:49.572Z",
    "referers": [
        "http://127.0.0.1:3117/basic/level1/?query=<img src=/beacon/run1 onerror=fetch(\"/beacon/run1\")>",
        "http://127.0.0.1:3117/dom/level3/"
    ],
    "user_agents": ["HeadlessChrome/128.0", "curl/8.7.1"],
    "truncated": false,
    "hits": [
        {"at": "2026-08-29T13:45:43.696Z", "method": "GET",  "referer": "http://127.0.0.1:3117/basic/level1/?query=<img src=/beacon/run1 onerror=fetch(\"/beacon/run1\")>", "user_agent": "HeadlessChrome/128.0"},
        {"at": "2026-08-29T13:45:49.567Z", "method": "GET",  "referer": "http://127.0.0.1:3117/dom/level3/", "user_agent": "curl/8.7.1"},
        {"at": "2026-08-29T13:45:49.572Z", "method": "POST", "referer": "http://127.0.0.1:3117/dom/level3/", "user_agent": "curl/8.7.1"}
    ]
}
```

**3. Clear it, then read it again:**

```
$ curl -s -X DELETE "http://127.0.0.1:3117/beacon/log"
{"cleared":true,"tokens":2,"hits":4}

$ curl -s "http://127.0.0.1:3117/beacon/log"
{"tokens":0,"total_hits":0,"dropped_tokens":0,"logs":[]}

$ curl -s "http://127.0.0.1:3117/beacon/log?token=run1"
{"token":"run1","fired":false,"count":0,"first":null,"last":null,"referers":[],"user_agents":[],"truncated":false,"hits":[]}

$ curl -s -o /dev/null "http://127.0.0.1:3117/beacon/run3"
$ curl -s -X POST "http://127.0.0.1:3117/beacon/log/clear"
{"cleared":true,"tokens":1,"hits":1}
$ curl -s "http://127.0.0.1:3117/beacon/log"
{"tokens":0,"total_hits":0,"dropped_tokens":0,"logs":[]}
```

**4. Invalid token — 400, and the token is not echoed back:**

```
$ curl -s -i "http://127.0.0.1:3117/beacon/%3Cscript%3Ealert(1)%3C%2Fscript%3E" | head -3
HTTP/1.1 400 Bad Request
Content-Type: application/json

$ curl -s "http://127.0.0.1:3117/beacon/%3Cscript%3Ealert(1)%3C%2Fscript%3E"
{"error":"invalid token","pattern":"[A-Za-z0-9_-]{1,64}","reserved":["log"]}
```

(Kemal URL-decodes path params, so `%2F` and `%00` land *inside* the token and are caught by the pattern, not by the router — covered in the spec.)

**5. Catalog untouched:**

```
$ curl -s http://127.0.0.1:3117/map/json  | grep -c beacon
0
$ curl -s http://127.0.0.1:3117/sitemap.xml | grep -c beacon
0
```

**6. Every verb records except the preflight:**

```
$ curl -sI "…/beacon/run1"; curl -s -X QUERY -H 'Content-Type: text/plain' --data x "…/beacon/run1"; curl -s -X PATCH "…/beacon/run1"
count: 3 methods: ['HEAD', 'QUERY', 'PATCH']

$ curl -s -i -X OPTIONS "…/beacon/run1" | head -3
HTTP/1.1 204 No Content
Content-Type: application/json
```

**7. The payload shape from the docs round-trips through a maze, and the per-token cap holds against a live burst:**

```
$ curl -s -G "…/basic/level1/" --data-urlencode "query=<img src=/beacon/run1 onerror=fetch('/beacon/run1')>" | grep -o "<img src=/beacon/run1[^>]*>"
<img src=/beacon/run1 onerror=fetch('/beacon/run1')>

$ for i in $(seq 1 105); do curl -s -o /dev/null "…/beacon/cap1"; done
count: 105 stored hits: 100 truncated: True
```

## For the reviewer

- **Not verified in a real browser.** The Chrome extension is not connected in this environment, so I proved the wiring server-side (step 7: the maze reflects the beacon payload verbatim, and every verb a browser could send is recorded) rather than watching an `onerror` actually fire. Worth one manual load of `/basic/level1/?query=<img src=/beacon/run1 onerror=fetch('/beacon/run1')>` before merge.
- **Route precedence.** `/beacon/log` (static) beating `/beacon/:token` (named) relies on radix ranking normal nodes above named ones. There is an explicit spec for it ("does not let /beacon/log be swallowed by the token route"), but it is the one behaviour inherited from a dependency rather than stated in our code.
- **Referer diversity under truncation.** `referers` / `user_agents` are derived from the stored hits, so past 100 hits on one token a *new* referer stops being recorded. Deliberate — it keeps the memory bound to one number (tokens × hits × value length) instead of three — but it means the caps assume a benchmark uses fresh tokens per run.
- Nothing outside `src/mazes/beacon.cr` and `spec/beacon_spec.cr` is in the diff. README/CHANGELOG/AGENTS.md are left for the orchestrator's consolidation pass; the beacon is documented in the comment block at the top of its own file.
