### PR TITLE
Rewrite the benchmark scorecard to use the metadata XSSMaze serves

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,123 +1,258 @@
 # XSSMaze Benchmark Scripts
 
-This directory contains automated benchmark tools for measuring XSS scanner performance against XSSMaze.
+Tools for scoring an XSS scanner against a running XSSMaze instance.
 
 ## Files
 
-- **`benchmark.py`**: Main Python benchmark script
-- **`benchmark.sh`**: Convenience shell wrapper
+- **`benchmark.py`**: the scorecard
+- **`benchmark.sh`**: convenience wrapper (dependency check, then pass-through)
 
 ## Quick Start
 
 ```bash
 # Start XSSMaze (in one terminal)
 cd ..
-./bin/xssmaze -b 0.0.0.0
+./bin/xssmaze
 
-# Run benchmark (in another terminal)
+# Score a scanner (in another terminal)
 cd scripts
-./benchmark.sh http://localhost:3000
+./benchmark.sh http://localhost:3000 --scanner nuclei
 ```
 
 ## Requirements
 
 - Python 3.x
-- `requests` library (automatically installed by `benchmark.sh`)
-- Optional: Scanner tools like [Nuclei](https://github.com/projectdiscovery/nuclei)
+- `requests` (installed by `benchmark.sh` if missing)
+- Optional: the scanner under test, e.g. [Nuclei](https://github.com/projectdiscovery/nuclei)
 
-## Usage
+## What gets scored, and why
 
-### Basic Benchmark
+Every number comes from the structured vulnerability metadata XSSMaze already
+serves on `/map/json` — `vuln.class`, `vuln.reach`, `vuln.exploitable`. **The
+denominator is deliberately smaller than the catalog.** Two populations are
+held out, and both exclusions are on purpose:
 
-```bash
-python3 benchmark.py http://localhost:3000
+### `exploitable: false` — controls
+
+Six endpoints (the whole `xsleak` category plus `dom-level10`) are marked
+`vuln.class: non-xss-control`, `exploitable: false`. They are not XSS bugs;
+they are true negatives that exist to catch scanners which cry wolf.
+
+- They are **removed from the denominator**. A scanner that reports nothing
+  there is behaving correctly and must not be punished for it.
+- A detection on one is a **false positive**, in every `--reach` mode.
+- They are still handed to the scanner to probe, otherwise a false positive on
+  a control could never be observed and the precision column would be
+  decorative.
+
+### `reach: "client"` — browser-only delivery
+
+Twenty endpoints take their payload from a channel that only exists inside a
+browser: `fragment`, `postmessage`, `window-name`, clipboard, drag-and-drop.
+A request-only scanner cannot deliver a payload to them at all — the fragment
+is never even sent to the server. Scoring one against them measures nothing,
+so `--reach` picks the population explicitly and the report always labels
+which one it used.
+
+### `reach: "unknown"` — untriaged
+
+Most of the catalog has not been triaged yet (`vuln.class: unclassified`,
+`reach: "unknown"`). "Not yet classified" is a different claim from "reviewed
+and found reachable", so untriaged endpoints stay out of the default
+denominator too. `--reach all` includes them, broken out on their own row so
+they are never silently folded into the server-reachable score.
+
+The header of every report prints the census, so the size of each population
+is visible before any rate is read:
+
+```
+Catalog:           1064 endpoints, 175 categories
+Controls:          6 with exploitable=false (a detection there is a FALSE POSITIVE, never a miss)
+Exploitable reach: 20 client, 200 server, 838 unknown
+
+Scoring mode:      --reach server
+Scored population: 200 exploitable endpoints (reach: server)
+Not scored:        20 client-reach, 838 unknown-reach, plus 6 controls — hits there are listed separately, never as TP or FN
 ```
 
-### With Verbose Output
+### The metrics
+
+| Term | Definition |
+|------|------------|
+| **TP** | detection resolving to an endpoint in the scored population |
+| **FN** | scored endpoint with no detection (`population − TP`) |
+| **FP** | detection on an `exploitable: false` control, **or** on a path that is not a registered maze |
+| **Precision** | `TP / (TP + FP)` |
+| **Recall** | `TP / population` |
+| **F1** | harmonic mean of the two |
+
+A detection on a real bug that sits *outside* the scored population — a
+client-only endpoint under `--reach server`, say — is neither. It is listed as
+an **unscored hit**: the finding is genuine, it just does not belong to the
+population this run measures.
+
+Detections are matched to endpoints by normalized path (trailing slash
+insensitive, host and query ignored). Mazes that take their payload in the
+path (`:path` params, e.g. `/path/level1/a`) match on their parent directory,
+because a scanner reports the segment it actually sent.
+
+## Reach modes
 
 ```bash
-python3 benchmark.py http://localhost:3000 -v
+--reach server   # default: the 200 endpoints a request-only scanner can reach
+--reach client   # the 20 browser-only endpoints, for a browser-driven scanner
+--reach all      # every exploitable endpoint, with a per-reach breakdown
 ```
 
-### Generate Markdown Report
+`--reach all` still reports server / client / unknown as separate rows. The
+two populations are never merged into one unlabelled number.
+
+## Detection contract
+
+**A custom scanner must declare how it reports a finding.** Exactly one of
+`--detect-regex` or `--detect-json` is required, and a zero exit code never
+marks a detection on its own.
+
+This replaces the previous heuristic — *"exit code 0, or the words
+xss/vulnerable/detected/found appear anywhere in stdout"* — which scored every
+scanner that merely ran successfully at 100%, making every custom-scanner
+number the tool produced meaningless.
+
+| Flag | Meaning |
+|------|---------|
+| `--detect-regex REGEX` | a finding is recorded only where this matches |
+| `--detect-json PATH` | dotted extractor over the scanner's JSON / JSON Lines output, e.g. `results[].url`, `[].matched-at` |
+| `--detect-stream` | which stream the contract reads: `stdout` (default), `stderr`, `both` |
+
+### Per-URL mode — `{URL}`
+
+The scanner runs once per endpoint. The contract decides whether *that*
+endpoint was flagged: the regex matching anywhere, or the extractor yielding
+at least one truthy value.
 
 ```bash
-python3 benchmark.py http://localhost:3000 -o report.md
+python3 benchmark.py http://localhost:3000 --scanner none \
+  --custom-scanner "mytool --url {URL}" --custom-scanner-name MyTool \
+  --detect-regex 'VULNERABLE'
 ```
 
-### Run Specific Scanner
+### Batch mode — `{URLFILE}`, or no placeholder
+
+The scanner runs once over the whole target list, given a file of URLs via
+`{URLFILE}` or the list on stdin. Detections are the URLs read *out of its
+output*: the extractor's values, or capture group 1 of the regex (the whole
+match if it has no groups).
 
 ```bash
-python3 benchmark.py http://localhost:3000 --scanner nuclei
+# structured output
+python3 benchmark.py http://localhost:3000 --scanner none \
+  --custom-scanner "mytool -l {URLFILE} -json" \
+  --detect-json 'results[].url'
+
+# line-oriented output like "FOUND http://host/path"
+python3 benchmark.py http://localhost:3000 --scanner none \
+  --custom-scanner "mytool -l {URLFILE}" \
+  --detect-regex '^FOUND (\S+)'
 ```
 
-### Custom Scanner
+`--detect-json` accepts one JSON document or JSON Lines; `[]` flattens an
+array level, so `[].url`, `results[].url` and `a.b[][].url` all work.
+Unparseable lines are skipped rather than aborting the run.
 
-```bash
-python3 benchmark.py http://localhost:3000 \
-  --custom-scanner "curl -s {URL}" \
-  --custom-scanner-name "cURL"
-```
+The exit code never marks a detection either way. In batch mode a non-zero
+exit is reported as a warning and the output is scored anyway — a crash after
+some findings should not silently become a clean sheet. In per-URL mode it is
+ignored outright.
+
+### Timeouts
+
+`--scanner-timeout SECONDS` applies per invocation: 30s by default in per-URL
+mode, 600s in batch mode.
 
 ## Output
 
-The tool generates:
+### Console
 
-1. **Console Output**: Summary table with detection rates
-2. **Detailed Statistics**: Breakdown by category
-3. **Markdown Report** (optional): Exportable benchmark results
+Summary table, then per-scanner detail: the confusion counts, precision /
+recall / F1, breakdowns by `vuln.class` and by category against the corrected
+denominator, and the full list of false positives and unscored hits.
 
-Example:
 ```
-======================================================================
-XSSMaze Scanner Benchmark Results
-======================================================================
+Scanner                 TP    FN    FP  Precision    Recall      F1      Time
+------------------------------------------------------------------------------
+FakeBatch                8   192     3      72.7%      4.0%   0.076      0.0s
+```
 
-Target: http://localhost:3000
-Total Registered Endpoints: 957
-Categories: 162
+The per-category table is capped at `--breakdown-limit` rows (default 20,
+worst first; `0` for all). Markdown and JSON always contain every row.
 
-Scanner              Detected     Missed       Rate         Time (s)
-----------------------------------------------------------------------
-Nuclei               234          723          24.5%        125.3s
+### Markdown — `-o FILE`
+
+The same corrected numbers as tables, plus the named lists.
+
+### JSON — `--json FILE`
+
+Machine-readable, so two runs can be diffed in CI:
+
+```json
+{
+  "target": "http://localhost:3000",
+  "reach_mode": "server",
+  "catalog": {
+    "total": 1064, "controls": 6, "scored_population": 200,
+    "exploitable_by_reach": {"server": 200, "client": 20, "unknown": 838}
+  },
+  "scanners": [{
+    "name": "MyTool", "reported_findings": 13, "population": 200,
+    "true_positives": 8, "false_negatives": 192, "false_positives": 3,
+    "false_positives_on_controls": 2, "false_positives_unmatched": 1,
+    "unscored_hits": 2,
+    "precision": 0.727273, "recall": 0.04, "f1": 0.075829,
+    "by_reach": {}, "by_class": {}, "by_type": {},
+    "detected": [], "missed": [],
+    "detected_controls": [], "detected_non_mazes": [],
+    "detected_out_of_scope": []
+  }]
+}
+```
+
+```bash
+# regression gate: fail the build if recall drops
+python3 benchmark.py http://localhost:3000 --scanner nuclei --json run.json
+python3 -c "import json,sys; r=json.load(open('run.json'))['scanners'][0]; \
+  sys.exit(r['recall'] < 0.20 or r['false_positives'] > 0)"
 ```
 
 ## Adding Scanner Support
 
-### Option 1: Custom Scanner Command
+### Option 1: `--custom-scanner`
 
-Use the `--custom-scanner` option:
+Any tool that can be told about a URL and print what it found — see the
+detection contract above. Nothing needs to change in `benchmark.py`.
 
-```bash
-python3 benchmark.py http://localhost:3000 \
-  --custom-scanner "myxss {URL}" \
-  --custom-scanner-name "MyScanner"
-```
+### Option 2: extend `benchmark.py`
 
-### Option 2: Extend benchmark.py
-
-Add a new scanner method to `benchmark.py`:
+Add a method that returns a `ScannerResult`. Only the raw detections and the
+elapsed time are its job; scoring is done centrally, so a new scanner
+automatically gets the same denominator.
 
 ```python
 def run_my_scanner(self) -> ScannerResult:
-    """Run My Scanner against endpoints."""
-    import time
-
-    self.log("\n=== Running My Scanner ===", force=True)
+    """Run My Scanner against the scan targets."""
     start_time = time.time()
-    detected = set()
+    detected: Set[str] = set()
 
-    # Your scanner logic here
-    for ep in self.endpoints:
-        full_url = self.get_full_url(ep['url'])
-        # Run your scanner and update detected set
+    for ep in self.scan_targets:      # population + controls
+        full_url = self.get_full_url(ep.url)
+        # ... run the scanner; add the URL it flagged, not the one you sent
+        # detected.add(reported_url)
 
-    elapsed = time.time() - start_time
-    return ScannerResult('My Scanner', detected,
-                        len(self.endpoints), elapsed)
+    return ScannerResult("My Scanner", detected, time.time() - start_time)
 ```
 
-Then call it in the `main()` function.
+Detections may be full URLs or bare paths; `EndpointIndex.resolve` normalizes
+them. Call the method in `main()` and pass the result through
+`benchmark.score()` with the others.
 
 ## Troubleshooting
 
@@ -125,25 +260,39 @@ Then call it in the `main()` function.
 
 ```bash
 pip3 install requests
+# or, on a PEP 668 / externally-managed Python:
+python3 -m venv .venv && .venv/bin/pip install requests
+.venv/bin/python benchmark.py http://localhost:3000
 ```
+
+### "a custom scanner needs exactly one of --detect-regex or --detect-json"
+
+By design. See [Detection contract](#detection-contract) — the tool refuses to
+guess what counts as a finding.
 
 ### "nuclei: command not found"
 
-Install Nuclei or skip it:
-```bash
-python3 benchmark.py http://localhost:3000 --scanner all
-```
+Nuclei is skipped with a note in the report rather than failing the run. Use
+`--scanner none` to skip it deliberately.
 
 ### "Connection refused"
 
-Make sure XSSMaze is running and accessible:
 ```bash
 curl http://localhost:3000/health
 ```
 
+### Every rate looks low
+
+Check the header first. Under `--reach server` the denominator is the ~200
+server-reachable endpoints, not the whole catalog; a scanner finding 8 of them
+is at 4% recall, not 0.8%. If the "unscored hits" list is long, the scanner is
+finding real bugs in a population this mode does not score — try `--reach all`.
+
 ## Notes
 
-- The benchmark tool uses the `/map/json` endpoint to discover all vulnerability scenarios
-- Detection matching uses URL path comparison
-- Scanners that don't output findings won't count detections
-- Custom scanners need to output results to stdout or return 0 exit code for detection
+- The catalog comes from `/map/json`; the scored population comes from the same
+  endpoint's server-side filters (`?exploitable=true&reach=…`), so which
+  endpoints count is decided by the lab's own definitions rather than
+  re-derived here.
+- The full catalog is still fetched, because telling a false positive on a
+  control apart from one on a path that is not a maze needs all of it.

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -2,435 +2,952 @@
 """
 XSSMaze Benchmark Tool
 
-This script runs XSS scanners against the XSSMaze lab and generates
-a detection matrix scorecard showing how well each scanner performs.
+Runs an XSS scanner against a running XSSMaze instance and prints a scorecard.
+
+The scorecard is built from the structured vulnerability metadata XSSMaze
+already serves on /map/json, because two populations in the catalog must not
+be counted as detection misses:
+
+  * `vuln.exploitable == false` endpoints are deliberate true negatives (the
+    `non-xss-control` class). Reporting nothing there is *correct* behaviour,
+    so they are removed from the denominator entirely and a detection on one
+    is scored as a false positive instead.
+  * `vuln.reach == "client"` endpoints take their payload from a browser-only
+    channel (fragment, postMessage, window.name, clipboard, drag-and-drop). A
+    request-only scanner cannot deliver a payload there at all, so scoring it
+    against them measures nothing. `--reach` selects which population is
+    scored; the two are never merged into one unlabelled number.
+
+Anything still untriaged carries `reach: "unknown"` and is likewise kept out
+of the default denominator — "not yet classified" is not the same claim as
+"reviewed and found unreachable", and neither is a scanner's fault.
 """
 
 import argparse
 import json
+import os
+import re
+import shlex
 import subprocess
 import sys
 import tempfile
-import os
-from urllib.parse import urlparse, urljoin
-from typing import List, Dict, Set, Tuple
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from urllib.parse import urljoin, urlparse
+
 import requests
-from dataclasses import dataclass
+
+# Reach buckets scored by each --reach mode. Controls are excluded from every
+# one of them; they are scored as false positives instead, in all modes.
+REACH_MODES: Dict[str, Tuple[str, ...]] = {
+    "server": ("server",),
+    "client": ("client",),
+    "all": ("server", "client", "unknown"),
+}
+
+
+def normalize_path(url: str) -> str:
+    """Reduce a reported URL (absolute or relative) to a catalog path key."""
+    path = urlparse(url).path or "/"
+    if len(path) > 1 and path.endswith("/"):
+        path = path[:-1]
+    return path
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    """One entry of /map/json."""
+
+    name: str
+    url: str
+    type: str
+    method: str
+    params: Tuple[str, ...]
+    vuln_class: str
+    reach: str
+    delivery: Tuple[str, ...]
+    sources: Tuple[str, ...]
+    sinks: Tuple[str, ...]
+    exploitable: bool
+    note: Optional[str]
+
+    @classmethod
+    def from_json(cls, obj: Dict[str, Any]) -> "Endpoint":
+        vuln = obj.get("vuln") or {}
+        return cls(
+            name=obj["name"],
+            url=obj["url"],
+            type=obj.get("type", ""),
+            method=obj.get("method", "GET"),
+            params=tuple(obj.get("params") or ()),
+            vuln_class=vuln.get("class", "unclassified"),
+            reach=vuln.get("reach", "unknown"),
+            delivery=tuple(vuln.get("delivery") or ()),
+            sources=tuple(vuln.get("sources") or ()),
+            sinks=tuple(vuln.get("sinks") or ()),
+            exploitable=bool(vuln.get("exploitable", True)),
+            note=vuln.get("note"),
+        )
+
+    @property
+    def path(self) -> str:
+        return normalize_path(self.url)
+
+    @property
+    def is_control(self) -> bool:
+        return not self.exploitable
+
+    @property
+    def path_prefix(self) -> Optional[str]:
+        """Directory to match on for mazes that take their payload in the path.
+
+        Those register a sample last segment (`:path` params, e.g.
+        `/path/level1/a`), but a scanner reports the segment it actually sent,
+        so an exact path compare would never line up.
+        """
+        if not any(p.startswith(":") for p in self.params):
+            return None
+        parent = self.path.rsplit("/", 1)[0]
+        return parent or None
+
+
+class EndpointIndex:
+    """Resolves whatever a scanner reported back to a catalog endpoint."""
+
+    def __init__(self, endpoints: Sequence[Endpoint]):
+        self.endpoints = list(endpoints)
+        self._by_path: Dict[str, Endpoint] = {}
+        for ep in self.endpoints:
+            self._by_path.setdefault(ep.path, ep)
+        # Longest prefix first, so /path/level1 wins over a hypothetical /path.
+        self._prefixes: List[Tuple[str, Endpoint]] = sorted(
+            ((ep.path_prefix, ep) for ep in self.endpoints if ep.path_prefix),
+            key=lambda pair: len(pair[0]),
+            reverse=True,
+        )
+
+    def resolve(self, reported: str) -> Optional[Endpoint]:
+        path = normalize_path(reported)
+        hit = self._by_path.get(path)
+        if hit is not None:
+            return hit
+        for prefix, ep in self._prefixes:
+            if path == prefix or path.startswith(prefix + "/"):
+                return ep
+        return None
 
 
 @dataclass
 class ScannerResult:
-    """Represents results from a scanner run."""
+    """Raw output of one scanner run: what it claimed, and how long it took."""
+
     name: str
-    detected_endpoints: Set[str]
-    total_checked: int
-    execution_time: float
+    detections: Set[str] = field(default_factory=set)
+    execution_time: float = 0.0
+    skipped: bool = False
+    skip_reason: str = ""
+
+
+@dataclass
+class Score:
+    """A scanner's confusion matrix against one scored population."""
+
+    scanner: ScannerResult
+    population: List[Endpoint]
+    tp: List[Endpoint]
+    fn: List[Endpoint]
+    fp_controls: List[Endpoint]
+    fp_unmatched: List[str]
+    unscored_hits: List[Endpoint]
+
+    @property
+    def fp(self) -> int:
+        return len(self.fp_controls) + len(self.fp_unmatched)
+
+    @property
+    def precision(self) -> float:
+        claimed = len(self.tp) + self.fp
+        return len(self.tp) / claimed if claimed else 0.0
+
+    @property
+    def recall(self) -> float:
+        return len(self.tp) / len(self.population) if self.population else 0.0
+
+    @property
+    def f1(self) -> float:
+        p, r = self.precision, self.recall
+        return 2 * p * r / (p + r) if (p + r) else 0.0
+
+
+def breakdown(population: Sequence[Endpoint], detected: Set[str],
+              key) -> Dict[str, Dict[str, Any]]:
+    """detected/missed per key, against the corrected denominator."""
+    rows: Dict[str, Dict[str, Any]] = {}
+    for ep in population:
+        row = rows.setdefault(key(ep), {"total": 0, "detected": 0, "missed": 0})
+        row["total"] += 1
+        if ep.name in detected:
+            row["detected"] += 1
+    for row in rows.values():
+        row["missed"] = row["total"] - row["detected"]
+        row["rate"] = row["detected"] / row["total"] * 100 if row["total"] else 0.0
+    return rows
+
+
+def sorted_breakdown(rows: Dict[str, Dict[str, Any]]) -> List[Tuple[str, Dict[str, Any]]]:
+    """Worst first: most missed, then largest, then alphabetical."""
+    return sorted(rows.items(), key=lambda kv: (-kv[1]["missed"], -kv[1]["total"], kv[0]))
+
+
+# --------------------------------------------------------------------------
+# Detection contract
+# --------------------------------------------------------------------------
+
+
+def parse_json_path(expr: str) -> List[Tuple[str, Optional[str]]]:
+    """Compile a dotted extractor like `results[].matched-at` into steps.
+
+    `[]` flattens one array level, so `[].url`, `results[].url` and
+    `a.b[][].url` all work. Deliberately tiny: enough to pull URLs out of the
+    JSON scanners already emit, without a jsonpath dependency.
+    """
+    steps: List[Tuple[str, Optional[str]]] = []
+    for raw in expr.split("."):
+        if not raw:
+            continue
+        key, arrays = raw, 0
+        while key.endswith("[]"):
+            key, arrays = key[:-2], arrays + 1
+        if key:
+            steps.append(("key", key))
+        steps.extend([("each", None)] * arrays)
+    return steps
+
+
+def apply_json_path(doc: Any, steps: Sequence[Tuple[str, Optional[str]]]) -> List[Any]:
+    values = [doc]
+    for kind, key in steps:
+        nxt: List[Any] = []
+        for value in values:
+            if kind == "key":
+                if isinstance(value, dict) and key in value:
+                    nxt.append(value[key])
+            elif isinstance(value, list):
+                nxt.extend(value)
+        values = nxt
+    return values
+
+
+def json_documents(text: str) -> List[Any]:
+    """Parse stdout as one JSON document, else as JSON Lines."""
+    text = text.strip()
+    if not text:
+        return []
+    try:
+        return [json.loads(text)]
+    except json.JSONDecodeError:
+        pass
+    docs = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            docs.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return docs
+
+
+class DetectionContract:
+    """How a scanner's output is turned into detections.
+
+    The predecessor of this class was a heuristic — "exit code 0, *or* the
+    word xss/vulnerable/detected/found appears anywhere in stdout" — which
+    scored every scanner that merely ran successfully at 100%. A detection now
+    has to be stated by the scanner and matched explicitly here. The exit code
+    is only ever used to report that the run itself failed.
+    """
+
+    def __init__(self, regex: Optional[str], json_path: Optional[str],
+                 stream: str = "stdout"):
+        if bool(regex) == bool(json_path):
+            raise ValueError(
+                "a custom scanner needs exactly one of --detect-regex or "
+                "--detect-json; exit code alone never marks a detection"
+            )
+        # MULTILINE so a line-oriented contract like '^FOUND (\S+)'
+        # anchors per output line rather than only at the first byte.
+        self.regex = re.compile(regex, re.MULTILINE) if regex else None
+        self.json_path = json_path
+        self.steps = parse_json_path(json_path) if json_path else None
+        self.stream = stream
+
+    def describe(self) -> str:
+        what = f"--detect-regex {self.regex.pattern!r}" if self.regex \
+            else f"--detect-json {self.json_path!r}"
+        return f"{what} on {self.stream}"
+
+    def _text(self, stdout: str, stderr: str) -> str:
+        if self.stream == "stderr":
+            return stderr
+        if self.stream == "both":
+            return stdout + "\n" + stderr
+        return stdout
+
+    def values(self, stdout: str, stderr: str) -> List[str]:
+        """Every value the contract extracts — used as URLs in batch mode."""
+        text = self._text(stdout, stderr)
+        if self.regex is not None:
+            return [m.group(1) if m.groups() else m.group(0)
+                    for m in self.regex.finditer(text)]
+        out: List[str] = []
+        for doc in json_documents(text):
+            for value in apply_json_path(doc, self.steps or []):
+                if value is None or value is False:
+                    continue
+                out.append(value if isinstance(value, str) else json.dumps(value))
+        return out
+
+    def matched(self, stdout: str, stderr: str) -> bool:
+        """Did the scanner claim a finding? — used in per-URL mode."""
+        if self.regex is not None:
+            return self.regex.search(self._text(stdout, stderr)) is not None
+        return bool(self.values(stdout, stderr))
+
+
+# --------------------------------------------------------------------------
+# Benchmark
+# --------------------------------------------------------------------------
 
 
 class XSSMazeBenchmark:
     """Main benchmark orchestrator."""
 
-    def __init__(self, target_url: str, verbose: bool = False):
-        """
-        Initialize benchmark.
-
-        Args:
-            target_url: Base URL of running XSSMaze instance
-            verbose: Enable verbose output
-        """
-        self.target_url = target_url.rstrip('/')
+    def __init__(self, target_url: str, reach_mode: str = "server",
+                 verbose: bool = False):
+        self.target_url = target_url.rstrip("/")
+        self.reach_mode = reach_mode
         self.verbose = verbose
-        self.endpoints: List[Dict] = []
+        self.endpoints: List[Endpoint] = []
+        self.population: List[Endpoint] = []
+        self.index = EndpointIndex([])
 
     def log(self, message: str, force: bool = False):
-        """Print message if verbose mode enabled."""
         if self.verbose or force:
             print(message)
 
+    # -- catalog ----------------------------------------------------------
+
+    def _map_json(self, **filters: str) -> List[Endpoint]:
+        response = requests.get(f"{self.target_url}/map/json",
+                                params=filters or None, timeout=30)
+        response.raise_for_status()
+        return [Endpoint.from_json(o) for o in response.json().get("endpoints", [])]
+
     def fetch_endpoints(self) -> bool:
-        """
-        Fetch all XSSMaze endpoints from /map/json.
+        """Load the whole catalog, then let the server pick the population.
 
-        Returns:
-            True if successful, False otherwise
+        /map/json accepts `?reach=` and `?exploitable=`, so which endpoints
+        count is decided by the lab's own definitions rather than re-derived
+        here. The full catalog is still needed to tell a false positive on a
+        control apart from one on a path that is not a maze at all.
         """
-        map_url = f"{self.target_url}/map/json"
-        self.log(f"Fetching endpoints from {map_url}...", force=True)
-
+        self.log(f"Fetching endpoints from {self.target_url}/map/json ...", force=True)
         try:
-            response = requests.get(map_url, timeout=10)
-            response.raise_for_status()
-            data = response.json()
-
-            self.endpoints = data.get('endpoints', [])
-            self.log(f"Retrieved {len(self.endpoints)} endpoints", force=True)
-            return True
-
+            self.endpoints = self._map_json()
+            reaches = REACH_MODES[self.reach_mode]
+            if len(reaches) == 1:
+                self.population = self._map_json(exploitable="true", reach=reaches[0])
+            else:
+                self.population = self._map_json(exploitable="true")
         except requests.RequestException as e:
             print(f"Error fetching endpoints: {e}", file=sys.stderr)
             return False
 
+        self.index = EndpointIndex(self.endpoints)
+        self.log(f"Retrieved {len(self.endpoints)} endpoints; "
+                 f"{len(self.population)} scored under --reach {self.reach_mode}",
+                 force=True)
+        return True
+
+    @property
+    def controls(self) -> List[Endpoint]:
+        return [ep for ep in self.endpoints if ep.is_control]
+
+    @property
+    def scan_targets(self) -> List[Endpoint]:
+        """URLs handed to the scanner: the population plus every control.
+
+        Controls have to be probed, otherwise a false positive on one could
+        never be observed and the precision column would be decorative.
+        """
+        seen = {ep.name for ep in self.population}
+        return sorted(self.population + [ep for ep in self.controls
+                                         if ep.name not in seen],
+                      key=lambda ep: ep.name)
+
+    def reach_census(self) -> Dict[str, int]:
+        census: Dict[str, int] = {}
+        for ep in self.endpoints:
+            if ep.is_control:
+                continue
+            census[ep.reach] = census.get(ep.reach, 0) + 1
+        return census
+
     def get_full_url(self, endpoint_url: str) -> str:
-        """Convert relative endpoint URL to full URL."""
-        if endpoint_url.startswith('http'):
+        if endpoint_url.startswith("http"):
             return endpoint_url
-        return urljoin(self.target_url, endpoint_url)
+        return urljoin(self.target_url + "/", endpoint_url.lstrip("/"))
+
+    # -- scanners ---------------------------------------------------------
 
     def run_nuclei_scanner(self) -> ScannerResult:
-        """
-        Run Nuclei scanner against endpoints.
-
-        Returns:
-            ScannerResult with detection data
-        """
-        import time
-
+        """Run Nuclei against the scan targets and read its JSON findings."""
         self.log("\n=== Running Nuclei Scanner ===", force=True)
         start_time = time.time()
-        detected = set()
+        detected: Set[str] = set()
 
-        # Check if nuclei is available
         try:
-            subprocess.run(['nuclei', '-version'],
-                         capture_output=True, check=True)
+            subprocess.run(["nuclei", "-version"], capture_output=True, check=True)
         except (subprocess.CalledProcessError, FileNotFoundError):
             self.log("Nuclei not found, skipping...", force=True)
-            return ScannerResult('nuclei', detected, len(self.endpoints), 0)
+            return ScannerResult("Nuclei", detected, 0.0, skipped=True,
+                                 skip_reason="nuclei not found in PATH")
 
-        # Create temporary file with URLs
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt',
-                                        delete=False) as f:
-            for ep in self.endpoints:
-                full_url = self.get_full_url(ep['url'])
-                f.write(f"{full_url}\n")
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            for ep in self.scan_targets:
+                f.write(self.get_full_url(ep.url) + "\n")
             url_file = f.name
 
         try:
-            # Run nuclei with XSS templates
             self.log("Running nuclei (this may take a few minutes)...")
-
             result = subprocess.run([
-                'nuclei',
-                '-l', url_file,
-                '-t', 'cves/',
-                '-t', 'vulnerabilities/',
-                '-tags', 'xss',
-                '-json',
-                '-silent'
-            ], capture_output=True, text=True, timeout=300)
+                "nuclei", "-l", url_file,
+                "-t", "cves/", "-t", "vulnerabilities/",
+                "-tags", "xss", "-json", "-silent",
+            ], capture_output=True, text=True, timeout=900)
 
-            # Parse JSON output
-            for line in result.stdout.strip().split('\n'):
-                if not line:
+            for line in result.stdout.splitlines():
+                if not line.strip():
                     continue
                 try:
                     finding = json.loads(line)
-                    matched_url = finding.get('matched-at', '')
-                    if matched_url:
-                        # Extract path from matched URL
-                        parsed = urlparse(matched_url)
-                        path_query = parsed.path
-                        if parsed.query:
-                            path_query += '?' + parsed.query
-                        detected.add(path_query)
                 except json.JSONDecodeError:
                     continue
-
+                matched_url = finding.get("matched-at", "")
+                if matched_url:
+                    detected.add(matched_url)
         except subprocess.TimeoutExpired:
             self.log("Nuclei scan timed out", force=True)
-        except Exception as e:
+        except OSError as e:
             self.log(f"Nuclei scan error: {e}", force=True)
         finally:
             os.unlink(url_file)
 
         elapsed = time.time() - start_time
-        self.log(f"Nuclei detected {len(detected)} endpoints in {elapsed:.1f}s")
+        self.log(f"Nuclei reported {len(detected)} findings in {elapsed:.1f}s")
+        return ScannerResult("Nuclei", detected, elapsed)
 
-        return ScannerResult('Nuclei', detected, len(self.endpoints), elapsed)
+    def run_custom_scanner(self, name: str, template: str,
+                           contract: DetectionContract,
+                           timeout: Optional[int] = None) -> ScannerResult:
+        """Run a custom scanner under an explicit detection contract.
 
-    def run_custom_scanner(self, name: str, command: List[str],
-                          url_placeholder: str = '{URL}') -> ScannerResult:
+        `{URL}` in the template runs the scanner once per endpoint, and the
+        contract decides whether *that* endpoint was flagged. `{URLFILE}` (or
+        no placeholder at all, in which case the list arrives on stdin) runs it
+        once over the whole list, and the contract extracts the URLs it
+        flagged. Either way a detection needs a real match.
         """
-        Run a custom scanner command.
-
-        Args:
-            name: Scanner name
-            command: Command to run (use {URL} as placeholder)
-            url_placeholder: What to replace with each URL
-
-        Returns:
-            ScannerResult with detection data
-        """
-        import time
-
         self.log(f"\n=== Running {name} Scanner ===", force=True)
+        self.log(f"Detection contract: {contract.describe()}", force=True)
         start_time = time.time()
-        detected = set()
 
-        for ep in self.endpoints:
-            full_url = self.get_full_url(ep['url'])
-
-            # Replace URL placeholder in command
-            cmd = [part.replace(url_placeholder, full_url) for part in command]
-
-            try:
-                result = subprocess.run(cmd, capture_output=True,
-                                      text=True, timeout=30)
-
-                # Simple heuristic: if exit code is 0 or output contains certain keywords
-                if result.returncode == 0 or any(keyword in result.stdout.lower()
-                    for keyword in ['xss', 'vulnerable', 'detected', 'found']):
-                    parsed = urlparse(full_url)
-                    path_query = parsed.path
-                    if parsed.query:
-                        path_query += '?' + parsed.query
-                    detected.add(path_query)
-
-            except (subprocess.TimeoutExpired, Exception) as e:
-                self.log(f"Error scanning {full_url}: {e}")
-                continue
+        argv = shlex.split(template)
+        targets = self.scan_targets
+        if any("{URL}" in part for part in argv):
+            detected = self._run_per_url(name, argv, contract, targets,
+                                         timeout if timeout is not None else 30)
+        else:
+            detected = self._run_batch(name, argv, contract, targets,
+                                       timeout if timeout is not None else 600)
 
         elapsed = time.time() - start_time
-        self.log(f"{name} detected {len(detected)} endpoints in {elapsed:.1f}s")
+        self.log(f"{name} reported {len(detected)} findings in {elapsed:.1f}s",
+                 force=True)
+        return ScannerResult(name, detected, elapsed)
 
-        return ScannerResult(name, detected, len(self.endpoints), elapsed)
+    def _run_per_url(self, name: str, argv: List[str],
+                     contract: DetectionContract, targets: List[Endpoint],
+                     timeout: int) -> Set[str]:
+        detected: Set[str] = set()
+        for i, ep in enumerate(targets, 1):
+            full_url = self.get_full_url(ep.url)
+            cmd = [part.replace("{URL}", full_url) for part in argv]
+            try:
+                proc = subprocess.run(cmd, capture_output=True, text=True,
+                                      timeout=timeout)
+            except subprocess.TimeoutExpired:
+                self.log(f"  timeout scanning {full_url}")
+                continue
+            except OSError as e:
+                print(f"Error running {name}: {e}", file=sys.stderr)
+                break
+            if contract.matched(proc.stdout, proc.stderr):
+                detected.add(ep.url)
+            if self.verbose and i % 50 == 0:
+                self.log(f"  {i}/{len(targets)} scanned, {len(detected)} flagged")
+        return detected
 
-    def match_detections(self, detected_urls: Set[str]) -> Tuple[Set[str], Set[str]]:
-        """
-        Match detected URLs against registered endpoints.
+    def _run_batch(self, name: str, argv: List[str],
+                   contract: DetectionContract, targets: List[Endpoint],
+                   timeout: int) -> Set[str]:
+        urls = "\n".join(self.get_full_url(ep.url) for ep in targets) + "\n"
+        url_file = None
+        if any("{URLFILE}" in part for part in argv):
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".txt",
+                                             delete=False) as f:
+                f.write(urls)
+                url_file = f.name
+            argv = [part.replace("{URLFILE}", url_file) for part in argv]
+            stdin = None
+        else:
+            stdin = urls
 
-        Args:
-            detected_urls: Set of detected URL paths
+        try:
+            proc = subprocess.run(argv, input=stdin, capture_output=True,
+                                  text=True, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            self.log(f"{name} timed out after {timeout}s", force=True)
+            return set()
+        except OSError as e:
+            print(f"Error running {name}: {e}", file=sys.stderr)
+            return set()
+        finally:
+            if url_file:
+                os.unlink(url_file)
 
-        Returns:
-            Tuple of (matched_names, unmatched_urls)
-        """
-        matched = set()
-        unmatched = set(detected_urls)
+        if proc.returncode != 0:
+            self.log(f"{name} exited {proc.returncode} "
+                     f"(scoring its output anyway)", force=True)
+        return set(contract.values(proc.stdout, proc.stderr))
 
-        for detected in detected_urls:
-            for ep in self.endpoints:
-                ep_url = ep['url']
-                ep_path = urlparse(ep_url).path
-                detected_path = urlparse(detected).path
+    # -- scoring ----------------------------------------------------------
 
-                # Match by path (exact or prefix match)
-                if ep_path == detected_path or ep_url.startswith(detected):
-                    matched.add(ep['name'])
-                    unmatched.discard(detected)
-                    break
+    def score(self, result: ScannerResult) -> Score:
+        """TP / FN / FP against the population, controls held out as FP."""
+        in_scope = {ep.name for ep in self.population}
+        tp: Dict[str, Endpoint] = {}
+        controls: Dict[str, Endpoint] = {}
+        unscored: Dict[str, Endpoint] = {}
+        unmatched: Set[str] = set()
 
-        return matched, unmatched
+        for reported in result.detections:
+            ep = self.index.resolve(reported)
+            if ep is None:
+                # Not a maze at all: the scanner invented a finding.
+                unmatched.add(normalize_path(reported))
+            elif ep.is_control:
+                controls[ep.name] = ep
+            elif ep.name in in_scope:
+                tp[ep.name] = ep
+            else:
+                # A real bug, but outside the population this mode scores.
+                # Neither a hit nor a miss; reported separately.
+                unscored[ep.name] = ep
 
-    def generate_scorecard(self, results: List[ScannerResult]):
-        """
-        Generate and print scorecard for all scanner results.
+        fn = [ep for ep in self.population if ep.name not in tp]
+        return Score(
+            scanner=result,
+            population=list(self.population),
+            tp=sorted(tp.values(), key=lambda ep: ep.name),
+            fn=fn,
+            fp_controls=sorted(controls.values(), key=lambda ep: ep.name),
+            fp_unmatched=sorted(unmatched),
+            unscored_hits=sorted(unscored.values(), key=lambda ep: ep.name),
+        )
 
-        Args:
-            results: List of ScannerResult objects
-        """
-        total_endpoints = len(self.endpoints)
+    # -- reporting --------------------------------------------------------
 
-        print("\n" + "=" * 70)
+    def _header_lines(self) -> List[str]:
+        census = self.reach_census()
+        reaches = REACH_MODES[self.reach_mode]
+        excluded = [f"{n} {reach}-reach" for reach, n in sorted(census.items())
+                    if reach not in reaches]
+        lines = [
+            f"Target:            {self.target_url}",
+            f"Catalog:           {len(self.endpoints)} endpoints, "
+            f"{len(set(ep.type for ep in self.endpoints))} categories",
+            f"Controls:          {len(self.controls)} with exploitable=false "
+            f"(a detection there is a FALSE POSITIVE, never a miss)",
+            "Exploitable reach: " + ", ".join(f"{n} {reach}" for reach, n
+                                              in sorted(census.items())),
+            "",
+            f"Scoring mode:      --reach {self.reach_mode}",
+            f"Scored population: {len(self.population)} exploitable endpoints "
+            f"(reach: {', '.join(reaches)})",
+        ]
+        if excluded:
+            lines.append(f"Not scored:        {', '.join(excluded)}, plus "
+                         f"{len(self.controls)} controls — hits there are "
+                         f"listed separately, never as TP or FN")
+        return lines
+
+    def generate_scorecard(self, scores: List[Score], breakdown_limit: int = 20):
+        print("\n" + "=" * 78)
         print("XSSMaze Scanner Benchmark Results")
-        print("=" * 70)
-        print(f"\nTarget: {self.target_url}")
-        print(f"Total Registered Endpoints: {total_endpoints}")
-        print(f"Categories: {len(set(ep['type'] for ep in self.endpoints))}")
+        print("=" * 78 + "\n")
+        for line in self._header_lines():
+            print(line)
         print()
 
-        if not results:
+        if not scores:
             print("No scanner results available.")
             return
 
-        # Print summary table
-        print(f"{'Scanner':<20} {'Detected':<12} {'Missed':<12} {'Rate':<12} {'Time (s)':<12}")
-        print("-" * 70)
+        print(f"{'Scanner':<20} {'TP':>5} {'FN':>5} {'FP':>5} "
+              f"{'Precision':>10} {'Recall':>9} {'F1':>7} {'Time':>9}")
+        print("-" * 78)
+        for score in scores:
+            if score.scanner.skipped:
+                print(f"{score.scanner.name:<20} {'— skipped: ' + score.scanner.skip_reason}")
+                continue
+            print(f"{score.scanner.name:<20} {len(score.tp):>5} {len(score.fn):>5} "
+                  f"{score.fp:>5} {score.precision * 100:>9.1f}% "
+                  f"{score.recall * 100:>8.1f}% {score.f1:>7.3f} "
+                  f"{score.scanner.execution_time:>8.1f}s")
 
-        for result in results:
-            matched, _ = self.match_detections(result.detected_endpoints)
-            detected_count = len(matched)
-            missed_count = total_endpoints - detected_count
-            detection_rate = (detected_count / total_endpoints * 100) if total_endpoints > 0 else 0
+        for score in scores:
+            if score.scanner.skipped:
+                continue
+            self._print_detail(score, breakdown_limit)
 
-            print(f"{result.name:<20} {detected_count:<12} {missed_count:<12} "
-                  f"{detection_rate:<11.1f}% {result.execution_time:<11.1f}s")
+    def _print_detail(self, score: Score, breakdown_limit: int):
+        detected = {ep.name for ep in score.tp}
+        total = len(score.population)
+        print(f"\n\n--- {score.scanner.name} ---\n")
+        print(f"  Reported findings:  {len(score.scanner.detections)}")
+        print(f"  True positives:     {len(score.tp)}/{total}")
+        print(f"  False negatives:    {len(score.fn)}/{total}")
+        print(f"  False positives:    {score.fp} "
+              f"({len(score.fp_controls)} on controls, "
+              f"{len(score.fp_unmatched)} on non-maze paths)")
+        if score.unscored_hits:
+            print(f"  Unscored hits:      {len(score.unscored_hits)} "
+                  f"(real bugs outside --reach {self.reach_mode})")
+        print(f"  Precision:          {score.precision * 100:.1f}%")
+        print(f"  Recall:             {score.recall * 100:.1f}%")
+        print(f"  F1:                 {score.f1:.3f}")
 
-        print()
+        if self.reach_mode == "all":
+            self._print_table("By reach", breakdown(score.population, detected,
+                                                    lambda ep: ep.reach), 0)
+        self._print_table("By vulnerability class",
+                          breakdown(score.population, detected,
+                                    lambda ep: ep.vuln_class), 0)
+        self._print_table("By category (worst first)",
+                          breakdown(score.population, detected,
+                                    lambda ep: ep.type), breakdown_limit)
 
-        # Print detailed breakdown for each scanner
-        for result in results:
-            matched, unmatched = self.match_detections(result.detected_endpoints)
-            detected_count = len(matched)
-            missed_count = total_endpoints - detected_count
+        if score.fp_controls:
+            print("\n  False positives on controls "
+                  "(exploitable=false — reporting nothing here is correct):")
+            for ep in score.fp_controls:
+                print(f"    ✗ {ep.name}  {ep.url}")
+        if score.fp_unmatched:
+            print("\n  False positives on paths that are not mazes:")
+            for path in score.fp_unmatched:
+                print(f"    ✗ {path}")
+        if score.unscored_hits:
+            print("\n  Hits outside the scored population "
+                  "(counted as neither TP nor FP):")
+            for ep in score.unscored_hits:
+                print(f"    · {ep.name}  [reach: {ep.reach}]  {ep.url}")
+        if self.verbose and score.tp:
+            print("\n  Detected:")
+            for ep in score.tp:
+                print(f"    ✓ {ep.name}  {ep.url}")
 
-            print(f"\n--- {result.name} Detailed Results ---")
-            print(f"✓ True Positives: {detected_count}/{total_endpoints}")
-            print(f"✗ False Negatives (Missed): {missed_count}/{total_endpoints}")
+    def _print_table(self, title: str, rows: Dict[str, Dict[str, Any]],
+                     limit: int):
+        ordered = sorted_breakdown(rows)
+        shown = ordered[:limit] if limit else ordered
+        print(f"\n  {title}:")
+        width = max((len(k) for k, _ in shown), default=4)
+        for key, row in shown:
+            print(f"    {key:<{width}}  {row['detected']:>4} detected  "
+                  f"{row['missed']:>4} missed  of {row['total']:>4}  "
+                  f"({row['rate']:.1f}%)")
+        if len(ordered) > len(shown):
+            print(f"    ... {len(ordered) - len(shown)} more "
+                  f"(use --breakdown-limit 0, -o or --json for the full table)")
 
-            if self.verbose and matched:
-                print("\nDetected endpoints:")
-                for name in sorted(matched):
-                    print(f"  ✓ {name}")
-
-            # Calculate missed by category
-            if missed_count > 0:
-                missed_by_category = {}
-                for ep in self.endpoints:
-                    if ep['name'] not in matched:
-                        cat = ep['type']
-                        missed_by_category[cat] = missed_by_category.get(cat, 0) + 1
-
-                print("\nMissed by category:")
-                for cat, count in sorted(missed_by_category.items(),
-                                        key=lambda x: x[1], reverse=True):
-                    total_in_cat = sum(1 for ep in self.endpoints
-                                     if ep['type'] == cat)
-                    print(f"  {cat}: {count}/{total_in_cat} missed")
-
-    def generate_markdown_report(self, results: List[ScannerResult],
-                                output_file: str):
-        """
-        Generate markdown report file.
-
-        Args:
-            results: List of ScannerResult objects
-            output_file: Path to output markdown file
-        """
-        total_endpoints = len(self.endpoints)
-
-        with open(output_file, 'w') as f:
+    def generate_markdown_report(self, scores: List[Score], output_file: str):
+        with open(output_file, "w") as f:
             f.write("# XSSMaze Scanner Benchmark Report\n\n")
-            f.write(f"**Target:** `{self.target_url}`  \n")
-            f.write(f"**Total Endpoints:** {total_endpoints}  \n")
-            f.write(f"**Categories:** {len(set(ep['type'] for ep in self.endpoints))}  \n\n")
+            for line in self._header_lines():
+                if line:
+                    label, _, value = line.partition(":")
+                    f.write(f"**{label.strip()}:** {value.strip()}  \n")
+            f.write("\n> Endpoints with `exploitable: false` are deliberate true "
+                    "negatives and are excluded from the denominator; a detection "
+                    "on one is a false positive. Endpoints outside the scored "
+                    "`reach` are excluded too — a request-only scanner cannot "
+                    "deliver a payload to a browser-only channel.\n\n")
 
             f.write("## Summary\n\n")
-            f.write("| Scanner | Detected | Missed | Detection Rate | Time (s) |\n")
-            f.write("|---------|----------|--------|----------------|----------|\n")
-
-            for result in results:
-                matched, _ = self.match_detections(result.detected_endpoints)
-                detected_count = len(matched)
-                missed_count = total_endpoints - detected_count
-                detection_rate = (detected_count / total_endpoints * 100) if total_endpoints > 0 else 0
-
-                f.write(f"| {result.name} | {detected_count} | {missed_count} | "
-                       f"{detection_rate:.1f}% | {result.execution_time:.1f}s |\n")
+            f.write("| Scanner | TP | FN | FP | Precision | Recall | F1 | Time |\n")
+            f.write("|---------|----|----|----|-----------|--------|----|------|\n")
+            for score in scores:
+                if score.scanner.skipped:
+                    f.write(f"| {score.scanner.name} | — | — | — | — | — | — | "
+                            f"skipped: {score.scanner.skip_reason} |\n")
+                    continue
+                f.write(f"| {score.scanner.name} | {len(score.tp)} | {len(score.fn)} "
+                        f"| {score.fp} | {score.precision * 100:.1f}% "
+                        f"| {score.recall * 100:.1f}% | {score.f1:.3f} "
+                        f"| {score.scanner.execution_time:.1f}s |\n")
 
             f.write("\n## Detailed Results\n\n")
+            for score in scores:
+                f.write(f"### {score.scanner.name}\n\n")
+                if score.scanner.skipped:
+                    f.write(f"Skipped: {score.scanner.skip_reason}\n\n")
+                    continue
+                total = len(score.population)
+                detected = {ep.name for ep in score.tp}
+                f.write(f"- **Reported findings:** {len(score.scanner.detections)}\n")
+                f.write(f"- **True positives:** {len(score.tp)}/{total}\n")
+                f.write(f"- **False negatives:** {len(score.fn)}/{total}\n")
+                f.write(f"- **False positives:** {score.fp} "
+                        f"({len(score.fp_controls)} on controls, "
+                        f"{len(score.fp_unmatched)} on non-maze paths)\n")
+                if score.unscored_hits:
+                    f.write(f"- **Unscored hits:** {len(score.unscored_hits)} "
+                            f"(real bugs outside `--reach {self.reach_mode}`)\n")
+                f.write(f"- **Precision / Recall / F1:** {score.precision * 100:.1f}% / "
+                        f"{score.recall * 100:.1f}% / {score.f1:.3f}\n\n")
 
-            for result in results:
-                matched, _ = self.match_detections(result.detected_endpoints)
-                detected_count = len(matched)
-                missed_count = total_endpoints - detected_count
+                if self.reach_mode == "all":
+                    self._write_table(f, "By Reach",
+                                      breakdown(score.population, detected,
+                                                lambda ep: ep.reach))
+                self._write_table(f, "By Vulnerability Class",
+                                  breakdown(score.population, detected,
+                                            lambda ep: ep.vuln_class))
+                self._write_table(f, "By Category",
+                                  breakdown(score.population, detected,
+                                            lambda ep: ep.type))
 
-                f.write(f"### {result.name}\n\n")
-                f.write(f"- **True Positives:** {detected_count}/{total_endpoints}\n")
-                f.write(f"- **False Negatives:** {missed_count}/{total_endpoints}\n")
-
-                # Missed by category
-                if missed_count > 0:
-                    missed_by_category = {}
-                    for ep in self.endpoints:
-                        if ep['name'] not in matched:
-                            cat = ep['type']
-                            missed_by_category[cat] = missed_by_category.get(cat, 0) + 1
-
-                    f.write("\n**Missed by Category:**\n\n")
-                    for cat, count in sorted(missed_by_category.items(),
-                                           key=lambda x: x[1], reverse=True):
-                        total_in_cat = sum(1 for ep in self.endpoints
-                                         if ep['type'] == cat)
-                        f.write(f"- `{cat}`: {count}/{total_in_cat} missed\n")
-
-                f.write("\n")
+                if score.fp_controls or score.fp_unmatched:
+                    f.write("**False Positives:**\n\n")
+                    for ep in score.fp_controls:
+                        f.write(f"- `{ep.name}` (`{ep.url}`) — control, "
+                                f"`exploitable: false`\n")
+                    for path in score.fp_unmatched:
+                        f.write(f"- `{path}` — not a registered maze\n")
+                    f.write("\n")
+                if score.unscored_hits:
+                    f.write("**Hits Outside the Scored Population:**\n\n")
+                    for ep in score.unscored_hits:
+                        f.write(f"- `{ep.name}` (`{ep.url}`) — reach `{ep.reach}`\n")
+                    f.write("\n")
 
         print(f"\nMarkdown report saved to: {output_file}")
 
+    @staticmethod
+    def _write_table(f, title: str, rows: Dict[str, Dict[str, Any]]):
+        f.write(f"**{title}:**\n\n")
+        f.write("| Key | Detected | Missed | Total | Rate |\n")
+        f.write("|-----|----------|--------|-------|------|\n")
+        for key, row in sorted_breakdown(rows):
+            f.write(f"| `{key}` | {row['detected']} | {row['missed']} "
+                    f"| {row['total']} | {row['rate']:.1f}% |\n")
+        f.write("\n")
+
+    def generate_json_report(self, scores: List[Score], output_file: str):
+        """Machine-readable scorecard, so CI can diff two runs."""
+        report = {
+            "target": self.target_url,
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "reach_mode": self.reach_mode,
+            "catalog": {
+                "total": len(self.endpoints),
+                "controls": len(self.controls),
+                "exploitable_by_reach": self.reach_census(),
+                "scored_population": len(self.population),
+                "categories": len(set(ep.type for ep in self.endpoints)),
+            },
+            "scanners": [],
+        }
+        for score in scores:
+            entry: Dict[str, Any] = {
+                "name": score.scanner.name,
+                "skipped": score.scanner.skipped,
+                "execution_time": round(score.scanner.execution_time, 3),
+            }
+            if score.scanner.skipped:
+                entry["skip_reason"] = score.scanner.skip_reason
+                report["scanners"].append(entry)
+                continue
+            detected = {ep.name for ep in score.tp}
+            entry.update({
+                "reported_findings": len(score.scanner.detections),
+                "population": len(score.population),
+                "true_positives": len(score.tp),
+                "false_negatives": len(score.fn),
+                "false_positives": score.fp,
+                "false_positives_on_controls": len(score.fp_controls),
+                "false_positives_unmatched": len(score.fp_unmatched),
+                "unscored_hits": len(score.unscored_hits),
+                "precision": round(score.precision, 6),
+                "recall": round(score.recall, 6),
+                "f1": round(score.f1, 6),
+                "by_reach": breakdown(score.population, detected,
+                                      lambda ep: ep.reach),
+                "by_class": breakdown(score.population, detected,
+                                      lambda ep: ep.vuln_class),
+                "by_type": breakdown(score.population, detected,
+                                     lambda ep: ep.type),
+                "detected": [ep.name for ep in score.tp],
+                "missed": [ep.name for ep in score.fn],
+                "detected_controls": [ep.name for ep in score.fp_controls],
+                "detected_non_mazes": list(score.fp_unmatched),
+                "detected_out_of_scope": [
+                    {"name": ep.name, "reach": ep.reach} for ep in score.unscored_hits
+                ],
+            })
+            report["scanners"].append(entry)
+
+        with open(output_file, "w") as f:
+            json.dump(report, f, indent=2, sort_keys=False)
+            f.write("\n")
+        print(f"JSON report saved to: {output_file}")
+
+
+EPILOG = """
+Examples:
+  # Score a scanner against the server-reachable population (the default)
+  python3 benchmark.py http://localhost:3000 --scanner nuclei
+
+  # Custom scanner, one invocation per URL, regex detection contract
+  python3 benchmark.py http://localhost:3000 --scanner none \\
+    --custom-scanner "mytool --url {URL}" --custom-scanner-name MyTool \\
+    --detect-regex '"severity":\\s*"(?:high|critical)"'
+
+  # Custom scanner, one invocation over the whole list, JSON extractor
+  python3 benchmark.py http://localhost:3000 --scanner none \\
+    --custom-scanner "mytool -l {URLFILE} -json" \\
+    --detect-json 'results[].url'
+
+  # Include client-only endpoints (browser-driven scanners) and save both reports
+  python3 benchmark.py http://localhost:3000 --reach all -o report.md --json run.json
+
+Detection contract:
+  A custom scanner MUST be given --detect-regex or --detect-json. A zero exit
+  code never marks a detection; the old heuristic that did scored every
+  well-behaved scanner at 100%.
+
+Scoring:
+  Endpoints with vuln.exploitable == false are controls: they are excluded from
+  the denominator, and a detection on one is a false positive. --reach selects
+  which reach bucket is scored; endpoints outside it are reported separately
+  and counted as neither a hit nor a miss.
+"""
+
 
 def main():
-    """Main entry point."""
     parser = argparse.ArgumentParser(
-        description='Benchmark XSS scanners against XSSMaze',
+        description="Benchmark XSS scanners against XSSMaze",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  # Benchmark against local instance
-  python benchmark.py http://localhost:3000
-
-  # Run with verbose output
-  python benchmark.py http://localhost:3000 -v
-
-  # Generate markdown report
-  python benchmark.py http://localhost:3000 -o report.md
-
-  # Run specific scanners only
-  python benchmark.py http://localhost:3000 --scanner nuclei
-
-  # Run with custom scanner command
-  python benchmark.py http://localhost:3000 --custom-scanner "myxss {URL}"
-        """
+        epilog=EPILOG,
     )
-
-    parser.add_argument('target_url',
-                       help='Target URL of running XSSMaze instance')
-
-    parser.add_argument('-v', '--verbose',
-                       action='store_true',
-                       help='Enable verbose output')
-
-    parser.add_argument('-o', '--output',
-                       metavar='FILE',
-                       help='Output markdown report to FILE')
-
-    parser.add_argument('--scanner',
-                       choices=['nuclei', 'all'],
-                       default='all',
-                       help='Scanner to run (default: all available)')
-
-    parser.add_argument('--custom-scanner',
-                       metavar='COMMAND',
-                       help='Custom scanner command (use {URL} as placeholder)')
-
-    parser.add_argument('--custom-scanner-name',
-                       metavar='NAME',
-                       default='Custom',
-                       help='Name for custom scanner')
+    parser.add_argument("target_url", help="Target URL of running XSSMaze instance")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Enable verbose output")
+    parser.add_argument("-o", "--output", metavar="FILE",
+                        help="Write the markdown report to FILE")
+    parser.add_argument("--json", metavar="FILE", dest="json_output",
+                        help="Write the machine-readable scorecard to FILE")
+    parser.add_argument("--reach", choices=sorted(REACH_MODES), default="server",
+                        help="Which population to score: 'server' (default; the "
+                             "endpoints a request-only scanner can actually "
+                             "reach), 'client' (browser-only channels), or 'all' "
+                             "(both, broken out by reach)")
+    parser.add_argument("--breakdown-limit", type=int, default=20, metavar="N",
+                        help="Rows in the per-category console table; 0 for all "
+                             "(default: 20). Markdown and JSON always get all.")
+    parser.add_argument("--scanner", choices=["nuclei", "all", "none"],
+                        default="all",
+                        help="Built-in scanner to run (default: all available)")
+    parser.add_argument("--custom-scanner", metavar="COMMAND",
+                        help="Custom scanner command. {URL} runs it once per "
+                             "endpoint; {URLFILE} (or no placeholder, list on "
+                             "stdin) runs it once over the whole list.")
+    parser.add_argument("--custom-scanner-name", metavar="NAME", default="Custom",
+                        help="Name for the custom scanner in the report")
+    parser.add_argument("--detect-regex", metavar="REGEX",
+                        help="Detection contract: a finding is recorded only "
+                             "where this matches. In batch mode capture group 1 "
+                             "(or the whole match) is the flagged URL.")
+    parser.add_argument("--detect-json", metavar="PATH",
+                        help="Detection contract for structured output: a dotted "
+                             "extractor such as 'results[].url' applied to the "
+                             "scanner's JSON or JSON Lines output.")
+    parser.add_argument("--detect-stream", choices=["stdout", "stderr", "both"],
+                        default="stdout",
+                        help="Stream the detection contract reads (default: stdout)")
+    parser.add_argument("--scanner-timeout", type=int, metavar="SECONDS",
+                        help="Timeout per custom scanner invocation "
+                             "(default: 30 per-URL, 600 batch)")
 
     args = parser.parse_args()
 
-    # Initialize benchmark
-    benchmark = XSSMazeBenchmark(args.target_url, verbose=args.verbose)
+    contract = None
+    if args.custom_scanner:
+        try:
+            contract = DetectionContract(args.detect_regex, args.detect_json,
+                                         args.detect_stream)
+        except ValueError as e:
+            parser.error(str(e))
+    elif args.detect_regex or args.detect_json:
+        parser.error("--detect-regex/--detect-json only apply to --custom-scanner")
 
-    # Fetch endpoints
+    benchmark = XSSMazeBenchmark(args.target_url, reach_mode=args.reach,
+                                 verbose=args.verbose)
     if not benchmark.fetch_endpoints():
         return 1
-
-    if len(benchmark.endpoints) == 0:
+    if not benchmark.endpoints:
         print("No endpoints found. Is XSSMaze running?", file=sys.stderr)
         return 1
+    if not benchmark.population:
+        print(f"No endpoints match --reach {args.reach}; nothing to score.",
+              file=sys.stderr)
+        return 1
 
-    # Run scanners
-    results = []
-
-    if args.scanner == 'all' or args.scanner == 'nuclei':
+    results: List[ScannerResult] = []
+    if args.scanner in ("all", "nuclei"):
         results.append(benchmark.run_nuclei_scanner())
+    if contract is not None:
+        results.append(benchmark.run_custom_scanner(
+            args.custom_scanner_name, args.custom_scanner, contract,
+            args.scanner_timeout))
 
-    if args.custom_scanner:
-        cmd = args.custom_scanner.split()
-        results.append(
-            benchmark.run_custom_scanner(args.custom_scanner_name, cmd)
-        )
+    if not results:
+        print("No scanners selected. Pass --scanner nuclei or --custom-scanner.",
+              file=sys.stderr)
+        return 1
 
-    # Generate reports
-    benchmark.generate_scorecard(results)
-
+    scores = [benchmark.score(r) for r in results]
+    benchmark.generate_scorecard(scores, args.breakdown_limit)
     if args.output:
-        benchmark.generate_markdown_report(results, args.output)
-
+        benchmark.generate_markdown_report(scores, args.output)
+    if args.json_output:
+        benchmark.generate_json_report(scores, args.json_output)
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 #
-# benchmark.sh - Shell wrapper for XSSMaze benchmark tool
+# benchmark.sh - Shell wrapper for the XSSMaze benchmark scorecard
 #
-# This script provides a convenient shell interface to the Python benchmark tool.
-# It handles common setup tasks and provides helpful error messages.
+# Checks the Python side is usable, then hands every argument straight to
+# benchmark.py. See scripts/README.md for the scoring model and the detection
+# contract a custom scanner has to satisfy.
+#
+#   ./benchmark.sh http://localhost:3000 --scanner nuclei
+#   ./benchmark.sh http://localhost:3000 --scanner none \
+#       --custom-scanner "mytool -l {URLFILE} -json" --detect-json 'results[].url'
 
 set -e
 
@@ -30,7 +35,9 @@ check_python_deps() {
         echo "Installing requests package..." >&2
         python3 -m pip install requests --quiet --user || {
             echo "Error: Failed to install requests package" >&2
-            echo "Please run: pip3 install requests" >&2
+            echo "Run 'pip3 install requests', or use a virtualenv:" >&2
+            echo "  python3 -m venv .venv && .venv/bin/pip install requests" >&2
+            echo "  .venv/bin/python ${BENCHMARK_PY} <target>" >&2
             return 1
         }
     fi


### PR DESCRIPTION
## What changed

`scripts/benchmark.py` was measuring the wrong thing, exactly as the project README says.

### 1. The denominator

`generate_scorecard` computed `missed = total_endpoints - detected_count`, so a scanner was
charged for two populations it cannot be blamed for:

- the **6 `exploitable: false` controls** (`non-xss-control` — the whole `xsleak` category plus
  `dom-level10`). Reporting nothing there is the *correct* answer, and there was no
  false-positive metric of any kind, so a scanner that flagged every control scored identically
  to one that flagged none.
- the **20 `reach: "client"` endpoints** (fragment, postMessage, window.name, clipboard,
  drag-and-drop). A request-only scanner cannot deliver a payload there at all.
- and, in practice, the **838 still-untriaged endpoints** (`reach: "unknown"`).

Now: **TP / FN / FP with precision, recall and F1**. Controls leave the denominator entirely and
a detection on one is a **false positive**, as is a detection on a path that is not a registered
maze. `--reach` picks the scored population — `server` (default, the 200 endpoints a request-only
scanner can actually reach), `client`, or `all` (with a per-reach row so the populations are never
merged into one unlabelled number). A hit on a *real* bug outside the scored population is neither
TP nor FP; it is listed separately as an **unscored hit**.

The "missed by category" block, which inherited the same inflated denominator, is replaced by
breakdowns **by `vuln.class`** and **by `type`** showing detected *and* missed against the
corrected denominator. `--json FILE` writes the whole scorecard for CI to diff; the markdown
report is kept with the same corrected numbers.

Which endpoints count is decided by the lab's own definitions: the population comes from
`/map/json?exploitable=true&reach=…`. The full catalog is still fetched, because telling a false
positive on a control apart from one on a non-maze path needs all of it.

### 2. `run_custom_scanner`

```python
if result.returncode == 0 or any(keyword in result.stdout.lower()
    for keyword in ['xss', 'vulnerable', 'detected', 'found']):
```

Any scanner that merely exited successfully scored 100%. Replaced with an explicit **detection
contract**: a custom scanner must be given exactly one of `--detect-regex` (matched against
stdout / stderr / both, `--detect-stream`) or `--detect-json` (a dotted extractor such as
`results[].url` over JSON or JSON Lines output). Exit code alone never marks a detection —
in batch mode a non-zero exit is warned about and the output scored anyway, in per-URL mode it is
ignored outright.

`{URL}` in the command runs the tool once per endpoint and the contract decides whether *that*
endpoint was flagged. `{URLFILE}` (or no placeholder — list on stdin) runs it once over the whole
list and reads the flagged URLs back out of its output.

Scan targets are the scored population **plus every control**, so a false positive on a control is
actually observable instead of the precision column being decorative.

### 3. Docs

`scripts/README.md` rewritten: the scoring model, why controls and client-only endpoints are
handled the way they are, the reach modes, the detection contract with worked examples for both
invocation modes, the three output formats, and a CI regression-gate snippet.

---

## Verification

### Static

```
$ python3 -m py_compile scripts/benchmark.py     # exit 0
$ pyflakes scripts/benchmark.py                  # exit 0, no output
$ bash -n scripts/benchmark.sh                   # exit 0
```

No Crystal was touched, and the Crystal side is still clean:

```
$ crystal tool format --check                    # exit 0
$ crystal spec
Finished in 113.67 milliseconds
137 examples, 0 failures, 0 errors, 0 pending
```

### End-to-end against a live lab

`shards install && shards build`, then `./bin/xssmaze -p 31337 -q --no-banner &`
(`{"status":"ok","uptime_seconds":4,"endpoints":1064}`).

Driven with a fake scanner whose findings are a fixed list chosen to hit every bucket:
8 server-reach exploitable endpoints, 2 controls (`dom-level10`, `xsleak-level1`), 1 path that is
not a maze, 1 client-only endpoint (`dom-level2`), and `/path/level1/%3Csvg%3E` (a `:path` maze
reported with a different last segment, to exercise prefix matching).

**Hand-computed expectation, `--reach server`:** population = 200; TP = 8; FN = 200 − 8 = 192;
FP = 2 controls + 1 non-maze = 3; precision = 8/11 = 72.7%; recall = 8/200 = 4.0%;
F1 = 2·0.7273·0.04 / 0.7673 = 0.076. The client-only and untriaged hits are neither.

```
$ python3 scripts/benchmark.py http://127.0.0.1:31337 --scanner none \
    --custom-scanner "python3 fake_scanner_batch.py" --custom-scanner-name FakeBatch \
    --detect-json 'results[].url' --breakdown-limit 6

Target:            http://127.0.0.1:31337
Catalog:           1064 endpoints, 175 categories
Controls:          6 with exploitable=false (a detection there is a FALSE POSITIVE, never a miss)
Exploitable reach: 20 client, 200 server, 838 unknown

Scoring mode:      --reach server
Scored population: 200 exploitable endpoints (reach: server)
Not scored:        20 client-reach, 838 unknown-reach, plus 6 controls — hits there are listed separately, never as TP or FN

Scanner                 TP    FN    FP  Precision    Recall      F1      Time
------------------------------------------------------------------------------
FakeBatch                8   192     3      72.7%      4.0%   0.076      0.0s


--- FakeBatch ---

  Reported findings:  13
  True positives:     8/200
  False negatives:    192/200
  False positives:    3 (2 on controls, 1 on non-maze paths)
  Unscored hits:      2 (real bugs outside --reach server)
  Precision:          72.7%
  Recall:             4.0%
  F1:                 0.076

  By vulnerability class:
    dom                     3 detected   137 missed  of  140  (2.1%)
    reflected-html          1 detected    20 missed  of   21  (4.8%)
    reflected-attr          1 detected    19 missed  of   20  (5.0%)
    reflected-js            1 detected    11 missed  of   12  (8.3%)
    prototype-pollution     1 detected     3 missed  of    4  (25.0%)
    csti                    1 detected     2 missed  of    3  (33.3%)

  By category (worst first):
    dom           0 detected    25 missed  of   25  (0.0%)
    prototype     1 detected     9 missed  of   10  (10.0%)
    domsink       0 detected     8 missed  of    8  (0.0%)
    sink          0 detected     8 missed  of    8  (0.0%)
    websocket     0 detected     7 missed  of    7  (0.0%)
    fragment      0 detected     6 missed  of    6  (0.0%)
    ... 31 more (use --breakdown-limit 0, -o or --json for the full table)

  False positives on controls (exploitable=false — reporting nothing here is correct):
    ✗ dom-level10  /dom/level10/
    ✗ xsleak-level1  /xsleak/search?q=admin

  False positives on paths that are not mazes:
    ✗ /not-a-maze/level1

  Hits outside the scored population (counted as neither TP nor FP):
    · dom-level2  [reach: client]  /dom/level2/
    · path-level1  [reach: unknown]  /path/level1/a
```

Every figure matches the hand computation, the two controls are false positives rather than
misses, and `/path/level1/%3Csvg%3E` resolved to `path-level1` via the prefix matcher.

**Same scanner, `--reach all`** — population 1058, so `dom-level2` and `path-level1` become TP:
TP = 10, FN = 1048, FP = 3, precision = 10/13 = 76.9%, recall = 10/1058 = 0.9%, F1 = 0.019.

```
Scoring mode:      --reach all
Scored population: 1058 exploitable endpoints (reach: server, client, unknown)

Scanner                 TP    FN    FP  Precision    Recall      F1      Time
------------------------------------------------------------------------------
FakeBatch               10  1048     3      76.9%      0.9%   0.019      0.0s

  By reach:
    unknown     1 detected   837 missed  of  838  (0.1%)
    server      8 detected   192 missed  of  200  (4.0%)
    client      1 detected    19 missed  of   20  (5.0%)
```

### The exit-code bug is gone

Two scanners that the old heuristic would have scored at 100% — one exits 0 per URL and says
nothing, one echoes every URL and exits 0:

```
$ ... --custom-scanner "true {URL}" --custom-scanner-name AlwaysExitsZero --detect-regex 'VULNERABLE'
AlwaysExitsZero          0   200     0       0.0%      0.0%   0.000      0.4s

$ ... --custom-scanner "cat" --custom-scanner-name EchoesEverything --detect-regex 'VULNERABLE'
EchoesEverything         0   200     0       0.0%      0.0%   0.000      0.0s
```

### Other paths exercised

| Case | Result |
|------|--------|
| per-URL + `--detect-regex` (`fake_scanner_url.py --url {URL}`) | TP 8, FP 2, precision 80.0% — only controls are in the target list, so no non-maze FP |
| batch + `{URLFILE}` + `--detect-stream stderr` + `^FOUND (\S+)` + exit 3 | `FakeLines exited 3 (scoring its output anyway)`, TP 8, FP 2, precision 80.0% |
| `--reach client` | population 20, TP 1, FN 19, FP 3, 9 unscored hits |
| `--custom-scanner` with no contract | `error: a custom scanner needs exactly one of --detect-regex or --detect-json; exit code alone never marks a detection` |
| both contract flags | same error |
| `--detect-regex` without `--custom-scanner` | `error: --detect-regex/--detect-json only apply to --custom-scanner` |
| `--scanner none` with no custom scanner | `No scanners selected...`, exit 1 |
| unreachable target | connection error reported, exit 1 |
| nuclei absent | skipped with a reason in console, markdown and JSON, not scored as 0% |
| `-o report.md`, `--json run.json` | both written, full 174-row `by_type` table in each |

## For the reviewer

- **The 838 untriaged endpoints are the judgement call here.** The brief specified `--reach server`
  as the default, which drops everything that is not `reach: "server"` — and today that is 79% of
  the catalog, because most endpoints have never been triaged. I did not want that to be silent, so
  the header prints the full census and names what is excluded, and `--reach all` scores them with
  `unknown` on its own row. If you would rather the default were `all`, it is one line
  (`--reach` default in `main()`).
- **Nuclei's invocation is unchanged** (`-json`, `-tags xss`, the same template dirs) — I only
  rewired where its findings go. Nuclei is not installed here, so only its skip path is
  exercised above; the flags are untested by me and `-json` is deprecated in favour of `-jsonl` on
  recent versions.
- **Endpoint matching** is by normalized path (trailing slash insensitive, host and query ignored).
  I verified there are no path collisions across the 1064 endpoints after that normalization.
  Mazes with `:path` params match on their parent directory.
- **`README.md` at the repo root** describes the benchmark in its "Benchmarking scanners" section
  and now understates what the tool does (it does not mention `--reach`, `--json`, or the detection
  contract). It is outside my file list, so I left it for the docs consolidation pass.
