### PR TITLE
feat(mazes): triage 209 untriaged endpoints (slice T1)

### DIFF
--- a/src/mazes/attribute_event_xss.cr
+++ b/src/mazes/attribute_event_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Reflection inside onmouseover JS string
 # Query is placed inside a single-quoted JS string in an onmouseover event handler.
 # Bypass: break out with ') then inject new attribute/tag, e.g. ')//
-Xssmaze.push("attr-event-level1", "/attr-event/level1/?query=a", "reflection in onmouseover JS string context")
+Xssmaze.push("attr-event-level1", "/attr-event/level1/?query=a", "reflection in onmouseover JS string context",
+  vuln: "reflected-attr", delivery: ["query"], note: "the handler only runs on hover; the enclosing attribute is double-quoted, so break out of it to inject a self-firing tag")
 maze_get "/attr-event/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ end
 # Level 2: Reflection inside onsubmit JS string
 # Query is placed inside a single-quoted JS string in an onsubmit handler.
 # Bypass: break out with ') then inject handler, e.g. ');alert(1)//
-Xssmaze.push("attr-event-level2", "/attr-event/level2/?query=a", "reflection in onsubmit JS string context")
+Xssmaze.push("attr-event-level2", "/attr-event/level2/?query=a", "reflection in onsubmit JS string context",
+  vuln: "reflected-attr", delivery: ["query"], note: "the handler only runs on form submit; the enclosing attribute is double-quoted, so break out of it to inject a self-firing tag")
 maze_get "/attr-event/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ end
 # Level 3: Reflection inside onload JS string
 # Query is placed inside a single-quoted JS string in a body onload handler.
 # Bypass: break out with ') then inject, e.g. ');alert(1)//
-Xssmaze.push("attr-event-level3", "/attr-event/level3/?query=a", "reflection in body onload JS string context")
+Xssmaze.push("attr-event-level3", "/attr-event/level3/?query=a", "reflection in body onload JS string context",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/attr-event/level3/" do |env|
   query = env.params.query["query"]
 
@@ -32,7 +35,8 @@ end
 # Query is placed inside a single-quoted JS string in an img onerror handler.
 # The img src is intentionally invalid to trigger onerror.
 # Bypass: break out with ') then inject, e.g. ');alert(1)//
-Xssmaze.push("attr-event-level4", "/attr-event/level4/?query=a", "reflection in img onerror JS string context")
+Xssmaze.push("attr-event-level4", "/attr-event/level4/?query=a", "reflection in img onerror JS string context",
+  vuln: "reflected-attr", delivery: ["query"], note: "the img src is deliberately broken, so the onerror handler fires without interaction")
 maze_get "/attr-event/level4/" do |env|
   query = env.params.query["query"]
 
@@ -42,7 +46,8 @@ end
 # Level 5: Reflection inside onblur JS string
 # Query is placed inside a single-quoted JS string in an input onblur handler.
 # Bypass: break out with ') then inject, e.g. ');alert(1)//
-Xssmaze.push("attr-event-level5", "/attr-event/level5/?query=a", "reflection in input onblur JS string context")
+Xssmaze.push("attr-event-level5", "/attr-event/level5/?query=a", "reflection in input onblur JS string context",
+  vuln: "reflected-attr", delivery: ["query"], note: "the handler only runs when the input loses focus; the enclosing attribute is double-quoted, so break out of it to inject a self-firing tag")
 maze_get "/attr-event/level5/" do |env|
   query = env.params.query["query"]
 
@@ -52,7 +57,8 @@ end
 # Level 6: Reflection inside onclick JS string
 # Query is placed inside a single-quoted JS string in a button onclick handler.
 # Bypass: break out with ') then inject, e.g. ');alert(1)//
-Xssmaze.push("attr-event-level6", "/attr-event/level6/?query=a", "reflection in button onclick JS string context")
+Xssmaze.push("attr-event-level6", "/attr-event/level6/?query=a", "reflection in button onclick JS string context",
+  vuln: "reflected-attr", delivery: ["query"], note: "the handler only runs on click; the enclosing attribute is double-quoted, so break out of it to inject a self-firing tag")
 maze_get "/attr-event/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/attrname_xss.cr
+++ b/src/mazes/attrname_xss.cr
@@ -1,22 +1,26 @@
-Xssmaze.push("attrname-level1", "/attrname/level1/?query=a", "user controls attribute name on a tag")
+Xssmaze.push("attrname-level1", "/attrname/level1/?query=a", "user controls attribute name on a tag",
+  vuln: "reflected-attr", delivery: ["query"], note: "the value lands in attribute-name position, so no quote breakout is needed: onmouseover=alert(1) x works as-is")
 maze_get "/attrname/level1/" do |env|
   query = env.params.query["query"]
   "<div #{query}='value'>hi</div>"
 end
 
-Xssmaze.push("attrname-level2", "/attrname/level2/?query=a", "attribute name on a button (onclick injection)")
+Xssmaze.push("attrname-level2", "/attrname/level2/?query=a", "attribute name on a button (onclick injection)",
+  vuln: "reflected-attr", delivery: ["query"], note: "the attribute value is fixed to alert(1); supply only the name, e.g. autofocus onfocus, so it fires without a click")
 maze_get "/attrname/level2/" do |env|
   query = env.params.query["query"]
   "<button #{query}='alert(1)'>click</button>"
 end
 
-Xssmaze.push("attrname-level3", "/attrname/level3/?query=a", "attribute name with space stripped (newline bypass)")
+Xssmaze.push("attrname-level3", "/attrname/level3/?query=a", "attribute name with space stripped (newline bypass)",
+  vuln: "reflected-attr", delivery: ["query"], note: "literal spaces are stripped, so separate attributes with a tab or newline; the trailing =go value is not callable, so bring your own handler")
 maze_get "/attrname/level3/" do |env|
   query = env.params.query["query"].gsub(" ", "")
   "<input type='text' #{query}='go'>"
 end
 
-Xssmaze.push("attrname-level4", "/attrname/level4/?query=a", "attribute name on <a>, equals stripped (boolean attr bypass)")
+Xssmaze.push("attrname-level4", "/attrname/level4/?query=a", "attribute name on <a>, equals stripped (boolean attr bypass)",
+  vuln: "reflected-attr", delivery: ["query"], note: "= is stripped, so no attribute can be given a value; close the tag and inject <script>alert(1)</script>, which needs no =")
 maze_get "/attrname/level4/" do |env|
   query = env.params.query["query"].gsub("=", "")
   "<a href='#' #{query}>link</a>"

--- a/src/mazes/basic.cr
+++ b/src/mazes/basic.cr
@@ -1,35 +1,42 @@
-Xssmaze.push("basic-level1", "/basic/level1/?query=a", "no escape")
+Xssmaze.push("basic-level1", "/basic/level1/?query=a", "no escape",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/basic/level1/" do |env|
   env.params.query["query"]
 end
 
-Xssmaze.push("basic-level2", "/basic/level2/?query=a", "escape to double-quot")
+Xssmaze.push("basic-level2", "/basic/level2/?query=a", "escape to double-quot",
+  vuln: "reflected-html", delivery: ["query"], note: "only double quotes are entity-encoded, which the HTML body context does not need")
 maze_get "/basic/level2/" do |env|
   Filters.escape_double_quote(env.params.query["query"])
 end
 
-Xssmaze.push("basic-level3", "/basic/level3/?query=a", "escape to single-quot")
+Xssmaze.push("basic-level3", "/basic/level3/?query=a", "escape to single-quot",
+  vuln: "reflected-html", delivery: ["query"], note: "only single quotes are entity-encoded, which the HTML body context does not need")
 maze_get "/basic/level3/" do |env|
   Filters.escape_single_quote(env.params.query["query"])
 end
 
-Xssmaze.push("basic-level4", "/basic/level4/?query=a", "escape to all quot")
+Xssmaze.push("basic-level4", "/basic/level4/?query=a", "escape to all quot",
+  vuln: "reflected-html", delivery: ["query"], note: "both quote characters are entity-encoded; angle brackets pass through untouched")
 maze_get "/basic/level4/" do |env|
   Filters.escape_quotes(env.params.query["query"])
 end
 
-Xssmaze.push("basic-level5", "/basic/level5/?query=a", "escape to parenthesis")
+Xssmaze.push("basic-level5", "/basic/level5/?query=a", "escape to parenthesis",
+  vuln: "reflected-html", delivery: ["query"], note: "parentheses are stripped, so alert(1) never survives; use a paren-free call such as alert`1`")
 maze_get "/basic/level5/" do |env|
   Filters.strip_parens(env.params.query["query"])
 end
 
-Xssmaze.push("basic-level6", "/basic/level6/?query=a", "escape to all quot and parenthesis")
+Xssmaze.push("basic-level6", "/basic/level6/?query=a", "escape to all quot and parenthesis",
+  vuln: "reflected-html", delivery: ["query"], note: "quotes are encoded and parentheses stripped; a backtick call such as alert`1` still works")
 maze_get "/basic/level6/" do |env|
   query = Filters.escape_quotes(env.params.query["query"])
   Filters.strip_parens(query)
 end
 
-Xssmaze.push("basic-level7", "/basic/level7/?query=a", "escape to all quot and parenthesis and backtick")
+Xssmaze.push("basic-level7", "/basic/level7/?query=a", "escape to all quot and parenthesis and backtick",
+  vuln: "reflected-html", delivery: ["query"], note: "quotes, parentheses and backticks are all removed, so the call has to come from a handler assignment: <script>onerror=alert;throw 1</script>")
 maze_get "/basic/level7/" do |env|
   query = Filters.escape_quotes(env.params.query["query"])
   query = Filters.strip_parens(query)

--- a/src/mazes/char_limit_filter_xss.cr
+++ b/src/mazes/char_limit_filter_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Strips < and > but reflects in input value attribute (double-quoted)
 # Bypass: break out of attribute with " onfocus=alert(1) autofocus "
-Xssmaze.push("charlimit-level1", "/charlimit/level1/?query=a", "strips angle brackets, reflects in input value attribute")
+Xssmaze.push("charlimit-level1", "/charlimit/level1/?query=a", "strips angle brackets, reflects in input value attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped; break out of the double-quoted input value and add an event handler")
 maze_get "/charlimit/level1/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("<", "").gsub(">", "")
@@ -13,7 +14,8 @@ end
 
 # Level 2: Strips double quotes but reflects in single-quoted attribute
 # Bypass: break out of single-quoted attribute with '
-Xssmaze.push("charlimit-level2", "/charlimit/level2/?query=a", "strips double quotes, reflects in single-quoted attribute")
+Xssmaze.push("charlimit-level2", "/charlimit/level2/?query=a", "strips double quotes, reflects in single-quoted attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "double quotes are stripped; the title attribute is single-quoted")
 maze_get "/charlimit/level2/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("\"", "")
@@ -26,7 +28,8 @@ end
 
 # Level 3: Strips single and double quotes but reflects raw in body
 # Bypass: <img src=x onerror=alert(1)> (no quotes needed)
-Xssmaze.push("charlimit-level3", "/charlimit/level3/?query=a", "strips all quotes, reflects raw in body")
+Xssmaze.push("charlimit-level3", "/charlimit/level3/?query=a", "strips all quotes, reflects raw in body",
+  vuln: "reflected-html", delivery: ["query"], note: "both quote characters are stripped, so the payload has to be quote-free: <img src=x onerror=alert(1)>")
 maze_get "/charlimit/level3/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("'", "").gsub("\"", "")
@@ -39,7 +42,8 @@ end
 
 # Level 4: Strips parentheses but reflects raw in body
 # Bypass: backticks <img src=x onerror=alert`1`> or <script>throw onerror=alert,1</script>
-Xssmaze.push("charlimit-level4", "/charlimit/level4/?query=a", "strips parentheses, reflects raw in body")
+Xssmaze.push("charlimit-level4", "/charlimit/level4/?query=a", "strips parentheses, reflects raw in body",
+  vuln: "reflected-html", delivery: ["query"], note: "parentheses are stripped; use a backtick call such as <img src=x onerror=alert`1`>")
 maze_get "/charlimit/level4/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("(", "").gsub(")", "")
@@ -52,7 +56,8 @@ end
 
 # Level 5: Strips forward slash but reflects raw in body
 # Bypass: <img src=x onerror=alert(1)> (img is self-closing, no / needed)
-Xssmaze.push("charlimit-level5", "/charlimit/level5/?query=a", "strips forward slash, reflects raw in body")
+Xssmaze.push("charlimit-level5", "/charlimit/level5/?query=a", "strips forward slash, reflects raw in body",
+  vuln: "reflected-html", delivery: ["query"], note: "forward slashes are stripped, so no closing tag survives; use a void element such as <img src=x onerror=alert(1)>")
 maze_get "/charlimit/level5/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("/", "")
@@ -65,7 +70,8 @@ end
 
 # Level 6: Strips equals sign but reflects raw in body
 # Bypass: <script>alert(1)</script> (no = needed)
-Xssmaze.push("charlimit-level6", "/charlimit/level6/?query=a", "strips equals sign, reflects raw in body")
+Xssmaze.push("charlimit-level6", "/charlimit/level6/?query=a", "strips equals sign, reflects raw in body",
+  vuln: "reflected-html", delivery: ["query"], note: "= is stripped, so no attribute takes a value; <script>alert(1)</script> needs none")
 maze_get "/charlimit/level6/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("=", "")

--- a/src/mazes/conditional_reflect_xss.cr
+++ b/src/mazes/conditional_reflect_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflects only if input length > 5 chars
 # Standard XSS payloads are all > 5 chars, so they pass the check
-Xssmaze.push("condreflect-level1", "/condreflect/level1/?query=a", "reflects only if input length > 5")
+Xssmaze.push("condreflect-level1", "/condreflect/level1/?query=a", "reflects only if input length > 5",
+  vuln: "reflected-html", delivery: ["query"], note: "nothing is reflected unless the value is longer than 5 characters, so a short scanner marker sees no reflection")
 maze_get "/condreflect/level1/" do |env|
   query = env.params.query["query"]
 
@@ -13,7 +14,8 @@ end
 
 # Level 2: Reflects only if input contains a digit
 # Most payloads and scanner markers contain digits
-Xssmaze.push("condreflect-level2", "/condreflect/level2/?query=a", "reflects only if input contains a digit")
+Xssmaze.push("condreflect-level2", "/condreflect/level2/?query=a", "reflects only if input contains a digit",
+  vuln: "reflected-html", delivery: ["query"], note: "nothing is reflected unless the value contains a digit, so a purely alphabetic marker sees no reflection")
 maze_get "/condreflect/level2/" do |env|
   query = env.params.query["query"]
 
@@ -26,7 +28,8 @@ end
 
 # Level 3: Reflects only if input does NOT start with '<'
 # Payloads prefixed with space like " <img src=x onerror=alert(1)>" bypass this
-Xssmaze.push("condreflect-level3", "/condreflect/level3/?query=a", "reflects only if input does not start with <")
+Xssmaze.push("condreflect-level3", "/condreflect/level3/?query=a", "reflects only if input does not start with <",
+  vuln: "reflected-html", delivery: ["query"], note: "a value starting with < is not reflected at all; prefix the payload with any other character")
 maze_get "/condreflect/level3/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +42,8 @@ end
 
 # Level 4: Reflects input twice if it contains '<', once if it doesn't
 # Standard payloads with '<' get double-reflected, both exploitable
-Xssmaze.push("condreflect-level4", "/condreflect/level4/?query=a", "double reflection when input contains <")
+Xssmaze.push("condreflect-level4", "/condreflect/level4/?query=a", "double reflection when input contains <",
+  vuln: "reflected-html", delivery: ["query"], note: "a value containing < is reflected twice, once in a div and once in a p")
 maze_get "/condreflect/level4/" do |env|
   query = env.params.query["query"]
 
@@ -51,7 +55,8 @@ maze_get "/condreflect/level4/" do |env|
 end
 
 # Level 5: Always reflects, wraps in <code> if param 'lang' is present, <div> otherwise
-Xssmaze.push("condreflect-level5", "/condreflect/level5/?query=a", "wraps in code tag if lang param present, div otherwise")
+Xssmaze.push("condreflect-level5", "/condreflect/level5/?query=a", "wraps in code tag if lang param present, div otherwise",
+  vuln: "reflected-html", delivery: ["query"], note: "an extra lang parameter of any value switches the wrapper from <div> to <code>; the payload always lands in query")
 maze_get "/condreflect/level5/" do |env|
   query = env.params.query["query"]
   has_lang = env.params.query.has_key?("lang")
@@ -65,7 +70,8 @@ end
 
 # Level 6: Reflects raw if input < 100 chars, HTML-encodes if >= 100
 # Standard short payloads work fine
-Xssmaze.push("condreflect-level6", "/condreflect/level6/?query=a", "raw reflection if input < 100 chars, encoded otherwise")
+Xssmaze.push("condreflect-level6", "/condreflect/level6/?query=a", "raw reflection if input < 100 chars, encoded otherwise",
+  vuln: "reflected-html", delivery: ["query"], note: "values of 100 characters or more are entity-encoded, so keep the payload short")
 maze_get "/condreflect/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/css_injection.cr
+++ b/src/mazes/css_injection.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("css-injection-level1", "/css/level1/?query=a", "CSS expression() XSS (IE)")
+Xssmaze.push("css-injection-level1", "/css/level1/?query=a", "CSS expression() XSS (IE)",
+  vuln: "reflected-html", delivery: ["query"], note: "CSS expression() has not executed in any browser since IE11; the live path is closing the </style> block and injecting a tag")
 maze_get "/css/level1/" do |env|
   query = env.params.query["query"]
 
@@ -14,7 +15,8 @@ maze_get "/css/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("css-injection-level2", "/css/level2/?query=a", "CSS import with javascript: URL")
+Xssmaze.push("css-injection-level2", "/css/level2/?query=a", "CSS import with javascript: URL",
+  vuln: "reflected-html", delivery: ["query"], note: "a javascript: URL in @import does not execute; the live path is closing the </style> block and injecting a tag")
 maze_get "/css/level2/" do |env|
   query = env.params.query["query"]
 
@@ -28,7 +30,8 @@ maze_get "/css/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("css-injection-level3", "/css/level3/?query=a", "CSS background-image with javascript: URL")
+Xssmaze.push("css-injection-level3", "/css/level3/?query=a", "CSS background-image with javascript: URL",
+  vuln: "reflected-html", delivery: ["query"], note: "a javascript: URL in background-image does not execute; the live path is closing the </style> block and injecting a tag")
 maze_get "/css/level3/" do |env|
   query = env.params.query["query"]
 
@@ -46,7 +49,8 @@ maze_get "/css/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("css-injection-level4", "/css/level4/?query=a", "CSS content property XSS")
+Xssmaze.push("css-injection-level4", "/css/level4/?query=a", "CSS content property XSS",
+  vuln: "reflected-html", delivery: ["query"], note: "the content property renders text only; the live path is closing the </style> block and injecting a tag")
 maze_get "/css/level4/" do |env|
   query = env.params.query["query"]
 
@@ -62,7 +66,8 @@ maze_get "/css/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("css-injection-level5", "/css/level5/?query=a", "CSS keyframes animation XSS")
+Xssmaze.push("css-injection-level5", "/css/level5/?query=a", "CSS keyframes animation XSS",
+  vuln: "reflected-html", delivery: ["query"], note: "a keyframe background URL does not execute; the live path is closing the </style> block and injecting a tag")
 maze_get "/css/level5/" do |env|
   query = env.params.query["query"]
 
@@ -81,7 +86,8 @@ maze_get "/css/level5/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("css-injection-level6", "/css/level6/?query=a", "CSS attr() function with HTML injection")
+Xssmaze.push("css-injection-level6", "/css/level6/?query=a", "CSS attr() function with HTML injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "the CSS attr() display is a decoy: the value lands in a single-quoted data-content attribute, so break out of that")
 maze_get "/css/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/decode.cr
+++ b/src/mazes/decode.cr
@@ -1,13 +1,15 @@
 require "base64"
 
-Xssmaze.push("decode-level1", "/decode/level1/?query=a", "base64 decode")
+Xssmaze.push("decode-level1", "/decode/level1/?query=a", "base64 decode",
+  vuln: "reflected-html", delivery: ["query"], note: "the value must be valid base64; anything else answers Decode Error, so the payload is the base64 of the markup")
 maze_get "/decode/level1/" do |env|
   Base64.decode_string(env.params.query["query"])
 rescue
   "Decode Error"
 end
 
-Xssmaze.push("decode-level2", "/decode/level2/?query=a", "url decode")
+Xssmaze.push("decode-level2", "/decode/level2/?query=a", "url decode",
+  vuln: "reflected-html", delivery: ["query"], note: "a literal < is rejected, but the server URL-decodes once afterwards, so send %253C (which arrives as %3C)")
 maze_get "/decode/level2/" do |env|
   if env.params.query["query"].includes?("<")
     "Detect Special Character"
@@ -18,7 +20,8 @@ rescue
   "Decode Error"
 end
 
-Xssmaze.push("decode-level3", "/decode/level3/?query=a", "double url decode")
+Xssmaze.push("decode-level3", "/decode/level3/?query=a", "double url decode",
+  vuln: "reflected-html", delivery: ["query"], note: "URL-decoded once, checked for <, then decoded again; send %25253C so the check sees %3C")
 maze_get "/decode/level3/" do |env|
   data = URI.decode(env.params.query["query"])
   if data.includes?("<")
@@ -30,7 +33,8 @@ rescue
   "Decode Error"
 end
 
-Xssmaze.push("decode-level4", "/decode/level4/?query=a", "double base64 decode")
+Xssmaze.push("decode-level4", "/decode/level4/?query=a", "double base64 decode",
+  vuln: "reflected-html", delivery: ["query"], note: "the value is base64-decoded twice; anything else answers Decode Error")
 maze_get "/decode/level4/" do |env|
   data = Base64.decode_string(env.params.query["query"])
   Base64.decode_string(data)

--- a/src/mazes/dialog_xss.cr
+++ b/src/mazes/dialog_xss.cr
@@ -1,16 +1,19 @@
-Xssmaze.push("dialog-level1", "/dialog/level1/?query=a", "raw query inside <dialog open> element")
+Xssmaze.push("dialog-level1", "/dialog/level1/?query=a", "raw query inside <dialog open> element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/dialog/level1/" do |env|
   query = env.params.query["query"]
   "<dialog open>#{query}</dialog>"
 end
 
-Xssmaze.push("dialog-level2", "/dialog/level2/?query=a", "query reflected as <dialog> id")
+Xssmaze.push("dialog-level2", "/dialog/level2/?query=a", "query reflected as <dialog> id",
+  vuln: "reflected-attr", delivery: ["query"], note: "the id attribute is single-quoted")
 maze_get "/dialog/level2/" do |env|
   query = env.params.query["query"]
   "<dialog open id='#{query}'>hello</dialog>"
 end
 
-Xssmaze.push("dialog-level3", "/dialog/level3/?query=a", "query as form returnValue inside dialog")
+Xssmaze.push("dialog-level3", "/dialog/level3/?query=a", "query as form returnValue inside dialog",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into two single-quoted value attributes, on the input and on the button")
 maze_get "/dialog/level3/" do |env|
   query = env.params.query["query"]
   "<dialog open>
@@ -21,7 +24,8 @@ maze_get "/dialog/level3/" do |env|
   </dialog>"
 end
 
-Xssmaze.push("dialog-level4", "/dialog/level4/?query=a", "showModal trigger with query as innerHTML")
+Xssmaze.push("dialog-level4", "/dialog/level4/?query=a", "showModal trigger with query as innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is JSON-escaped into the script, so there is no string breakout; innerHTML does not run a bare <script>, so use <img src=x onerror=...>")
 maze_get "/dialog/level4/" do |env|
   query = env.params.query["query"]
   "<dialog id='d'></dialog>
@@ -32,7 +36,8 @@ maze_get "/dialog/level4/" do |env|
    </script>"
 end
 
-Xssmaze.push("dialog-level5", "/dialog/level5/?query=a", "<dialog> with filtered <script> tag (case bypass)")
+Xssmaze.push("dialog-level5", "/dialog/level5/?query=a", "<dialog> with filtered <script> tag (case bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "only the exact lowercase <script> and </script> strings are removed; <ScRiPt>, <script src=x> or <img src=x onerror=...> all pass")
 maze_get "/dialog/level5/" do |env|
   query = env.params.query["query"].gsub("<script>", "").gsub("</script>", "")
   "<dialog open>#{query}</dialog>"

--- a/src/mazes/ecommerce_xss.cr
+++ b/src/mazes/ecommerce_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Product name - raw reflection in product-title h1 with itemprop
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("ecommerce-level1", "/ecommerce/level1/?query=a", "product name raw reflection with itemprop")
+Xssmaze.push("ecommerce-level1", "/ecommerce/level1/?query=a", "product name raw reflection with itemprop",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: Product price context - raw reflection inside price span
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("ecommerce-level2", "/ecommerce/level2/?query=a", "product price raw reflection")
+Xssmaze.push("ecommerce-level2", "/ecommerce/level2/?query=a", "product price raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ end
 
 # Level 3: Search filter tag - raw reflection in filter tag span
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("ecommerce-level3", "/ecommerce/level3/?query=a", "search filter tag raw reflection")
+Xssmaze.push("ecommerce-level3", "/ecommerce/level3/?query=a", "search filter tag raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level3/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +30,8 @@ end
 
 # Level 4: Cart item name - raw reflection in table cell
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("ecommerce-level4", "/ecommerce/level4/?query=a", "cart item name in table cell raw reflection")
+Xssmaze.push("ecommerce-level4", "/ecommerce/level4/?query=a", "cart item name in table cell raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level4/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +40,8 @@ end
 
 # Level 5: Review content - raw reflection in review body paragraph
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("ecommerce-level5", "/ecommerce/level5/?query=a", "review body raw reflection")
+Xssmaze.push("ecommerce-level5", "/ecommerce/level5/?query=a", "review body raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level5/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +50,8 @@ end
 
 # Level 6: Breadcrumb trail - raw reflection in active breadcrumb item
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("ecommerce-level6", "/ecommerce/level6/?query=a", "breadcrumb active item raw reflection")
+Xssmaze.push("ecommerce-level6", "/ecommerce/level6/?query=a", "breadcrumb active item raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/encoding_edge_xss.cr
+++ b/src/mazes/encoding_edge_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Server HTML-encodes only the literal pair "<>" when they appear adjacent
 # Individual < or > pass through untouched — standard injection works
-Xssmaze.push("encodingedge-level1", "/encodingedge/level1/?query=a", "only adjacent <> pair encoded, individual < > pass through")
+Xssmaze.push("encodingedge-level1", "/encodingedge/level1/?query=a", "only adjacent <> pair encoded, individual < > pass through",
+  vuln: "reflected-html", delivery: ["query"], note: "only the adjacent pair <> is entity-encoded; a lone < or > passes through")
 maze_get "/encodingedge/level1/" do |env|
   query = env.params.query["query"]
   # Only encode the exact string "<>" — individual angle brackets survive
@@ -11,7 +12,8 @@ end
 
 # Level 2: Server strips "<script" (case-sensitive) but not "<Script" or "<SCRIPT"
 # Mixed case like <Script>alert(1)</Script> bypasses the filter
-Xssmaze.push("encodingedge-level2", "/encodingedge/level2/?query=a", "case-sensitive <script strip (mixed case bypass)")
+Xssmaze.push("encodingedge-level2", "/encodingedge/level2/?query=a", "case-sensitive <script strip (mixed case bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "only the lowercase <script prefix is stripped; <Script> or any other tag passes")
 maze_get "/encodingedge/level2/" do |env|
   query = env.params.query["query"]
   # Case-sensitive strip — only lowercase "<script" is removed
@@ -22,7 +24,8 @@ end
 
 # Level 3: Server replaces only the FIRST double quote with &quot; (using .sub not .gsub)
 # Reflected in attribute context — send a sacrificial " first, then the real breakout "
-Xssmaze.push("encodingedge-level3", "/encodingedge/level3/?query=a", "only first double-quote encoded (sub not gsub)")
+Xssmaze.push("encodingedge-level3", "/encodingedge/level3/?query=a", "only first double-quote encoded (sub not gsub)",
+  vuln: "reflected-attr", delivery: ["query"], note: "only the first double quote is encoded (sub, not gsub); send a sacrificial quote before the real breakout")
 maze_get "/encodingedge/level3/" do |env|
   query = env.params.query["query"]
   # Only first " is escaped — second " can break out of attribute
@@ -33,7 +36,8 @@ end
 
 # Level 4: Server hex-encodes all alphabetic characters in the first 10 characters of input
 # Characters after position 10 are left raw — pad with 10 digits then inject
-Xssmaze.push("encodingedge-level4", "/encodingedge/level4/?query=a", "first 10 chars alpha hex-encoded, rest raw")
+Xssmaze.push("encodingedge-level4", "/encodingedge/level4/?query=a", "first 10 chars alpha hex-encoded, rest raw",
+  vuln: "reflected-html", delivery: ["query"], note: "alphabetic characters in the first 10 are entity-encoded so they cannot form a tag name; pad with 10 digits before the payload")
 maze_get "/encodingedge/level4/" do |env|
   query = env.params.query["query"]
   # Hex-encode alpha chars in first 10 characters only
@@ -47,7 +51,8 @@ end
 
 # Level 5: Server converts < to fullwidth ＜ and > to fullwidth ＞
 # Reflected in attribute value — no angle brackets needed, break out with " and add event handler
-Xssmaze.push("encodingedge-level5", "/encodingedge/level5/?query=a", "angle brackets to fullwidth, reflected in attribute (quote breakout)")
+Xssmaze.push("encodingedge-level5", "/encodingedge/level5/?query=a", "angle brackets to fullwidth, reflected in attribute (quote breakout)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets become fullwidth look-alikes, so no tag can be opened; break out of the double-quoted input value and add an event handler")
 maze_get "/encodingedge/level5/" do |env|
   query = env.params.query["query"]
   # Convert angle brackets to fullwidth Unicode equivalents
@@ -59,7 +64,8 @@ end
 # Level 6: Server strips everything matching /<[^>]*>/ (angle-bracket-enclosed content) from QUERY
 # Reflected in attribute value — since angles are stripped, use " to break out of attribute
 # No angle brackets needed for attribute-context XSS: " onfocus=alert(1) autofocus "
-Xssmaze.push("encodingedge-level6", "/encodingedge/level6/?query=a", "regex strips <...> tags from input, reflected in attribute (no angles needed)")
+Xssmaze.push("encodingedge-level6", "/encodingedge/level6/?query=a", "regex strips <...> tags from input, reflected in attribute (no angles needed)",
+  vuln: "reflected-attr", delivery: ["query"], note: "anything shaped like a tag is regex-stripped; break out of the double-quoted input value and add an event handler, which needs no angle brackets")
 maze_get "/encodingedge/level6/" do |env|
   query = env.params.query["query"]
   # Strip anything that looks like an HTML tag

--- a/src/mazes/form_element_xss.cr
+++ b/src/mazes/form_element_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflected in <input placeholder="QUERY">
-Xssmaze.push("formelement-level1", "/formelement/level1/?query=a", "reflection in input placeholder attribute")
+Xssmaze.push("formelement-level1", "/formelement/level1/?query=a", "reflection in input placeholder attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/formelement/level1/" do |env|
 end
 
 # Level 2: Reflected in <textarea placeholder="QUERY">
-Xssmaze.push("formelement-level2", "/formelement/level2/?query=a", "reflection in textarea placeholder attribute")
+Xssmaze.push("formelement-level2", "/formelement/level2/?query=a", "reflection in textarea placeholder attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ maze_get "/formelement/level2/" do |env|
 end
 
 # Level 3: Reflected in <button title="QUERY">
-Xssmaze.push("formelement-level3", "/formelement/level3/?query=a", "reflection in button title attribute")
+Xssmaze.push("formelement-level3", "/formelement/level3/?query=a", "reflection in button title attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level3/" do |env|
   query = env.params.query["query"]
 
@@ -32,7 +35,8 @@ maze_get "/formelement/level3/" do |env|
 end
 
 # Level 4: Reflected in <select name="QUERY">
-Xssmaze.push("formelement-level4", "/formelement/level4/?query=a", "reflection in select name attribute")
+Xssmaze.push("formelement-level4", "/formelement/level4/?query=a", "reflection in select name attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level4/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +47,8 @@ maze_get "/formelement/level4/" do |env|
 end
 
 # Level 5: Reflected in <option value="QUERY">
-Xssmaze.push("formelement-level5", "/formelement/level5/?query=a", "reflection in option value attribute")
+Xssmaze.push("formelement-level5", "/formelement/level5/?query=a", "reflection in option value attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level5/" do |env|
   query = env.params.query["query"]
 
@@ -54,7 +59,8 @@ maze_get "/formelement/level5/" do |env|
 end
 
 # Level 6: Reflected in <label for="QUERY">
-Xssmaze.push("formelement-level6", "/formelement/level6/?query=a", "reflection in label for attribute")
+Xssmaze.push("formelement-level6", "/formelement/level6/?query=a", "reflection in label for attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/headless_generator_xss.cr
+++ b/src/mazes/headless_generator_xss.cr
@@ -16,7 +16,8 @@ headless_callback_log = Xssmaze::Store.group("headless-generator/level5")
 # Level 1: Basic HTML to PDF - No Filtering
 # Accepts HTML input and simulates PDF generation with no sanitization
 # Vulnerable to direct XSS execution in headless browser context
-Xssmaze.push("headless-generator-level1", "/headless-generator/level1/", "HTML to PDF - no filtering", "POST", ["html"])
+Xssmaze.push("headless-generator-level1", "/headless-generator/level1/", "HTML to PDF - no filtering", "POST", ["html"],
+  vuln: "reflected-html", delivery: ["body"], note: "the headless browser is only simulated; the html field is reflected raw into this response and executes in the requesting browser")
 maze_get "/headless-generator/level1/" do |_|
   %(<form action='/headless-generator/level1/' method='post'>
       <textarea name='html' rows='10' cols='50'>&lt;h1&gt;Test Document&lt;/h1&gt;</textarea><br>
@@ -42,7 +43,8 @@ end
 # Level 2: SVG to PNG - No Filtering
 # Accepts SVG input for image generation
 # SVG can contain script elements that execute during rendering
-Xssmaze.push("headless-generator-level2", "/headless-generator/level2/", "SVG to PNG - no filtering", "POST", ["svg"])
+Xssmaze.push("headless-generator-level2", "/headless-generator/level2/", "SVG to PNG - no filtering", "POST", ["svg"],
+  vuln: "reflected-html", delivery: ["body"], note: "the renderer is only simulated; the svg field is inlined raw into an HTML response, so inline SVG rules apply")
 maze_get "/headless-generator/level2/" do |_|
   %(<form action='/headless-generator/level2/' method='post'>
       <textarea name='svg' rows='10' cols='50'>&lt;svg xmlns="http://www.w3.org/2000/svg"&gt;&lt;circle cx="50" cy="50" r="40"/&gt;&lt;/svg&gt;</textarea><br>
@@ -68,7 +70,8 @@ end
 # Level 3: HTML Sanitization with Bypass
 # Implements basic tag filtering but bypassable
 # Strips <script> tags but misses other execution vectors
-Xssmaze.push("headless-generator-level3", "/headless-generator/level3/", "HTML sanitization bypass", "POST", ["html"])
+Xssmaze.push("headless-generator-level3", "/headless-generator/level3/", "HTML sanitization bypass", "POST", ["html"],
+  vuln: "reflected-html", delivery: ["body"], note: "only a paired <script>...</script> on one line is stripped; <svg onload=...> or a script split across newlines passes")
 maze_get "/headless-generator/level3/" do |_|
   %(<form action='/headless-generator/level3/' method='post'>
       <textarea name='html' rows='10' cols='50'>&lt;h1&gt;Test Document&lt;/h1&gt;</textarea><br>
@@ -97,7 +100,8 @@ end
 # Level 4: SSRF via Internal URL Fetching
 # Accepts HTML with external resources (img src, link href)
 # Simulates headless browser fetching resources during rendering
-Xssmaze.push("headless-generator-level4", "/headless-generator/level4/", "SSRF via resource loading", "POST", ["html"])
+Xssmaze.push("headless-generator-level4", "/headless-generator/level4/", "SSRF via resource loading", "POST", ["html"],
+  vuln: "reflected-html", delivery: ["body"], note: "no SSRF actually happens, the URLs are only listed and escaped; the bug is the raw reflection of the html field below them")
 maze_get "/headless-generator/level4/" do |_|
   %(<form action='/headless-generator/level4/' method='post'>
       <textarea name='html' rows='10' cols='50'>&lt;img src="https://example.com/image.png"&gt;</textarea><br>
@@ -133,7 +137,8 @@ end
 # Level 5: JavaScript Callback Simulation with Webhook
 # Simulates JavaScript execution that triggers external callbacks
 # Useful for testing out-of-band XSS detection
-Xssmaze.push("headless-generator-level5", "/headless-generator/level5/", "JavaScript callback simulation", "POST", ["html", "callback_id"])
+Xssmaze.push("headless-generator-level5", "/headless-generator/level5/", "JavaScript callback simulation", "POST", ["html", "callback_id"],
+  vuln: "reflected-html", delivery: ["body"], note: "only the html field is injectable; callback_id is HTML-escaped everywhere it is echoed")
 maze_get "/headless-generator/level5/" do |_|
   callback_id = Random::Secure.hex(8)
   %(<form action='/headless-generator/level5/' method='post'>
@@ -197,7 +202,8 @@ end
 # Level 6: Content-Type Validation Bypass
 # Checks Content-Type but can be bypassed with polyglot files
 # Accepts JSON input claiming to be HTML
-Xssmaze.push("headless-generator-level6", "/headless-generator/level6/", "Content-Type validation bypass", "POST", ["content"])
+Xssmaze.push("headless-generator-level6", "/headless-generator/level6/", "Content-Type validation bypass", "POST", ["content"],
+  vuln: "reflected-html", delivery: ["body"], note: "the content field is reflected raw whether or not it parses as JSON; if it does, the html member is what gets reflected")
 maze_get "/headless-generator/level6/" do |_|
   %(<form action='/headless-generator/level6/' method='post'>
       <textarea name='content' rows='10' cols='50'>{"html": "&lt;h1&gt;Title&lt;/h1&gt;"}</textarea><br>

--- a/src/mazes/inattr_xss.cr
+++ b/src/mazes/inattr_xss.cr
@@ -1,32 +1,37 @@
-Xssmaze.push("inattr-xss-level1", "/inattr/level1/?query=a", "inattr-xss (double quote)")
+Xssmaze.push("inattr-xss-level1", "/inattr/level1/?query=a", "inattr-xss (double quote)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/inattr/level1/" do |env|
   query = env.params.query["query"]
 
   "<div class=\"#{query}\">Hello</div>"
 end
 
-Xssmaze.push("inattr-xss-level2", "/inattr/level2/?query=a", "inattr-xss (single quote)")
+Xssmaze.push("inattr-xss-level2", "/inattr/level2/?query=a", "inattr-xss (single quote)",
+  vuln: "reflected-attr", delivery: ["query"], note: "the class attribute is single-quoted")
 maze_get "/inattr/level2/" do |env|
   query = env.params.query["query"]
 
   "<div class='#{query}'>Hello</div>"
 end
 
-Xssmaze.push("inattr-xss-level3", "/inattr/level3/?query=a", "inattr-xss (double quote with <> filter)")
+Xssmaze.push("inattr-xss-level3", "/inattr/level3/?query=a", "inattr-xss (double quote with <> filter)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped; break out of the double-quoted attribute and add an event handler instead of a tag")
 maze_get "/inattr/level3/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
 
   "<div class=\"#{query}\">Hello</div>"
 end
 
-Xssmaze.push("inattr-xss-level4", "/inattr/level4/?query=a", "inattr-xss (single quote with <> filter)")
+Xssmaze.push("inattr-xss-level4", "/inattr/level4/?query=a", "inattr-xss (single quote with <> filter)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped; break out of the single-quoted attribute and add an event handler instead of a tag")
 maze_get "/inattr/level4/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
 
   "<div class='#{query}'>Hello</div>"
 end
 
-Xssmaze.push("inattr-xss-level5", "/inattr/level5/?query=a", "inattr-xss (double quote with <> and blank filter)")
+Xssmaze.push("inattr-xss-level5", "/inattr/level5/?query=a", "inattr-xss (double quote with <> and blank filter)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets and literal spaces are stripped; separate the injected attribute with a tab or newline")
 maze_get "/inattr/level5/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
   query = Filters.strip_spaces(query)
@@ -34,7 +39,8 @@ maze_get "/inattr/level5/" do |env|
   "<div class=\"#{query}\">Hello</div>"
 end
 
-Xssmaze.push("inattr-xss-level6", "/inattr/level6/?query=a", "inattr-xss (single quote with <> and blank filter)")
+Xssmaze.push("inattr-xss-level6", "/inattr/level6/?query=a", "inattr-xss (single quote with <> and blank filter)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets and literal spaces are stripped; separate the injected attribute with a tab or newline")
 maze_get "/inattr/level6/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
   query = Filters.strip_spaces(query)

--- a/src/mazes/inframe_xss.cr
+++ b/src/mazes/inframe_xss.cr
@@ -1,25 +1,29 @@
-Xssmaze.push("inframe-xss-level1", "/inframe/level1/?url=a", "src attribute in iframe tag", "GET", ["url"])
+Xssmaze.push("inframe-xss-level1", "/inframe/level1/?url=a", "src attribute in iframe tag", "GET", ["url"],
+  vuln: "reflected-attr", sinks: ["iframe.src"], delivery: ["query"], note: "the parameter is url, not query; both a quote breakout and a javascript: URL work")
 maze_get "/inframe/level1/" do |env|
   query = env.params.query["url"]
 
   "<iframe src='#{query}'></iframe>"
 end
 
-Xssmaze.push("inframe-xss-level2", "/inframe/level2/?url=a", "src attribute in iframe tag", "GET", ["url"])
+Xssmaze.push("inframe-xss-level2", "/inframe/level2/?url=a", "src attribute in iframe tag", "GET", ["url"],
+  vuln: "reflected-attr", sinks: ["iframe.src"], delivery: ["query"], note: "the parameter is url, not query; quotes are stripped so the attribute cannot be broken out, leaving a javascript: URL in the frame src")
 maze_get "/inframe/level2/" do |env|
   query = env.params.query["url"]
 
   "<iframe src='#{query.gsub("'", "").gsub("\"", "")}'></iframe>"
 end
 
-Xssmaze.push("inframe-xss-level3", "/inframe/level3/?url=a", "src attribute in iframe tag", "GET", ["url"])
+Xssmaze.push("inframe-xss-level3", "/inframe/level3/?url=a", "src attribute in iframe tag", "GET", ["url"],
+  vuln: "reflected-attr", sinks: ["iframe.src"], delivery: ["query"], note: "the parameter is url, not query; the value is lowercased and javascript: removed in one pass, so nest it as javajavascript:script:")
 maze_get "/inframe/level3/" do |env|
   query = env.params.query["url"]
 
   "<iframe src='#{query.gsub("'", "").gsub("\"", "").downcase.gsub("javascript:", "")}'></iframe>"
 end
 
-Xssmaze.push("inframe-xss-level4", "/inframe/level4/?url=a", "src attribute in iframe tag", "GET", ["url"])
+Xssmaze.push("inframe-xss-level4", "/inframe/level4/?url=a", "src attribute in iframe tag", "GET", ["url"],
+  vuln: "reflected-attr", sinks: ["iframe.src"], delivery: ["query"], note: "the parameter is url, not query; javascript: and alert are each removed in one pass, so nest both: javajavascript:script:alalertert`1`")
 maze_get "/inframe/level4/" do |env|
   query = env.params.query["url"]
 

--- a/src/mazes/js_context_xss.cr
+++ b/src/mazes/js_context_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Reflection in JS variable assignment var x = "QUERY";
 # Bypass: close script tag and inject HTML
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsctx-level1", "/jsctx/level1/?query=a", "reflection in JS variable assignment (double-quoted string)")
+Xssmaze.push("jsctx-level1", "/jsctx/level1/?query=a", "reflection in JS variable assignment (double-quoted string)",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/jsctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ end
 # Level 2: Reflection in JS object key {QUERY: "value"}
 # Bypass: close script tag and inject HTML
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsctx-level2", "/jsctx/level2/?query=a", "reflection in JS object key")
+Xssmaze.push("jsctx-level2", "/jsctx/level2/?query=a", "reflection in JS object key",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands in object-key position, so an in-JS break has to close the object literal; closing </script> is simpler")
 maze_get "/jsctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ end
 # Level 3: Reflection in JS array element ["a", "QUERY", "b"]
 # Bypass: close script tag and inject HTML
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsctx-level3", "/jsctx/level3/?query=a", "reflection in JS array element (double-quoted)")
+Xssmaze.push("jsctx-level3", "/jsctx/level3/?query=a", "reflection in JS array element (double-quoted)",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/jsctx/level3/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +34,8 @@ end
 # Level 4: Reflection in JS function argument func("QUERY")
 # Bypass: close script tag and inject HTML
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsctx-level4", "/jsctx/level4/?query=a", "reflection in JS function argument (double-quoted)")
+Xssmaze.push("jsctx-level4", "/jsctx/level4/?query=a", "reflection in JS function argument (double-quoted)",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/jsctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -41,7 +45,8 @@ end
 # Level 5: Reflection in JS regex /QUERY/g
 # Bypass: close script tag and inject HTML
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsctx-level5", "/jsctx/level5/?query=a", "reflection in JS regex literal")
+Xssmaze.push("jsctx-level5", "/jsctx/level5/?query=a", "reflection in JS regex literal",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands inside a regex literal, so terminate it with / before injecting, or close the </script> block")
 maze_get "/jsctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -51,7 +56,8 @@ end
 # Level 6: Reflection in JS multiline comment /* QUERY */
 # Bypass: close comment with */ then close script and inject HTML
 # e.g. */</script><script>alert(1)</script>
-Xssmaze.push("jsctx-level6", "/jsctx/level6/?query=a", "reflection in JS multiline comment (close comment and script)")
+Xssmaze.push("jsctx-level6", "/jsctx/level6/?query=a", "reflection in JS multiline comment (close comment and script)",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands inside a /* */ comment, so it must start with */ (or close the </script> block)")
 maze_get "/jsctx/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/late_reflection_xss.cr
+++ b/src/mazes/late_reflection_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: 500 chars of HTML before reflection in div
-Xssmaze.push("latereflect-level1", "/latereflect/level1/?query=a", "500 chars of HTML before reflection in div")
+Xssmaze.push("latereflect-level1", "/latereflect/level1/?query=a", "500 chars of HTML before reflection in div",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/latereflect/level1/" do |env|
   query = env.params.query["query"]
   padding = "<div class=\"wrapper\"><header><h1>Welcome to Our Application</h1><p>This is a comprehensive platform designed to help users manage their data efficiently.</p></header><nav><ul><li><a href=\"/home\">Home</a></li><li><a href=\"/about\">About</a></li><li><a href=\"/services\">Services</a></li><li><a href=\"/contact\">Contact</a></li></ul></nav><section class=\"intro\"><p>We provide excellent services for all your needs. Our team is dedicated to delivering quality results.</p></section></div>"
@@ -13,7 +14,8 @@ maze_get "/latereflect/level1/" do |env|
 end
 
 # Level 2: 1000 chars of HTML before reflection in p
-Xssmaze.push("latereflect-level2", "/latereflect/level2/?query=a", "1000 chars of HTML before reflection in p tag")
+Xssmaze.push("latereflect-level2", "/latereflect/level2/?query=a", "1000 chars of HTML before reflection in p tag",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/latereflect/level2/" do |env|
   query = env.params.query["query"]
   padding = "<div class=\"wrapper\"><header><h1>Welcome to Our Application Portal</h1><p>This is a comprehensive platform designed to help users manage their data efficiently and securely.</p></header><nav><ul><li><a href=\"/home\">Home</a></li><li><a href=\"/about\">About Us</a></li><li><a href=\"/services\">Services</a></li><li><a href=\"/products\">Products</a></li><li><a href=\"/contact\">Contact</a></li><li><a href=\"/support\">Support</a></li></ul></nav><section class=\"intro\"><p>We provide excellent services for all your needs. Our team of professionals is dedicated to delivering quality results on time and within budget.</p><p>Founded in 2020, we have grown to serve thousands of customers worldwide with innovative solutions and cutting-edge technology.</p></section><aside class=\"sidebar\"><h3>Latest News</h3><ul><li>New feature released this week</li><li>Quarterly report now available</li><li>Maintenance scheduled for next weekend</li></ul></aside><section class=\"features\"><h2>Key Features</h2><p>Our platform includes real-time analytics, automated reporting, team collaboration tools, and enterprise-grade security.</p></section></div>"
@@ -27,7 +29,8 @@ maze_get "/latereflect/level2/" do |env|
 end
 
 # Level 3: 2000 chars of HTML before reflection in input value
-Xssmaze.push("latereflect-level3", "/latereflect/level3/?query=a", "2000 chars of HTML before reflection in input value")
+Xssmaze.push("latereflect-level3", "/latereflect/level3/?query=a", "2000 chars of HTML before reflection in input value",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/latereflect/level3/" do |env|
   query = env.params.query["query"]
   block_a = "<div class=\"section-alpha\"><header><h1>Enterprise Dashboard Portal</h1><p>Manage your organization resources, teams, and analytics from one centralized location.</p></header><nav class=\"main-nav\"><ul><li><a href=\"/home\">Home</a></li><li><a href=\"/dashboard\">Dashboard</a></li><li><a href=\"/reports\">Reports</a></li><li><a href=\"/analytics\">Analytics</a></li><li><a href=\"/settings\">Settings</a></li><li><a href=\"/profile\">Profile</a></li><li><a href=\"/logout\">Logout</a></li></ul></nav></div>"
@@ -45,7 +48,8 @@ maze_get "/latereflect/level3/" do |env|
 end
 
 # Level 4: Reflection sandwiched between two 500-char blocks
-Xssmaze.push("latereflect-level4", "/latereflect/level4/?query=a", "reflection between two 500-char HTML blocks")
+Xssmaze.push("latereflect-level4", "/latereflect/level4/?query=a", "reflection between two 500-char HTML blocks",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/latereflect/level4/" do |env|
   query = env.params.query["query"]
   before_block = "<div class=\"before-content\"><header><h1>Application Framework Portal</h1><p>This platform provides tools for managing enterprise resources, analytics dashboards, and team collaboration features.</p></header><nav><ul><li><a href=\"/home\">Home</a></li><li><a href=\"/about\">About</a></li><li><a href=\"/services\">Services</a></li><li><a href=\"/contact\">Contact</a></li></ul></nav><section class=\"intro\"><p>We deliver excellence in every project. Our professionals ensure quality results with timely delivery.</p></section></div>"
@@ -61,7 +65,8 @@ maze_get "/latereflect/level4/" do |env|
 end
 
 # Level 5: 3000 chars of HTML before reflection in span
-Xssmaze.push("latereflect-level5", "/latereflect/level5/?query=a", "3000 chars of HTML before reflection in span")
+Xssmaze.push("latereflect-level5", "/latereflect/level5/?query=a", "3000 chars of HTML before reflection in span",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/latereflect/level5/" do |env|
   query = env.params.query["query"]
   block_a = "<div class=\"mega-header\"><header><h1>Global Enterprise Management System</h1><p>A comprehensive solution for managing worldwide operations, resources, and strategic business initiatives across all departments.</p></header><nav class=\"primary-nav\"><ul><li><a href=\"/home\">Home</a></li><li><a href=\"/dashboard\">Dashboard</a></li><li><a href=\"/projects\">Projects</a></li><li><a href=\"/teams\">Teams</a></li><li><a href=\"/reports\">Reports</a></li><li><a href=\"/settings\">Settings</a></li></ul></nav></div>"
@@ -81,7 +86,8 @@ maze_get "/latereflect/level5/" do |env|
 end
 
 # Level 6: 5000 chars of HTML before reflection in deep div
-Xssmaze.push("latereflect-level6", "/latereflect/level6/?query=a", "5000 chars of HTML before reflection in deep div")
+Xssmaze.push("latereflect-level6", "/latereflect/level6/?query=a", "5000 chars of HTML before reflection in deep div",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/latereflect/level6/" do |env|
   query = env.params.query["query"]
   block_a = "<div class=\"ultra-header\"><header class=\"site-header\"><h1>International Enterprise Resource Planning System</h1><p>Providing world-class solutions for organizations of all sizes across every industry sector and geographic region.</p><p>Our platform has been trusted by Fortune 500 companies for over a decade, delivering consistent results and exceptional reliability.</p></header><nav class=\"main-navigation\"><ul class=\"nav-list\"><li><a href=\"/home\">Home</a></li><li><a href=\"/dashboard\">Dashboard</a></li><li><a href=\"/projects\">Projects</a></li><li><a href=\"/resources\">Resources</a></li><li><a href=\"/analytics\">Analytics</a></li><li><a href=\"/reports\">Reports</a></li><li><a href=\"/admin\">Administration</a></li><li><a href=\"/settings\">Settings</a></li><li><a href=\"/help\">Help Center</a></li></ul></nav></div>"

--- a/src/mazes/manifest_xss.cr
+++ b/src/mazes/manifest_xss.cr
@@ -2,7 +2,8 @@
 # shortcuts[].url) are not script-execution sinks - browsers parse them
 # as data only. We keep just the realistic case where the page fetches
 # its own manifest at runtime and feeds a field back into innerHTML.
-Xssmaze.push("manifest-level1", "/manifest/level1/?query=a", "page fetches manifest.json and innerHTMLs description field")
+Xssmaze.push("manifest-level1", "/manifest/level1/?query=a", "page fetches manifest.json and innerHTMLs description field",
+  vuln: "dom", sources: ["fetch-response"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is JSON-escaped into the page, echoed by /manifest/level1/manifest.json and innerHTMLed; a double quote breaks the JSON, and innerHTML does not run a bare <script>, so use <img src=x onerror=...>")
 maze_get "/manifest/level1/" do |env|
   query = env.params.query["query"]
   "<div id='out'></div>

--- a/src/mazes/media_context_xss.cr
+++ b/src/mazes/media_context_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflected in <video src="QUERY">
-Xssmaze.push("mediacontext-level1", "/mediacontext/level1/?query=a", "reflection in video src attribute")
+Xssmaze.push("mediacontext-level1", "/mediacontext/level1/?query=a", "reflection in video src attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "a javascript: URL does not execute in a video src; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/mediacontext/level1/" do |env|
 end
 
 # Level 2: Reflected in <audio src="QUERY">
-Xssmaze.push("mediacontext-level2", "/mediacontext/level2/?query=a", "reflection in audio src attribute")
+Xssmaze.push("mediacontext-level2", "/mediacontext/level2/?query=a", "reflection in audio src attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "a javascript: URL does not execute in an audio src; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ maze_get "/mediacontext/level2/" do |env|
 end
 
 # Level 3: Reflected in <source src="QUERY"> inside a <video>
-Xssmaze.push("mediacontext-level3", "/mediacontext/level3/?query=a", "reflection in source src attribute inside video")
+Xssmaze.push("mediacontext-level3", "/mediacontext/level3/?query=a", "reflection in source src attribute inside video",
+  vuln: "reflected-attr", delivery: ["query"], note: "a javascript: URL does not execute in a <source> src; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level3/" do |env|
   query = env.params.query["query"]
 
@@ -32,7 +35,8 @@ maze_get "/mediacontext/level3/" do |env|
 end
 
 # Level 4: Reflected in <embed src="QUERY">
-Xssmaze.push("mediacontext-level4", "/mediacontext/level4/?query=a", "reflection in embed src attribute")
+Xssmaze.push("mediacontext-level4", "/mediacontext/level4/?query=a", "reflection in embed src attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "no browser still runs Flash, so the embed src is inert; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level4/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +47,8 @@ maze_get "/mediacontext/level4/" do |env|
 end
 
 # Level 5: Reflected in <track src="QUERY"> inside a <video>
-Xssmaze.push("mediacontext-level5", "/mediacontext/level5/?query=a", "reflection in track src attribute inside video")
+Xssmaze.push("mediacontext-level5", "/mediacontext/level5/?query=a", "reflection in track src attribute inside video",
+  vuln: "reflected-attr", delivery: ["query"], note: "a track src only ever loads a WebVTT file; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level5/" do |env|
   query = env.params.query["query"]
 
@@ -54,7 +59,8 @@ maze_get "/mediacontext/level5/" do |env|
 end
 
 # Level 6: Reflected in <img alt="QUERY">
-Xssmaze.push("mediacontext-level6", "/mediacontext/level6/?query=a", "reflection in img alt attribute")
+Xssmaze.push("mediacontext-level6", "/mediacontext/level6/?query=a", "reflection in img alt attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/mediacontext/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/modern_framework_xss.cr
+++ b/src/mazes/modern_framework_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: React-style dangerouslySetInnerHTML simulation
-Xssmaze.push("modern-level1", "/modern/level1/?query=a", "dangerouslySetInnerHTML simulation")
+Xssmaze.push("modern-level1", "/modern/level1/?query=a", "dangerouslySetInnerHTML simulation",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is percent-encoded into the JS string and decoded client-side, so there is no string breakout; innerHTML does not run a bare <script>, so use <img src=x onerror=...>")
 maze_get "/modern/level1/" do |env|
   query = env.params.query["query"]
 
@@ -13,7 +14,8 @@ maze_get "/modern/level1/" do |env|
 end
 
 # Level 2: Server-side markdown rendering (XSS via markdown link)
-Xssmaze.push("modern-level2", "/modern/level2/?query=a", "markdown link rendering")
+Xssmaze.push("modern-level2", "/modern/level2/?query=a", "markdown link rendering",
+  vuln: "reflected-html", delivery: ["query"], note: "the whole value is reflected raw, so the markdown rewrite is not needed; [x](javascript:alert(1)) additionally builds a clickable href")
 maze_get "/modern/level2/" do |env|
   query = env.params.query["query"]
   # Simple markdown-to-html: [text](url) -> <a href="url">text</a>
@@ -27,7 +29,8 @@ maze_get "/modern/level2/" do |env|
 end
 
 # Level 3: GraphQL-style error reflection
-Xssmaze.push("modern-level3", "/modern/level3/?query=a", "GraphQL error message reflection")
+Xssmaze.push("modern-level3", "/modern/level3/?query=a", "GraphQL error message reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "the response is text/html and the JSON-looking envelope is just <pre> text, so the value is a plain HTML-body reflection")
 maze_get "/modern/level3/" do |env|
   query = env.params.query["query"]
 
@@ -38,7 +41,8 @@ maze_get "/modern/level3/" do |env|
 end
 
 # Level 4: SSR hydration mismatch - server escapes but client doesn't
-Xssmaze.push("modern-level4", "/modern/level4/?query=a", "SSR hydration with client innerHTML")
+Xssmaze.push("modern-level4", "/modern/level4/?query=a", "SSR hydration with client innerHTML",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "the server-side copy is entity-encoded and is a decoy; the page re-reads the raw query parameter into innerHTML, so use <img src=x onerror=...>")
 maze_get "/modern/level4/" do |env|
   query = env.params.query["query"]
   server_safe = Filters.encode_angles(query)
@@ -53,7 +57,8 @@ maze_get "/modern/level4/" do |env|
 end
 
 # Level 5: CORS response with reflected origin
-Xssmaze.push("modern-level5", "/modern/level5/?query=a", "reflected in CORS headers + body")
+Xssmaze.push("modern-level5", "/modern/level5/?query=a", "reflected in CORS headers + body",
+  vuln: "reflected-html", delivery: ["query"], note: "the Access-Control-Allow-Origin echo is header-sanitised and not injectable; the bug is the raw body reflection of query")
 maze_get "/modern/level5/" do |env|
   query = env.params.query.fetch("query", "a")
   origin = env.request.headers.fetch("Origin", "*")
@@ -63,7 +68,8 @@ maze_get "/modern/level5/" do |env|
 end
 
 # Level 6: WebSocket URL injection
-Xssmaze.push("modern-level6", "/modern/level6/?wsurl=ws://localhost", "WebSocket URL injection")
+Xssmaze.push("modern-level6", "/modern/level6/?wsurl=ws://localhost", "WebSocket URL injection", "GET", ["wsurl"],
+  vuln: "reflected-js", delivery: ["query"], note: "the parameter is wsurl, not query; it lands raw in a single-quoted JS string, so close the string and run code")
 maze_get "/modern/level6/" do |env|
   wsurl = env.params.query.fetch("wsurl", "ws://localhost")
 

--- a/src/mazes/modern_realworld_bypass_xss.cr
+++ b/src/mazes/modern_realworld_bypass_xss.cr
@@ -5,7 +5,8 @@ level1_store = Hash(String, String).new
 
 # Level 1: Multi-Step / Multi-State Session-Locked Stored XSS
 # DAST scanners scan endpoints in isolation and do not track states across distinct HTTP methods/pages.
-Xssmaze.push("modern-bypass-level1", "/modern-bypass/level1/preview?view=draft", "Session-locked multi-step draft preview", "GET", ["view"])
+Xssmaze.push("modern-bypass-level1", "/modern-bypass/level1/preview?view=draft", "Session-locked multi-step draft preview", "GET", ["view"],
+  vuln: "stored", delivery: ["body"], note: "the payload enters as the content field of POST /modern-bypass/level1/save; this preview only renders it when the session_id cookie set by that POST is replayed together with view=draft")
 
 # Step 1: Endpoint to save draft (POST)
 maze_post "/modern-bypass/level1/save" do |env|
@@ -46,7 +47,8 @@ end
 # Level 2: DOM Clobbering to XSS via Global Config Override
 # Scanners lack the static/dynamic tracing engines to detect when a reflected attribute
 # overrides global namespaces, which are subsequently loaded into dynamic script tags.
-Xssmaze.push("modern-bypass-level2", "/modern-bypass/level2/?query=a", "DOM Clobbering XSS via global config override", "GET", ["query"])
+Xssmaze.push("modern-bypass-level2", "/modern-bypass/level2/?query=a", "DOM Clobbering XSS via global config override", "GET", ["query"],
+  vuln: "dom", sources: ["server-reflected"], sinks: ["script.src"], delivery: ["query"], note: "script/iframe/object/embed tags and on*= handlers are all stripped, so nothing executes directly; the surviving path is DOM clobbering with <a id=config href=data:text/javascript,alert(1)>, which window.config resolves to and the page loads as a script 500ms later")
 maze_get "/modern-bypass/level2/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -80,7 +82,8 @@ end
 # Level 3: Vue.js Client-Side Template Injection (CSTI) Bypassing Tag Filters
 # Scanners check for HTML injection by looking for tags like <script> or <img onerror>.
 # Stripping `<` and `>` bypasses these scanners completely while Vue parses curly braces.
-Xssmaze.push("modern-bypass-level3", "/modern-bypass/level3/?query=a", "Vue.js Client-Side Template Injection (CSTI) bypassing tag filters", "GET", ["query"])
+Xssmaze.push("modern-bypass-level3", "/modern-bypass/level3/?query=a", "Vue.js Client-Side Template Injection (CSTI) bypassing tag filters", "GET", ["query"],
+  vuln: "csti", delivery: ["query"], note: "Vue 2 compiles #app as a template and angle brackets are stripped, so the payload is a {{ }} expression; needs the jsdelivr CDN to be reachable")
 maze_get "/modern-bypass/level3/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -107,7 +110,8 @@ end
 
 # Level 4: Client-Side JavaScript Prototype Pollution to DOM XSS
 # Scanners do not test dynamic client-side hash parsing (#) or prototype poisoning.
-Xssmaze.push("modern-bypass-level4", %q(/modern-bypass/level4/#{"__proto__":{"scriptUrl":"data:text/javascript,alert(1)"}}), "Client-side Prototype Pollution to DOM XSS via hash parsing", "GET", [] of String)
+Xssmaze.push("modern-bypass-level4", %q(/modern-bypass/level4/#{"__proto__":{"scriptUrl":"data:text/javascript,alert(1)"}}), "Client-side Prototype Pollution to DOM XSS via hash parsing", "GET", [] of String,
+  vuln: "prototype-pollution", sources: ["location.hash"], sinks: ["script.src"], delivery: ["fragment"], note: "fragment only, so no request-only scanner can deliver it; the hash is JSON.parsed and merged, and the polluted scriptUrl key becomes the src of a dynamically created <script>")
 maze_get "/modern-bypass/level4/" do |_env|
   "<!doctype html><html><head><title>Dashboard</title></head><body>
   <h1>Modern Dashboard</h1>
@@ -159,7 +163,8 @@ end
 
 # Level 5: SVG Content-Type Reflection with Script Tag Stripping
 # Scanners assume SVG is safe when `<script>` is deleted, ignoring element-level event triggers like `<svg onload="...">`.
-Xssmaze.push("modern-bypass-level5", "/modern-bypass/level5/?svg=a", "SVG reflection with script tag stripping (requires direct navigation)", "GET", ["svg"])
+Xssmaze.push("modern-bypass-level5", "/modern-bypass/level5/?svg=a", "SVG reflection with script tag stripping (requires direct navigation)", "GET", ["svg"],
+  vuln: "reflected-html", delivery: ["query"], note: "the parameter is svg, not query; the response is served as image/svg+xml, so it only executes on direct navigation, and only <script> is stripped, leaving <svg onload=alert(1)>")
 maze_get "/modern-bypass/level5/" do |env|
   svg = env.params.query.fetch("svg", "")
 
@@ -174,7 +179,8 @@ end
 # Level 6: Entity Decoding inside Iframe `srcdoc` Attribute Context
 # Scanners check if `<script>` is escaped to `&lt;script&gt;` and report safe.
 # They miss that the browser decodes attribute entities inside `srcdoc` before parsing the frame HTML.
-Xssmaze.push("modern-bypass-level6", "/modern-bypass/level6/?query=a", "Iframe srcdoc attribute entity decoding bypass", "GET", ["query"])
+Xssmaze.push("modern-bypass-level6", "/modern-bypass/level6/?query=a", "Iframe srcdoc attribute entity decoding bypass", "GET", ["query"],
+  vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "entity-encoded in the outer document but decoded again when srcdoc is parsed")
 maze_get "/modern-bypass/level6/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -193,7 +199,8 @@ end
 
 # Level 7: Unicode Normalization (NFKC) Filter Bypass
 # DAST scanners rarely send Unicode homoglyphs to check normalization side-effects.
-Xssmaze.push("modern-bypass-level7", "/modern-bypass/level7/?query=a", "Unicode normalization (NFKC) filter bypass", "GET", ["query"])
+Xssmaze.push("modern-bypass-level7", "/modern-bypass/level7/?query=a", "Unicode normalization (NFKC) filter bypass", "GET", ["query"],
+  vuln: "reflected-js", sinks: ["innerHTML"], delivery: ["query"], note: "the keyword WAF (403) never looks at quotes, so the single-quoted JS string can simply be closed; the intended path is a fullwidth homoglyph payload that NFKC-normalises into real markup before innerHTML")
 maze_get "/modern-bypass/level7/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -220,7 +227,8 @@ end
 
 # Level 8: Flawed Regex Host Whitelist for Dynamic Scripts
 # Scanners do not test subdomain/credential validation bypasses of whitelist patterns.
-Xssmaze.push("modern-bypass-level8", "/modern-bypass/level8/?callback_url=https://xssmaze.com/js/callback.js", "Flawed regex domain whitelist bypass for dynamic scripts", "GET", ["callback_url"])
+Xssmaze.push("modern-bypass-level8", "/modern-bypass/level8/?callback_url=https://xssmaze.com/js/callback.js", "Flawed regex domain whitelist bypass for dynamic scripts", "GET", ["callback_url"],
+  vuln: "reflected-js", sinks: ["script.src"], delivery: ["query"], note: "the parameter is callback_url; it lands raw in a single-quoted JS string, so it runs whatever the whitelist decides. The intended bug is the unanchored host regex, which https://xssmaze.com.attacker.com/x.js satisfies")
 maze_get "/modern-bypass/level8/" do |env|
   url = env.params.query.fetch("callback_url", "https://xssmaze.com/js/callback.js")
 
@@ -251,7 +259,8 @@ end
 
 # Level 9: Event Handler in an Unquoted Attribute Context with Space Stripping (Requires Slash Delimiter)
 # Scanners check if they can inject attribute event handlers using alternative separators like `/` when spaces are stripped.
-Xssmaze.push("modern-bypass-level9", "/modern-bypass/level9/?query=a", "Event handler unquoted attribute with space stripping (requires slash separator)", "GET", ["query"])
+Xssmaze.push("modern-bypass-level9", "/modern-bypass/level9/?query=a", "Event handler unquoted attribute with space stripping (requires slash separator)", "GET", ["query"],
+  vuln: "reflected-attr", delivery: ["query"], note: "all whitespace is stripped, so a multi-attribute payload needs slash separators; the template already supplies the leading space, so onerror=alert(1) alone fires on the broken img")
 maze_get "/modern-bypass/level9/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -266,7 +275,8 @@ end
 
 # Level 10: Tag Injection in Nested <select> and <option> Elements
 # Tests if the scanner can properly identify single-quoted option attributes inside select contexts.
-Xssmaze.push("modern-bypass-level10", "/modern-bypass/level10/?query=a", "Nested select option attribute tag breakout", "GET", ["query"])
+Xssmaze.push("modern-bypass-level10", "/modern-bypass/level10/?query=a", "Nested select option attribute tag breakout", "GET", ["query"],
+  vuln: "reflected-attr", delivery: ["query"], note: "double quotes are encoded and the option value is single-quoted; the parser is in in-select mode, so close </select> before injecting anything other than <script>")
 maze_get "/modern-bypass/level10/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -286,7 +296,8 @@ end
 # Level 11: Style Context with Dynamic CSS Variable to JS Execution
 # The user parameter is reflected inside a style block. Scanners trying to close style tags are blocked by WAF.
 # Scanners must understand the style evaluates inside a CSS variable as plain JS by the page scripts.
-Xssmaze.push("modern-bypass-level11", "/modern-bypass/level11/?query=a", "Style context CSS variable to dynamic JS execution", "GET", ["query"])
+Xssmaze.push("modern-bypass-level11", "/modern-bypass/level11/?query=a", "Style context CSS variable to dynamic JS execution", "GET", ["query"],
+  vuln: "dom", sources: ["css-custom-property"], sinks: ["Function"], delivery: ["query"], note: "closing </style> is answered with 403, so no markup is involved at all: the CSS custom property value is read back and passed to new Function 500ms after load, making the payload plain JS such as alert(1)")
 maze_get "/modern-bypass/level11/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -325,7 +336,8 @@ end
 
 # Level 12: Content Security Policy (CSP) Bypass using JSONP Whitelisted Origin
 # Restricts script-src to self and googleapis. Users can bypass CSP using JSONP callback dynamically.
-Xssmaze.push("modern-bypass-level12", "/modern-bypass/level12/?query=a", "CSP bypass via Whitelisted JSONP API Endpoint", "GET", ["query"])
+Xssmaze.push("modern-bypass-level12", "/modern-bypass/level12/?query=a", "CSP bypass via Whitelisted JSONP API Endpoint", "GET", ["query"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the value lands in a single-quoted <script src> in <head>, but the CSP blocks inline script, so an inline breakout does not run; the bypass is to load a template-engine gadget from the whitelisted ajax.googleapis.com. The jquery.min.js callback parameter is not a real JSONP endpoint")
 maze_get "/modern-bypass/level12/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -343,7 +355,8 @@ end
 
 # Level 13: SVG Path Attribute Custom Trigger Injection
 # Measures if the scanner can detect XSS in custom data attributes or SVG sub-properties.
-Xssmaze.push("modern-bypass-level13", "/modern-bypass/level13/?query=a", "SVG Path custom action trigger XSS", "GET", ["query"])
+Xssmaze.push("modern-bypass-level13", "/modern-bypass/level13/?query=a", "SVG Path custom action trigger XSS", "GET", ["query"],
+  vuln: "reflected-attr", sinks: ["eval"], delivery: ["query"], note: "the single-quoted SVG path d attribute can be broken out of, but no breakout is needed: any d value containing xss: has the rest eval-ed 500ms after load, so xss:alert(1) is enough")
 maze_get "/modern-bypass/level13/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -370,7 +383,8 @@ end
 
 # Level 14: Strict Event Denylist (Requires Obscure Event Handlers)
 # Blocks the 10 most common event handlers. Scanner must utilize obscure events like pointerover or pointerdown.
-Xssmaze.push("modern-bypass-level14", "/modern-bypass/level14/?query=a", "Strict event denylist (requires obscure HTML5 events)", "GET", ["query"])
+Xssmaze.push("modern-bypass-level14", "/modern-bypass/level14/?query=a", "Strict event denylist (requires obscure HTML5 events)", "GET", ["query"],
+  vuln: "reflected-attr", delivery: ["query"], note: "ten common handlers are answered with 403; obscure ones are not, so break out of the double-quoted title with <details open ontoggle=alert(1)>")
 maze_get "/modern-bypass/level14/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -387,7 +401,8 @@ end
 
 # Level 15: Nested JSON String in Single-Quoted Attribute Context
 # Replaces double quotes but leaves single quotes intact. Breakout via single-quote attribute boundary.
-Xssmaze.push("modern-bypass-level15", "/modern-bypass/level15/?query=a", "Nested JSON inside single-quoted attribute breakout", "GET", ["query"])
+Xssmaze.push("modern-bypass-level15", "/modern-bypass/level15/?query=a", "Nested JSON inside single-quoted attribute breakout", "GET", ["query"],
+  vuln: "reflected-attr", sinks: ["innerHTML"], delivery: ["query"], note: "only double quotes are escaped, so a single quote leaves the data-info attribute; alternatively the JSON name member reaches document.body.innerHTML, so a quote-free payload works with no breakout at all")
 maze_get "/modern-bypass/level15/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -409,7 +424,8 @@ end
 
 # Level 16: Multi-Context Variable Splitting XSS
 # First reflection is fully HTML-escaped. Second reflection is unquoted raw JS.
-Xssmaze.push("modern-bypass-level16", "/modern-bypass/level16/?query=a", "Multi-context unquoted JS variable splitting", "GET", ["query"])
+Xssmaze.push("modern-bypass-level16", "/modern-bypass/level16/?query=a", "Multi-context unquoted JS variable splitting", "GET", ["query"],
+  vuln: "reflected-js", delivery: ["query"], note: "the first reflection is HTML-escaped; the second is an unquoted JS value, so the payload is a bare expression such as alert(1)")
 maze_get "/modern-bypass/level16/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -429,7 +445,8 @@ end
 # Level 17: Shadow DOM (Closed Root) Reflection via Client-Side Query Parsing
 # Static HTML response contains no user input; the sink is reached only after JS execution.
 # Many crawlers and simple DAST tools won't execute JS or inspect closed shadow roots.
-Xssmaze.push("modern-bypass-level17", "/modern-bypass/level17/?query=a", "Closed ShadowRoot innerHTML reflection via URLSearchParams (client-side only)", "GET", ["query"])
+Xssmaze.push("modern-bypass-level17", "/modern-bypass/level17/?query=a", "Closed ShadowRoot innerHTML reflection via URLSearchParams (client-side only)", "GET", ["query"],
+  vuln: "dom", sources: ["location.search"], sinks: ["attachShadow.innerHTML"], delivery: ["query"], note: "the server response carries no reflection at all, and the shadow root is closed, so the injected node is invisible to document queries")
 maze_get "/modern-bypass/level17/" do |_env|
   "<!doctype html><html><head><meta charset='utf-8'><title>Shadow DOM (closed) Reflection</title></head><body>
   <h1>Modern Bypass Level 17</h1>
@@ -449,7 +466,8 @@ end
 
 # Level 18: Closed ShadowRoot + Slot-Based Injection
 # The shadow DOM uses a slot, while the light DOM is populated via client-side innerHTML.
-Xssmaze.push("modern-bypass-level18", "/modern-bypass/level18/?query=a", "Closed ShadowRoot slot renders light DOM populated via client-side innerHTML", "GET", ["query"])
+Xssmaze.push("modern-bypass-level18", "/modern-bypass/level18/?query=a", "Closed ShadowRoot slot renders light DOM populated via client-side innerHTML", "GET", ["query"],
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "the server response carries no reflection at all; innerHTML does not run a bare <script>, so use <img src=x onerror=...>")
 maze_get "/modern-bypass/level18/" do |_env|
   "<!doctype html><html><head><meta charset='utf-8'><title>Shadow DOM Slot (closed)</title></head><body>
   <h1>Modern Bypass Level 18</h1>
@@ -472,7 +490,8 @@ end
 
 # Level 19: Web Messaging (postMessage) Origin RegExp Bypass
 # Evaluates event data from postMessage listeners where origin validation has weak unanchored RegExp.
-Xssmaze.push("modern-bypass-level19", "/modern-bypass/level19/", "Web Messaging (postMessage) origin RegExp bypass", "GET", [] of String)
+Xssmaze.push("modern-bypass-level19", "/modern-bypass/level19/", "Web Messaging (postMessage) origin RegExp bypass", "GET", [] of String,
+  vuln: "non-xss-control", sources: ["postMessage"], sinks: ["eval"], delivery: ["postmessage"], exploitable: false, note: "the inline script does not parse: `/https://xssmaze.com/.test(...)` tokenises as a regex followed by a line comment, so the if is never closed and the message listener is never registered. Nothing reaches eval, so reporting no XSS here is the correct result")
 maze_get "/modern-bypass/level19/" do |_env|
   "<!doctype html><html><head><meta charset='utf-8'><title>PostMessage Portal</title></head><body>
   <h1>Modern Bypass Level 19</h1>
@@ -503,7 +522,8 @@ end
 
 # Level 20: Double URL Decoding / Double Escape Bypass
 # The application uses explicit second URL decoding after passing input through a WAF rule checking first-level tags.
-Xssmaze.push("modern-bypass-level20", "/modern-bypass/level20/?query=a", "Double URL decoding / double escape bypass", "GET", ["query"])
+Xssmaze.push("modern-bypass-level20", "/modern-bypass/level20/?query=a", "Double URL decoding / double escape bypass", "GET", ["query"],
+  vuln: "reflected-html", delivery: ["query"], note: "the value is URL-decoded a second time after the WAF check, so double-encode the handler name as well as the angle brackets: %253Cimg%2520src%253Dx%2520%256Fnerror%253Dalert(1)%253E")
 maze_get "/modern-bypass/level20/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -525,7 +545,8 @@ end
 # Level 21: Context-Breaking JSON Script Tag Injection (Auto-Escaping Failure)
 # The application serializes a Crystal Hash to JSON and reflects it raw in a script block.
 # An attacker closes the script block with </script> and opens a new one, breaking JS parser rules.
-Xssmaze.push("modern-bypass-level21", "/modern-bypass/level21/?query=a", "Context-breaking JSON script tag injection", "GET", ["query"])
+Xssmaze.push("modern-bypass-level21", "/modern-bypass/level21/?query=a", "Context-breaking JSON script tag injection", "GET", ["query"],
+  vuln: "reflected-js", delivery: ["query"], note: "the value is JSON-serialised, so quotes are escaped, but </script> is not: close the script block and open a new one")
 maze_get "/modern-bypass/level21/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -551,7 +572,8 @@ end
 # Level 22: Alpine.js Directive Injection (Attribute Context)
 # Input is placed directly inside a div element's tag body as a custom attribute. Quotes are HTML-escaped to prevent attribute breakout.
 # Evaluated via Alpine.js directives (like x-init) which do not require quotes to run code in HTML.
-Xssmaze.push("modern-bypass-level22", "/modern-bypass/level22/?query=a", "Alpine.js directive attribute injection", "GET", ["query"])
+Xssmaze.push("modern-bypass-level22", "/modern-bypass/level22/?query=a", "Alpine.js directive attribute injection", "GET", ["query"],
+  vuln: "reflected-attr", delivery: ["query"], note: "quotes and angle brackets are HTML-escaped, so the payload has to be an unquoted Alpine directive in attribute-name position, e.g. x-init=alert(1); needs the jsdelivr CDN to be reachable")
 maze_get "/modern-bypass/level22/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -575,7 +597,8 @@ end
 # Level 23: Meta CSP Pre-Execution Race (Reflection before <meta> tag)
 # The application defines strict CSP via a <meta> tag in the head, but user reflection lands
 # before the meta tag. The browser runs injected scripts before parsing the CSP policy.
-Xssmaze.push("modern-bypass-level23", "/modern-bypass/level23/?query=a", "Meta CSP pre-execution race condition (reflection before meta tag)", "GET", ["query"])
+Xssmaze.push("modern-bypass-level23", "/modern-bypass/level23/?query=a", "Meta CSP pre-execution race condition (reflection before meta tag)", "GET", ["query"],
+  vuln: "reflected-html", delivery: ["query"], note: "the reflection lands in <head> before the CSP <meta>, which only covers what follows it, so a script injected here runs under script-src none")
 maze_get "/modern-bypass/level23/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -592,7 +615,8 @@ end
 
 # Level 24: AngularJS Client-Side Template Injection (CSTI) under Strict Tag Filters
 # Angle brackets are entirely stripped. Evaluated inside AngularJS framework container.
-Xssmaze.push("modern-bypass-level24", "/modern-bypass/level24/?query=a", "AngularJS Client-Side Template Injection (CSTI) bypassing HTML tags", "GET", ["query"])
+Xssmaze.push("modern-bypass-level24", "/modern-bypass/level24/?query=a", "AngularJS Client-Side Template Injection (CSTI) bypassing HTML tags", "GET", ["query"],
+  vuln: "csti", delivery: ["query"], note: "AngularJS 1.6.9 ng-app scope and angle brackets are stripped, so the payload is a {{ }} expression; needs the googleapis CDN to be reachable")
 maze_get "/modern-bypass/level24/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -613,7 +637,8 @@ end
 # Level 25: ES6 Template Literal Backtick Breakout with Placeholders
 # Reflections landing inside template literals can be exploited using ES6 placeholders `${...}`
 # or by escaping/using backticks if not filtered.
-Xssmaze.push("modern-bypass-level25", "/modern-bypass/level25/?query=a", "ES6 JS Template Literal Placeholder Injection", "GET", ["query"])
+Xssmaze.push("modern-bypass-level25", "/modern-bypass/level25/?query=a", "ES6 JS Template Literal Placeholder Injection", "GET", ["query"],
+  vuln: "reflected-js", delivery: ["query"], note: "both quote characters are backslash-escaped, but the value lands inside a backtick template literal; ${alert(1)} evaluates")
 maze_get "/modern-bypass/level25/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -634,7 +659,8 @@ end
 
 # Level 26: Nested Query Parameter Prototype Pollution XSS
 # Simulates deep query string key parsing where __proto__ allows poisoning object prototypes.
-Xssmaze.push("modern-bypass-level26", "/modern-bypass/level26/?query=a", "Query parameter recursive parsing prototype pollution to DOM XSS", "GET", ["query"])
+Xssmaze.push("modern-bypass-level26", "/modern-bypass/level26/?query=a", "Query parameter recursive parsing prototype pollution to DOM XSS", "GET", ["query"],
+  vuln: "prototype-pollution", sources: ["location.search"], sinks: ["script.src"], delivery: ["query"], note: "the parser splits keys on a pipe, not on brackets, so the bracket shape its own comment advertises does nothing; use ?__proto__|scriptUrl=data:text/javascript,alert(1)")
 maze_get "/modern-bypass/level26/" do |_env|
   "<!doctype html><html><head><meta charset='utf-8'><title>Admin Config Console</title></head><body>
   <h1>Configuration Loader</h1>

--- a/src/mazes/multiline_xss.cr
+++ b/src/mazes/multiline_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query reflected raw in <p> tag - standard injection
-Xssmaze.push("multiline-level1", "/multiline/level1/?query=a", "raw reflection in p tag")
+Xssmaze.push("multiline-level1", "/multiline/level1/?query=a", "raw reflection in p tag",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/multiline/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ end
 
 # Level 2: Query reflected in JS string with newlines NOT escaped
 # Bypass: inject newline then </script><img src=x onerror=alert(1)>
-Xssmaze.push("multiline-level2", "/multiline/level2/?query=a", "reflected in JS string, newlines not escaped")
+Xssmaze.push("multiline-level2", "/multiline/level2/?query=a", "reflected in JS string, newlines not escaped",
+  vuln: "reflected-js", delivery: ["query"], note: "double quotes are backslash-escaped but newlines are not, so close the </script> block rather than the string")
 maze_get "/multiline/level2/" do |env|
   query = env.params.query["query"]
   # Escape quotes but NOT newlines
@@ -27,7 +29,8 @@ end
 
 # Level 3: Query reflected in HTML attribute value with newlines allowed
 # Bypass: " onfocus=alert(1) autofocus "
-Xssmaze.push("multiline-level3", "/multiline/level3/?query=a", "reflected in attribute value, newlines allowed")
+Xssmaze.push("multiline-level3", "/multiline/level3/?query=a", "reflected in attribute value, newlines allowed",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/multiline/level3/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +42,8 @@ end
 
 # Level 4: Query reflected inside <textarea> tags
 # Bypass: close textarea with </textarea> then inject
-Xssmaze.push("multiline-level4", "/multiline/level4/?query=a", "reflected inside textarea tags")
+Xssmaze.push("multiline-level4", "/multiline/level4/?query=a", "reflected inside textarea tags",
+  vuln: "reflected-html", delivery: ["query"], note: "<textarea> is a raw-text element, so the payload has to open with </textarea>")
 maze_get "/multiline/level4/" do |env|
   query = env.params.query["query"]
 
@@ -51,7 +55,8 @@ end
 
 # Level 5: Query split on newlines, each line wrapped in <li>
 # Bypass: inject HTML in any line
-Xssmaze.push("multiline-level5", "/multiline/level5/?query=a", "split on newlines into li tags")
+Xssmaze.push("multiline-level5", "/multiline/level5/?query=a", "split on newlines into li tags",
+  vuln: "reflected-html", delivery: ["query"], note: "the value is split on newlines and each line is wrapped raw in its own <li>")
 maze_get "/multiline/level5/" do |env|
   query = env.params.query["query"]
   lines = query.split("\n")
@@ -67,7 +72,8 @@ end
 
 # Level 6: Query reflected inside <pre> tags
 # Bypass: close pre with </pre> then inject
-Xssmaze.push("multiline-level6", "/multiline/level6/?query=a", "reflected inside pre tags")
+Xssmaze.push("multiline-level6", "/multiline/level6/?query=a", "reflected inside pre tags",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/multiline/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/nested_filter_xss.cr
+++ b/src/mazes/nested_filter_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: First strips <script>, then strips <img> -- use <svg onload=alert(1)> which survives both
-Xssmaze.push("nestedfilter-level1", "/nestedfilter/level1/?query=a", "strips script then img tags (svg survives)")
+Xssmaze.push("nestedfilter-level1", "/nestedfilter/level1/?query=a", "strips script then img tags (svg survives)",
+  vuln: "reflected-html", delivery: ["query"], note: "<script> and <img> tags are both stripped; <svg onload=alert(1)> survives")
 maze_get "/nestedfilter/level1/" do |env|
   query = env.params.query["query"]
   query = Filters.strip_tags(query, ["script"])
@@ -9,7 +10,8 @@ maze_get "/nestedfilter/level1/" do |env|
 end
 
 # Level 2: First lowercases input, then strips <script> -- use <img src=x onerror=alert(1)>
-Xssmaze.push("nestedfilter-level2", "/nestedfilter/level2/?query=a", "lowercase then strip script (img survives)")
+Xssmaze.push("nestedfilter-level2", "/nestedfilter/level2/?query=a", "lowercase then strip script (img survives)",
+  vuln: "reflected-html", delivery: ["query"], note: "the value is lowercased before <script> is stripped, so mixed case does not help; use <img src=x onerror=alert(1)>")
 maze_get "/nestedfilter/level2/" do |env|
   query = env.params.query["query"].downcase
   query = Filters.strip_tags(query, ["script"])
@@ -19,7 +21,8 @@ end
 
 # Level 3: First strips on[a-z]+=, then strips <script> tag
 # Use <scr<script>ipt>alert(1)</scr</script>ipt> -- after <script> strip becomes <script>alert(1)</script>
-Xssmaze.push("nestedfilter-level3", "/nestedfilter/level3/?query=a", "strips event handlers then script (nested tag reconstruction)")
+Xssmaze.push("nestedfilter-level3", "/nestedfilter/level3/?query=a", "strips event handlers then script (nested tag reconstruction)",
+  vuln: "reflected-html", delivery: ["query"], note: "on*= handlers and <script> tags are each stripped in one pass, so nest the tag: <scr<script>ipt>alert(1)</scr</script>ipt>")
 maze_get "/nestedfilter/level3/" do |env|
   query = env.params.query["query"]
   query = query.gsub(/on[a-z]+=/, "")
@@ -30,7 +33,8 @@ end
 
 # Level 4: Strips < then strips > -- both angle brackets gone
 # Reflection in attribute context: <input value="QUERY"> -- break out with " onmouseover=alert(1) x="
-Xssmaze.push("nestedfilter-level4", "/nestedfilter/level4/?query=a", "strips < and > (attribute breakout)")
+Xssmaze.push("nestedfilter-level4", "/nestedfilter/level4/?query=a", "strips < and > (attribute breakout)",
+  vuln: "reflected-attr", delivery: ["query"], note: "both angle brackets are stripped; break out of the double-quoted input value and add an event handler")
 maze_get "/nestedfilter/level4/" do |env|
   query = env.params.query["query"]
   query = query.gsub("<", "")
@@ -40,7 +44,8 @@ maze_get "/nestedfilter/level4/" do |env|
 end
 
 # Level 5: URL-decodes once then strips <script> -- use <img src=x onerror=alert(1)> (not affected by script strip)
-Xssmaze.push("nestedfilter-level5", "/nestedfilter/level5/?query=a", "URL decode then strip script (img survives)")
+Xssmaze.push("nestedfilter-level5", "/nestedfilter/level5/?query=a", "URL decode then strip script (img survives)",
+  vuln: "reflected-html", delivery: ["query"], note: "the value is URL-decoded once before <script> is stripped, so encoding does not smuggle a script tag; <img src=x onerror=alert(1)> survives")
 maze_get "/nestedfilter/level5/" do |env|
   query = env.params.query["query"]
   begin
@@ -53,7 +58,8 @@ maze_get "/nestedfilter/level5/" do |env|
 end
 
 # Level 6: Strips "alert", then strips <script> -- use <img src=x onerror=confirm(1)>
-Xssmaze.push("nestedfilter-level6", "/nestedfilter/level6/?query=a", "strips alert keyword then script tag (confirm survives)")
+Xssmaze.push("nestedfilter-level6", "/nestedfilter/level6/?query=a", "strips alert keyword then script tag (confirm survives)",
+  vuln: "reflected-html", delivery: ["query"], note: "the literal lowercase alert and <script> tags are each stripped once; use confirm(1), or nest as alalertert")
 maze_get "/nestedfilter/level6/" do |env|
   query = env.params.query["query"]
   query = query.gsub("alert", "")

--- a/src/mazes/noscript_xss.cr
+++ b/src/mazes/noscript_xss.cr
@@ -1,10 +1,12 @@
-Xssmaze.push("noscript-level1", "/noscript/level1/?query=a", "raw reflection inside <noscript>")
+Xssmaze.push("noscript-level1", "/noscript/level1/?query=a", "raw reflection inside <noscript>",
+  vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled a browser parses <noscript> content as raw text, so the payload must open with </noscript> before any tag is recognised")
 maze_get "/noscript/level1/" do |env|
   query = env.params.query["query"]
   "<noscript>#{query}</noscript>"
 end
 
-Xssmaze.push("noscript-level2", "/noscript/level2/?query=a", "noscript content fed back to innerHTML by client JS")
+Xssmaze.push("noscript-level2", "/noscript/level2/?query=a", "noscript content fed back to innerHTML by client JS",
+  vuln: "dom", sources: ["textContent"], sinks: ["innerHTML"], delivery: ["query"], note: "the raw-text <noscript> body is relayed into innerHTML, so no </noscript> breakout is needed; innerHTML does not run a bare <script>, so use <img src=x onerror=...>")
 maze_get "/noscript/level2/" do |env|
   query = env.params.query["query"]
   "<noscript id='ns'>#{query}</noscript>
@@ -14,13 +16,15 @@ maze_get "/noscript/level2/" do |env|
    </script>"
 end
 
-Xssmaze.push("noscript-level3", "/noscript/level3/?query=a", "<noscript> stripped only literally; nested case bypass")
+Xssmaze.push("noscript-level3", "/noscript/level3/?query=a", "<noscript> stripped only literally; nested case bypass",
+  vuln: "reflected-html", delivery: ["query"], note: "only the exact lowercase <noscript> and </noscript> strings are stripped, and only once, so </NOSCRIPT> or </nos</noscript>cript> gets out of the raw-text element")
 maze_get "/noscript/level3/" do |env|
   query = env.params.query["query"].gsub("<noscript>", "").gsub("</noscript>", "")
   "<noscript>#{query}</noscript>"
 end
 
-Xssmaze.push("noscript-level4", "/noscript/level4/?query=a", "<noscript> with reflected attribute on inner <meta>")
+Xssmaze.push("noscript-level4", "/noscript/level4/?query=a", "<noscript> with reflected attribute on inner <meta>",
+  vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled the <meta> is never a real element (it sits in <noscript> raw text) and a meta refresh to javascript: does not execute anyway; close </noscript> and inject a tag")
 maze_get "/noscript/level4/" do |env|
   query = env.params.query["query"]
   "<noscript><meta http-equiv='refresh' content='0;url=#{query}'></noscript>"

--- a/src/mazes/partial_encode_xss.cr
+++ b/src/mazes/partial_encode_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Only `<` encoded to `&lt;` but `>` left raw
 # Reflected in body (can't open tags) AND in <input value="QUERY"> where `<` encoding is irrelevant
 # Bypass: " onfocus=alert(1) autofocus "
-Xssmaze.push("partialencode-level1", "/partial-encode/level1/?query=a", "only < encoded, reflected in input value attribute")
+Xssmaze.push("partialencode-level1", "/partial-encode/level1/?query=a", "only < encoded, reflected in input value attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "< is entity-encoded, so the body copy is inert; break out of the double-quoted input value instead")
 maze_get "/partial-encode/level1/" do |env|
   query = env.params.query["query"]
   encoded = query.gsub("<", "&lt;")
@@ -12,7 +13,8 @@ end
 # Level 2: Only `>` encoded to `&gt;` but `<` left raw
 # Reflected in <div title="QUERY"> — `>` is encoded so can't close the tag, but can break attribute
 # Bypass: " onfocus=alert(1) x="
-Xssmaze.push("partialencode-level2", "/partial-encode/level2/?query=a", "only > encoded, reflected in div title attribute")
+Xssmaze.push("partialencode-level2", "/partial-encode/level2/?query=a", "only > encoded, reflected in div title attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "> is entity-encoded, so the tag cannot be closed; break out of the double-quoted title attribute and add an event handler")
 maze_get "/partial-encode/level2/" do |env|
   query = env.params.query["query"]
   encoded = query.gsub(">", "&gt;")
@@ -22,7 +24,8 @@ end
 
 # Level 3: `"` and `'` encoded but `<>` left raw
 # Bypass: <img src=x onerror=alert(1)>
-Xssmaze.push("partialencode-level3", "/partial-encode/level3/?query=a", "quotes encoded but angle brackets raw")
+Xssmaze.push("partialencode-level3", "/partial-encode/level3/?query=a", "quotes encoded but angle brackets raw",
+  vuln: "reflected-html", delivery: ["query"], note: "both quote characters are encoded but angle brackets are raw; use a quote-free payload")
 maze_get "/partial-encode/level3/" do |env|
   query = env.params.query["query"]
   encoded = query.gsub("\"", "&quot;").gsub("'", "&#39;")
@@ -32,7 +35,8 @@ end
 
 # Level 4: `<script>` and `</script>` tags encoded but nothing else
 # Bypass: <img src=x onerror=alert(1)>
-Xssmaze.push("partialencode-level4", "/partial-encode/level4/?query=a", "script tags encoded but other tags raw")
+Xssmaze.push("partialencode-level4", "/partial-encode/level4/?query=a", "script tags encoded but other tags raw",
+  vuln: "reflected-html", delivery: ["query"], note: "only the exact <script> and </script> forms are encoded; <script src=x> or <img src=x onerror=alert(1)> passes")
 maze_get "/partial-encode/level4/" do |env|
   query = env.params.query["query"]
   encoded = query.gsub(/<script>/i, "&lt;script&gt;").gsub(/<\/script>/i, "&lt;/script&gt;")
@@ -42,7 +46,8 @@ end
 
 # Level 5: Only first `<` and first `>` encoded (using .sub not .gsub)
 # Bypass: send <> as decoy, then real payload: <><img src=x onerror=alert(1)>
-Xssmaze.push("partialencode-level5", "/partial-encode/level5/?query=a", "only first < and > encoded (sub not gsub)")
+Xssmaze.push("partialencode-level5", "/partial-encode/level5/?query=a", "only first < and > encoded (sub not gsub)",
+  vuln: "reflected-html", delivery: ["query"], note: "only the first < and the first > are encoded (sub, not gsub); send a sacrificial <> before the payload")
 maze_get "/partial-encode/level5/" do |env|
   query = env.params.query["query"]
   encoded = query.sub("<", "&lt;").sub(">", "&gt;")
@@ -52,7 +57,8 @@ end
 
 # Level 6: Encodes `&` `"` `'` but leaves `<` `>` raw
 # Bypass: <img src=x onerror=alert(1)>
-Xssmaze.push("partialencode-level6", "/partial-encode/level6/?query=a", "& and quotes encoded but angle brackets raw")
+Xssmaze.push("partialencode-level6", "/partial-encode/level6/?query=a", "& and quotes encoded but angle brackets raw",
+  vuln: "reflected-html", delivery: ["query"], note: "& is encoded, so an entity-encoded payload will not decode; angle brackets pass through raw")
 maze_get "/partial-encode/level6/" do |env|
   query = env.params.query["query"]
   encoded = query.gsub("&", "&amp;").gsub("\"", "&quot;").gsub("'", "&#39;")

--- a/src/mazes/race_condition_xss.cr
+++ b/src/mazes/race_condition_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflection inside <style> tag (CSS context injection)
 # Exploit: query="></style><script>alert(1)</script>
-Xssmaze.push("racecon-level1", "/racecon/level1/?query=a", "reflection inside style tag (CSS context)")
+Xssmaze.push("racecon-level1", "/racecon/level1/?query=a", "reflection inside style tag (CSS context)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name there is no race; the value lands in a <style> block, so open with </style> before injecting")
 maze_get "/racecon/level1/" do |env|
   query = env.params.query["query"]
 
@@ -14,7 +15,8 @@ end
 
 # Level 2: Reflection in <textarea> without encoding (must close textarea first)
 # Exploit: query=</textarea><script>alert(1)</script>
-Xssmaze.push("racecon-level2", "/racecon/level2/?query=a", "reflection inside textarea (raw, no encoding)")
+Xssmaze.push("racecon-level2", "/racecon/level2/?query=a", "reflection inside textarea (raw, no encoding)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name there is no race; <textarea> is a raw-text element, so open with </textarea>")
 maze_get "/racecon/level2/" do |env|
   query = env.params.query["query"]
 
@@ -29,7 +31,8 @@ end
 
 # Level 3: Reflection in SVG <text> element (SVG context)
 # Exploit: query=</text><svg onload=alert(1)> or query=</text><script>alert(1)</script>
-Xssmaze.push("racecon-level3", "/racecon/level3/?query=a", "reflection inside SVG text element")
+Xssmaze.push("racecon-level3", "/racecon/level3/?query=a", "reflection inside SVG text element",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name there is no race; the value lands in an <svg><text> node, so open with </text></svg>")
 maze_get "/racecon/level3/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +46,8 @@ end
 
 # Level 4: Reflection inside <title> tag (must close title to inject)
 # Exploit: query=</title><script>alert(1)</script>
-Xssmaze.push("racecon-level4", "/racecon/level4/?query=a", "reflection inside title tag")
+Xssmaze.push("racecon-level4", "/racecon/level4/?query=a", "reflection inside title tag",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name there is no race; <title> is a raw-text element, so open with </title>")
 maze_get "/racecon/level4/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/real_world_pattern_xss.cr
+++ b/src/mazes/real_world_pattern_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Search page with query in <input value="QUERY"> and in <p>Results for: QUERY</p>
 # Both reflection points are exploitable (attribute breakout + body injection)
-Xssmaze.push("rwpattern-level1", "/rwpattern/level1/?query=a", "search page: input value + results paragraph")
+Xssmaze.push("rwpattern-level1", "/rwpattern/level1/?query=a", "search page: input value + results paragraph",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected twice: into a double-quoted input value and raw into the results paragraph")
 maze_get "/rwpattern/level1/" do |env|
   query = env.params.query["query"]
 
@@ -12,7 +13,8 @@ maze_get "/rwpattern/level1/" do |env|
 end
 
 # Level 2: Profile page with query in <span class="username">QUERY</span>
-Xssmaze.push("rwpattern-level2", "/rwpattern/level2/?query=a", "profile page: username span injection")
+Xssmaze.push("rwpattern-level2", "/rwpattern/level2/?query=a", "profile page: username span injection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/rwpattern/level2/" do |env|
   query = env.params.query["query"]
 
@@ -25,7 +27,8 @@ maze_get "/rwpattern/level2/" do |env|
 end
 
 # Level 3: 404 page with query in <h1>404 - QUERY not found</h1>
-Xssmaze.push("rwpattern-level3", "/rwpattern/level3/?query=a", "404 page: path reflected in heading")
+Xssmaze.push("rwpattern-level3", "/rwpattern/level3/?query=a", "404 page: path reflected in heading",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/rwpattern/level3/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +39,8 @@ maze_get "/rwpattern/level3/" do |env|
 end
 
 # Level 4: Blog comment with query in <div class="comment"><p>QUERY</p></div>
-Xssmaze.push("rwpattern-level4", "/rwpattern/level4/?query=a", "blog comment: paragraph injection")
+Xssmaze.push("rwpattern-level4", "/rwpattern/level4/?query=a", "blog comment: paragraph injection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/rwpattern/level4/" do |env|
   query = env.params.query["query"]
 
@@ -48,7 +52,8 @@ end
 
 # Level 5: Admin panel with query in <td>QUERY</td> and <title>Admin - QUERY</title>
 # Both reflection points are exploitable
-Xssmaze.push("rwpattern-level5", "/rwpattern/level5/?query=a", "admin panel: table cell + title injection")
+Xssmaze.push("rwpattern-level5", "/rwpattern/level5/?query=a", "admin panel: table cell + title injection",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into both <title>, a raw-text element that needs a </title> first, and a table cell that does not")
 maze_get "/rwpattern/level5/" do |env|
   query = env.params.query["query"]
 
@@ -62,7 +67,8 @@ end
 
 # Level 6: API documentation page with query in <code> and <pre> blocks
 # Break out of code/pre tags with standard injection
-Xssmaze.push("rwpattern-level6", "/rwpattern/level6/?query=a", "API docs: code + pre block injection")
+Xssmaze.push("rwpattern-level6", "/rwpattern/level6/?query=a", "API docs: code + pre block injection",
+  vuln: "reflected-html", delivery: ["query"], note: "<code> and <pre> are ordinary elements, not raw text, so no closing tag is needed before injecting")
 maze_get "/rwpattern/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/regex_bypass_xss.cr
+++ b/src/mazes/regex_bypass_xss.cr
@@ -7,7 +7,8 @@
 # Real shape: hand-rolled WAF rule, in-house template filter, or a
 # CMS plugin that forgot the case-insensitive flag. Bypass: `<Script>`
 # or any mixed case.
-Xssmaze.push("regexbypass-level1", "/regexbypass/level1/?query=a", "case-sensitive <script blacklist (no /i)")
+Xssmaze.push("regexbypass-level1", "/regexbypass/level1/?query=a", "case-sensitive <script blacklist (no /i)",
+  vuln: "reflected-html", delivery: ["query"], note: "the strip is case-sensitive; <Script> passes")
 maze_get "/regexbypass/level1/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("<script", "").gsub("</script", "")
@@ -20,7 +21,8 @@ end
 # HTML permits `/` between attributes. Bypass: `<svg/onload=alert(1)>`
 # or `<img/src=x/onerror=alert(1)>`. Documented in many WAF bypass
 # write-ups.
-Xssmaze.push("regexbypass-level2", "/regexbypass/level2/?query=a", "on*= regex requires whitespace prefix (slash bypass)")
+Xssmaze.push("regexbypass-level2", "/regexbypass/level2/?query=a", "on*= regex requires whitespace prefix (slash bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "the handler regex needs whitespace before on*=; use a slash separator: <svg/onload=alert(1)>")
 maze_get "/regexbypass/level2/" do |env|
   query = env.params.query["query"]
   # Filter requires literal whitespace before the event handler, so
@@ -36,7 +38,8 @@ end
 # `href=` attribute where browsers decode HTML entities before URL
 # parsing. Bypass: `javas&#99;ript:alert(1)` or `&#106;avascript:`.
 # The lab also strips `data:` to keep the channel narrow.
-Xssmaze.push("regexbypass-level3", "/regexbypass/level3/?query=https://example.com", "javascript: literal strip but href decodes entities")
+Xssmaze.push("regexbypass-level3", "/regexbypass/level3/?query=https://example.com", "javascript: literal strip but href decodes entities",
+  vuln: "reflected-attr", delivery: ["query"], note: "javascript: and data: are stripped from the literal text but href decodes entities first (javas&#99;ript:alert(1)); quotes are unfiltered, so breaking out of the attribute also works")
 maze_get "/regexbypass/level3/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/javascript:/i, "").gsub(/data:/i, "")
@@ -48,7 +51,8 @@ end
 # Real shape: `gsub("<script>", "")` is run once. `<scr<script>ipt>`
 # collapses to `<script>` after the strip. Classic CVE pattern
 # (countless CMS plugin advisories).
-Xssmaze.push("regexbypass-level4", "/regexbypass/level4/?query=a", "single-pass <script> strip (nested-tag bypass)")
+Xssmaze.push("regexbypass-level4", "/regexbypass/level4/?query=a", "single-pass <script> strip (nested-tag bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "the strip runs once, so <scr<script>ipt> collapses back into <script>")
 maze_get "/regexbypass/level4/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/<script>/i, "").gsub(/<\/script>/i, "")
@@ -62,7 +66,8 @@ end
 # render. Bypass: send `%3Cscript%3E...%3C/script%3E` URL-encoded
 # past the server filter; the JS sink decodes and parses it.
 # Pattern observed in many SPA error pages.
-Xssmaze.push("regexbypass-level5", "/regexbypass/level5/?query=a", "server encodes < and >, client JS decodes via innerHTML")
+Xssmaze.push("regexbypass-level5", "/regexbypass/level5/?query=a", "server encodes < and >, client JS decodes via innerHTML",
+  vuln: "reflected-js", sinks: ["innerHTML"], delivery: ["query"], note: "only angle brackets are encoded, so the single-quoted JS string can simply be closed; the intended path is a double-encoded payload that decodeURIComponent restores before innerHTML")
 maze_get "/regexbypass/level5/" do |env|
   query = env.params.query["query"]
   filtered = Filters.encode_angles(query)
@@ -82,7 +87,8 @@ end
 # `<details ontoggle>`, `<input autofocus onfocus>`, or
 # `<video src=x onerror>` still execute. Standard scanner payload
 # rotation finds it.
-Xssmaze.push("regexbypass-level6", "/regexbypass/level6/?query=a", "blacklist misses details/input/video sinks")
+Xssmaze.push("regexbypass-level6", "/regexbypass/level6/?query=a", "blacklist misses details/input/video sinks",
+  vuln: "reflected-html", delivery: ["query"], note: "the blacklist misses <details ontoggle>, <input autofocus onfocus> and <video onerror>")
 maze_get "/regexbypass/level6/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/<\/?(script|img|iframe|svg|object|embed)[^>]*>/i, "")
@@ -94,7 +100,8 @@ end
 # Real shape: filter strips `\n` to defeat header-injection-style
 # attacks, but `\t` and `\r` still pass and HTML treats them as
 # whitespace. Bypass: `<img\tsrc=x\tonerror=alert(1)>`.
-Xssmaze.push("regexbypass-level7", "/regexbypass/level7/?query=a", "newline strip with tab/CR untouched")
+Xssmaze.push("regexbypass-level7", "/regexbypass/level7/?query=a", "newline strip with tab/CR untouched",
+  vuln: "reflected-html", delivery: ["query"], note: "only newlines are stripped; tabs and carriage returns still work as attribute separators")
 maze_get "/regexbypass/level7/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("\n", "")
@@ -107,7 +114,8 @@ end
 # all PoCs use it. Bypass: `(alert)(1)`, ``alert`1` ``, `top['ale'+'rt'](1)`,
 # `confirm(1)`, `prompt(1)` — any equivalent sink. Reflective into
 # a JS string context inside `<script>`.
-Xssmaze.push("regexbypass-level8", "/regexbypass/level8/?query=ok", "alert( literal signature inside JS sink")
+Xssmaze.push("regexbypass-level8", "/regexbypass/level8/?query=ok", "alert( literal signature inside JS sink",
+  vuln: "reflected-js", delivery: ["query"], note: "only the literal alert( is blocked; confirm(1) or alert`1` works, and the double-quoted JS string is otherwise unescaped")
 maze_get "/regexbypass/level8/" do |env|
   query = env.params.query["query"].gsub("alert(", "_blocked_")
 

--- a/src/mazes/replacement_filter_xss.cr
+++ b/src/mazes/replacement_filter_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Replaces <script> with [removed] (case sensitive)
 # Bypass: use uppercase <SCRIPT>, or use <img> / <svg> tags
-Xssmaze.push("replacementfilter-level1", "/replacementfilter/level1/?query=a", "case-sensitive <script> replacement")
+Xssmaze.push("replacementfilter-level1", "/replacementfilter/level1/?query=a", "case-sensitive <script> replacement",
+  vuln: "reflected-html", delivery: ["query"], note: "only the exact lowercase <script> is replaced; <SCRIPT> or <svg onload=alert(1)> passes")
 maze_get "/replacementfilter/level1/" do |env|
   query = env.params.query["query"]
   query = query.gsub("<script>", "[removed]")
@@ -10,7 +11,8 @@ end
 
 # Level 2: Replaces "alert" with [blocked] (case sensitive)
 # Bypass: use confirm(1) or prompt(1) instead
-Xssmaze.push("replacementfilter-level2", "/replacementfilter/level2/?query=a", "case-sensitive alert replacement")
+Xssmaze.push("replacementfilter-level2", "/replacementfilter/level2/?query=a", "case-sensitive alert replacement",
+  vuln: "reflected-html", delivery: ["query"], note: "the literal lowercase alert is replaced; use confirm(1) or prompt(1)")
 maze_get "/replacementfilter/level2/" do |env|
   query = env.params.query["query"]
   query = query.gsub("alert", "[blocked]")
@@ -20,7 +22,8 @@ end
 
 # Level 3: Replaces < with ( and > with )
 # Reflected inside <input value="QUERY"> — break out of attribute with " then use event handler
-Xssmaze.push("replacementfilter-level3", "/replacementfilter/level3/?query=a", "angle brackets replaced, reflected in attribute")
+Xssmaze.push("replacementfilter-level3", "/replacementfilter/level3/?query=a", "angle brackets replaced, reflected in attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are turned into parentheses, so no tag survives; break out of the double-quoted input value and add an event handler")
 maze_get "/replacementfilter/level3/" do |env|
   query = env.params.query["query"]
   query = query.gsub("<", "(").gsub(">", ")")
@@ -30,7 +33,8 @@ end
 
 # Level 4: Replaces "onerror" with empty string (single pass)
 # Bypass: "oonnererrorror" becomes "onerror" after removal, or use <script> tag
-Xssmaze.push("replacementfilter-level4", "/replacementfilter/level4/?query=a", "single-pass onerror removal")
+Xssmaze.push("replacementfilter-level4", "/replacementfilter/level4/?query=a", "single-pass onerror removal",
+  vuln: "reflected-html", delivery: ["query"], note: "only onerror is removed, and only in one pass, so oonnererrorror reassembles it; any other handler passes untouched")
 maze_get "/replacementfilter/level4/" do |env|
   query = env.params.query["query"]
   query = query.gsub("onerror", "")
@@ -40,7 +44,8 @@ end
 
 # Level 5: Replaces <img with empty string (single pass, case insensitive)
 # Bypass: "<<img" becomes "<img" after removal, or use <svg>/<script> tags
-Xssmaze.push("replacementfilter-level5", "/replacementfilter/level5/?query=a", "single-pass case-insensitive <img removal")
+Xssmaze.push("replacementfilter-level5", "/replacementfilter/level5/?query=a", "single-pass case-insensitive <img removal",
+  vuln: "reflected-html", delivery: ["query"], note: "only <img is removed, and only in one pass, so <i<imgmg reassembles it; <svg> and <script> pass untouched")
 maze_get "/replacementfilter/level5/" do |env|
   query = env.params.query["query"]
   query = query.gsub(/<img/i, "")
@@ -50,7 +55,8 @@ end
 
 # Level 6: Replaces all HTML entities (&...;) with empty string
 # Does not affect raw tags — standard injection works fine
-Xssmaze.push("replacementfilter-level6", "/replacementfilter/level6/?query=a", "HTML entity removal (raw tags unaffected)")
+Xssmaze.push("replacementfilter-level6", "/replacementfilter/level6/?query=a", "HTML entity removal (raw tags unaffected)",
+  vuln: "reflected-html", delivery: ["query"], note: "HTML entities are stripped from the value, so an entity-encoded payload does not survive; raw tags do")
 maze_get "/replacementfilter/level6/" do |env|
   query = env.params.query["query"]
   query = query.gsub(/&[a-zA-Z0-9#]+;/, "")

--- a/src/mazes/semantic_tag_xss.cr
+++ b/src/mazes/semantic_tag_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflected in <article><p>QUERY</p></article>
-Xssmaze.push("semantictag-level1", "/semantictag/level1/?query=a", "reflection in article > p element")
+Xssmaze.push("semantictag-level1", "/semantictag/level1/?query=a", "reflection in article > p element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/semantictag/level1/" do |env|
 end
 
 # Level 2: Reflected in <section><h2>QUERY</h2></section>
-Xssmaze.push("semantictag-level2", "/semantictag/level2/?query=a", "reflection in section > h2 element")
+Xssmaze.push("semantictag-level2", "/semantictag/level2/?query=a", "reflection in section > h2 element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ maze_get "/semantictag/level2/" do |env|
 end
 
 # Level 3: Reflected in <aside>QUERY</aside>
-Xssmaze.push("semantictag-level3", "/semantictag/level3/?query=a", "reflection in aside element")
+Xssmaze.push("semantictag-level3", "/semantictag/level3/?query=a", "reflection in aside element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level3/" do |env|
   query = env.params.query["query"]
 
@@ -32,7 +35,8 @@ maze_get "/semantictag/level3/" do |env|
 end
 
 # Level 4: Reflected in <nav><a href="#">QUERY</a></nav>
-Xssmaze.push("semantictag-level4", "/semantictag/level4/?query=a", "reflection in nav > a link text")
+Xssmaze.push("semantictag-level4", "/semantictag/level4/?query=a", "reflection in nav > a link text",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level4/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +47,8 @@ maze_get "/semantictag/level4/" do |env|
 end
 
 # Level 5: Reflected in <footer>QUERY</footer>
-Xssmaze.push("semantictag-level5", "/semantictag/level5/?query=a", "reflection in footer element")
+Xssmaze.push("semantictag-level5", "/semantictag/level5/?query=a", "reflection in footer element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level5/" do |env|
   query = env.params.query["query"]
 
@@ -54,7 +59,8 @@ maze_get "/semantictag/level5/" do |env|
 end
 
 # Level 6: Reflected in <main><blockquote>QUERY</blockquote></main>
-Xssmaze.push("semantictag-level6", "/semantictag/level6/?query=a", "reflection in main > blockquote element")
+Xssmaze.push("semantictag-level6", "/semantictag/level6/?query=a", "reflection in main > blockquote element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/stored_pattern_xss.cr
+++ b/src/mazes/stored_pattern_xss.cr
@@ -23,7 +23,8 @@ single = {
 # Level 1: comment system storing into attribute context
 # Real shape: comment body escaped for body display but reused
 # *raw* inside an attribute (`title=`, `data-*`). Reviews-style.
-Xssmaze.push("storedpat-level1", "/storedpat/level1/", "comment stored in body (escaped) + title attr (raw)", "POST")
+Xssmaze.push("storedpat-level1", "/storedpat/level1/", "comment stored in body (escaped) + title attr (raw)", "POST", ["body"],
+  vuln: "stored", delivery: ["body"], note: "the field is body, not query; the list text is HTML-escaped, so the injectable context is the raw double-quoted title attribute")
 maze_get "/storedpat/level1/" do |_|
   items = store["lvl1"].entries.map do |c|
     "<li title=\"#{c}\">#{Xssmaze.html_escape(c)}</li>"
@@ -51,7 +52,8 @@ end
 # `**bold**` and `*italic*` are converted; raw HTML passes through.
 # Real shape: GitHub README / Discourse cooked content, where the
 # renderer trusts the saved markdown.
-Xssmaze.push("storedpat-level2", "/storedpat/level2/", "profile bio markdown render (HTML pass-through)", "POST")
+Xssmaze.push("storedpat-level2", "/storedpat/level2/", "profile bio markdown render (HTML pass-through)", "POST", ["bio"],
+  vuln: "stored", delivery: ["body"], note: "the field is bio, not query; raw HTML passes straight through the markdown rewrite")
 maze_get "/storedpat/level2/" do |_|
   bio = single["lvl2"].value
   rendered = bio.gsub(/\*\*([^*]+)\*\*/) { "<strong>#{$1}</strong>" }
@@ -78,7 +80,8 @@ end
 # Real shape: e-commerce review form. Review body lands raw in
 # `<meta property="og:description">` content, which is attribute
 # context — escapes quotes only.
-Xssmaze.push("storedpat-level3", "/storedpat/level3/", "product review stored into <meta og:description>", "POST")
+Xssmaze.push("storedpat-level3", "/storedpat/level3/", "product review stored into <meta og:description>", "POST", ["review"],
+  vuln: "stored", delivery: ["body"], note: "the field is review, not query; the visible copy is HTML-escaped, so break out of the double-quoted <meta og:description> content in the head")
 maze_get "/storedpat/level3/" do |_|
   last = single["lvl3"].value
   "<!doctype html><html><head>
@@ -104,7 +107,8 @@ end
 # Level 4: chat message recent list (same-request preview + GET list)
 # Real shape: support chat / live discussion thread. New message is
 # appended and the entire thread re-rendered, raw.
-Xssmaze.push("storedpat-level4", "/storedpat/level4/", "chat message thread (raw render)", "POST")
+Xssmaze.push("storedpat-level4", "/storedpat/level4/", "chat message thread (raw render)", "POST", ["msg"],
+  vuln: "stored", delivery: ["body"], note: "the field is msg, not query")
 maze_get "/storedpat/level4/" do |_|
   msgs = store["lvl4"].entries.map { |m| "<div class='msg'>#{m}</div>" }.join
   "<!doctype html><html><body>
@@ -128,7 +132,8 @@ end
 # Real shape: Zendesk-style ticket. Subject lands in `<title>` and
 # in `<h1>` on the ticket-view page (a separate GET). Same-request
 # response also shows the stored subject for scanner detection.
-Xssmaze.push("storedpat-level5", "/storedpat/level5/", "ticket subject stored into <title> and <h1>", "POST")
+Xssmaze.push("storedpat-level5", "/storedpat/level5/", "ticket subject stored into <title> and <h1>", "POST", ["subject"],
+  vuln: "stored", delivery: ["body"], note: "the field is subject, not query; it is reflected into both <title>, a raw-text element, and an <h1> that needs no breakout")
 maze_get "/storedpat/level5/" do |_|
   subj = single["lvl5"].value
   "<!doctype html><html><head>
@@ -153,7 +158,8 @@ end
 # Real shape: admin dashboard fetches notes API and pastes the
 # `text` field into the DOM. POST stores; GET serves the API; the
 # HTML page wires it up.
-Xssmaze.push("storedpat-level6", "/storedpat/level6/", "admin note: POST stored, fetched JSON → innerHTML", "POST")
+Xssmaze.push("storedpat-level6", "/storedpat/level6/", "admin note: POST stored, fetched JSON → innerHTML", "POST", ["note"],
+  vuln: "stored", sources: ["fetch-response"], sinks: ["innerHTML"], delivery: ["body"], note: "the field is note, not query; the stored value is served by /storedpat/level6/api and pasted into innerHTML, so use <img src=x onerror=...>")
 maze_get "/storedpat/level6/" do |_|
   "<!doctype html><html><body>
   <h1>Admin notes</h1>

--- a/src/mazes/stored_xss.cr
+++ b/src/mazes/stored_xss.cr
@@ -7,7 +7,8 @@ stored_data = {
   "level4" => Xssmaze::Store.list("stored/level4"),
 }
 
-Xssmaze.push("stored-level1", "/stored/level1/", "stored XSS via guestbook (no filter)", "POST")
+Xssmaze.push("stored-level1", "/stored/level1/", "stored XSS via guestbook (no filter)", "POST",
+  vuln: "stored", delivery: ["body"], note: "the POST response re-renders the whole list, so the reflection is visible without a follow-up GET")
 maze_get "/stored/level1/" do |_|
   entries = stored_data["level1"].entries.map { |e| "<li>#{e}</li>" }.join
   "<html><body>
@@ -27,7 +28,8 @@ maze_post "/stored/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("stored-level2", "/stored/level2/", "stored XSS with angle bracket filter", "POST")
+Xssmaze.push("stored-level2", "/stored/level2/", "stored XSS with angle bracket filter", "POST",
+  vuln: "non-xss-control", delivery: ["body"], exploitable: false, note: "angle brackets are stripped before storage and the value is rendered as <li> text content, so no markup can be introduced; reporting no XSS here is the correct result")
 maze_get "/stored/level2/" do |_|
   entries = stored_data["level2"].entries.map { |e| "<li>#{e}</li>" }.join
   "<html><body>
@@ -47,7 +49,8 @@ maze_post "/stored/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("stored-level3", "/stored/level3/", "stored XSS in attribute context", "POST")
+Xssmaze.push("stored-level3", "/stored/level3/", "stored XSS in attribute context", "POST",
+  vuln: "stored", delivery: ["body"], note: "the visible copy is angle-encoded; the injectable context is the raw double-quoted title attribute on the same div")
 maze_get "/stored/level3/" do |_|
   entries = stored_data["level3"].entries.map { |e| "<div title=\"#{e}\">#{Filters.encode_angles(e)}</div>" }.join
   "<html><body>
@@ -67,7 +70,8 @@ maze_post "/stored/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("stored-level4", "/stored/level4/", "stored XSS in JSON API response rendered via innerHTML", "POST")
+Xssmaze.push("stored-level4", "/stored/level4/", "stored XSS in JSON API response rendered via innerHTML", "POST",
+  vuln: "stored", sources: ["fetch-response"], sinks: ["innerHTML"], delivery: ["body"], note: "the stored value is served by /stored/level4/api and pasted into innerHTML, so a bare <script> will not run; use <img src=x onerror=...>")
 maze_get "/stored/level4/" do |_|
   "<html><body>
   <h1>Stored XSS Level 4</h1>

--- a/src/mazes/tag_attribute_mix_xss.cr
+++ b/src/mazes/tag_attribute_mix_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query in both tag content and data attribute - either exploitable
-Xssmaze.push("tagattrmix-level1", "/tagattrmix/level1/?query=a", "reflection in both span content and data-info attribute")
+Xssmaze.push("tagattrmix-level1", "/tagattrmix/level1/?query=a", "reflection in both span content and data-info attribute",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected twice: into a double-quoted data-info attribute and raw into the span")
 maze_get "/tagattrmix/level1/" do |env|
   query = env.params.query["query"]
 
@@ -7,7 +8,8 @@ maze_get "/tagattrmix/level1/" do |env|
 end
 
 # Level 2: Query in class attribute - break out with double quote
-Xssmaze.push("tagattrmix-level2", "/tagattrmix/level2/?query=a", "reflection in class attribute (double quote breakout)")
+Xssmaze.push("tagattrmix-level2", "/tagattrmix/level2/?query=a", "reflection in class attribute (double quote breakout)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/tagattrmix/level2/" do |env|
   query = env.params.query["query"]
 
@@ -15,7 +17,8 @@ maze_get "/tagattrmix/level2/" do |env|
 end
 
 # Level 3: Query in img title attribute - break out with double quote
-Xssmaze.push("tagattrmix-level3", "/tagattrmix/level3/?query=a", "reflection in img title attribute (double quote breakout)")
+Xssmaze.push("tagattrmix-level3", "/tagattrmix/level3/?query=a", "reflection in img title attribute (double quote breakout)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/tagattrmix/level3/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +26,8 @@ maze_get "/tagattrmix/level3/" do |env|
 end
 
 # Level 4: Query in anchor data-id attribute - break out with double quote
-Xssmaze.push("tagattrmix-level4", "/tagattrmix/level4/?query=a", "reflection in anchor data-id attribute (double quote breakout)")
+Xssmaze.push("tagattrmix-level4", "/tagattrmix/level4/?query=a", "reflection in anchor data-id attribute (double quote breakout)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/tagattrmix/level4/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +35,8 @@ maze_get "/tagattrmix/level4/" do |env|
 end
 
 # Level 5: Query in meta content attribute - break out with double quote
-Xssmaze.push("tagattrmix-level5", "/tagattrmix/level5/?query=a", "reflection in meta content attribute (double quote breakout)")
+Xssmaze.push("tagattrmix-level5", "/tagattrmix/level5/?query=a", "reflection in meta content attribute (double quote breakout)",
+  vuln: "reflected-attr", delivery: ["query"], note: "the reflection is in <head>; a breakout implicitly opens <body>, so a self-firing tag still runs")
 maze_get "/tagattrmix/level5/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +44,8 @@ maze_get "/tagattrmix/level5/" do |env|
 end
 
 # Level 6: Query in div style url() - break out with single quote
-Xssmaze.push("tagattrmix-level6", "/tagattrmix/level6/?query=a", "reflection in style url() with single quote breakout")
+Xssmaze.push("tagattrmix-level6", "/tagattrmix/level6/?query=a", "reflection in style url() with single quote breakout",
+  vuln: "reflected-attr", delivery: ["query"], note: "the value sits in a single-quoted CSS url() inside a double-quoted style attribute; a double quote leaves style= entirely")
 maze_get "/tagattrmix/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/truncation_xss.cr
+++ b/src/mazes/truncation_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflects first 100 chars raw - short payloads like <svg/onload=alert(1)> (21 chars) fit easily
-Xssmaze.push("truncation-level1", "/truncation/level1/?query=a", "reflects first 100 chars raw")
+Xssmaze.push("truncation-level1", "/truncation/level1/?query=a", "reflects first 100 chars raw",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/truncation/level1/" do |env|
   query = env.params.query["query"]
   truncated = query[0, {query.size, 100}.min]
@@ -7,7 +8,8 @@ maze_get "/truncation/level1/" do |env|
 end
 
 # Level 2: Reflects first 50 chars raw - <img src=x onerror=alert(1)> (30 chars) fits
-Xssmaze.push("truncation-level2", "/truncation/level2/?query=a", "reflects first 50 chars raw")
+Xssmaze.push("truncation-level2", "/truncation/level2/?query=a", "reflects first 50 chars raw",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/truncation/level2/" do |env|
   query = env.params.query["query"]
   truncated = query[0, {query.size, 50}.min]
@@ -15,7 +17,8 @@ maze_get "/truncation/level2/" do |env|
 end
 
 # Level 3: Reflects first 200 chars inside input value attribute - break out with " onfocus=alert(1) autofocus "
-Xssmaze.push("truncation-level3", "/truncation/level3/?query=a", "reflects first 200 chars in input value attribute")
+Xssmaze.push("truncation-level3", "/truncation/level3/?query=a", "reflects first 200 chars in input value attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/truncation/level3/" do |env|
   query = env.params.query["query"]
   truncated = query[0, {query.size, 200}.min]
@@ -23,7 +26,8 @@ maze_get "/truncation/level3/" do |env|
 end
 
 # Level 4: Reflects first 30 chars raw - very short payloads like <svg/onload=alert()> (21 chars) fit
-Xssmaze.push("truncation-level4", "/truncation/level4/?query=a", "reflects first 30 chars raw")
+Xssmaze.push("truncation-level4", "/truncation/level4/?query=a", "reflects first 30 chars raw",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/truncation/level4/" do |env|
   query = env.params.query["query"]
   truncated = query[0, {query.size, 30}.min]
@@ -31,7 +35,8 @@ maze_get "/truncation/level4/" do |env|
 end
 
 # Level 5: Reflects first 80 chars inside script string - break out with </script><svg/onload=alert(1)> (31 chars)
-Xssmaze.push("truncation-level5", "/truncation/level5/?query=a", "reflects first 80 chars in script string context")
+Xssmaze.push("truncation-level5", "/truncation/level5/?query=a", "reflects first 80 chars in script string context",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/truncation/level5/" do |env|
   query = env.params.query["query"]
   truncated = query[0, {query.size, 80}.min]
@@ -39,7 +44,8 @@ maze_get "/truncation/level5/" do |env|
 end
 
 # Level 6: Reflects first 40 chars raw - <img src=x onerror=alert(1)> (30 chars) fits
-Xssmaze.push("truncation-level6", "/truncation/level6/?query=a", "reflects first 40 chars raw")
+Xssmaze.push("truncation-level6", "/truncation/level6/?query=a", "reflects first 40 chars raw",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/truncation/level6/" do |env|
   query = env.params.query["query"]
   truncated = query[0, {query.size, 40}.min]

--- a/src/mazes/whitespace_xss.cr
+++ b/src/mazes/whitespace_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: All spaces replaced by &nbsp; but in HTML body — tags still work
 # Use / as attribute delimiter instead of space: <img/src=x/onerror=alert(1)>
-Xssmaze.push("whitespace-level1", "/whitespace/level1/?query=a", "spaces replaced with &amp;nbsp; in body")
+Xssmaze.push("whitespace-level1", "/whitespace/level1/?query=a", "spaces replaced with &amp;nbsp; in body",
+  vuln: "reflected-html", delivery: ["query"], note: "spaces become &nbsp; entities, which do not separate attributes; use a slash instead: <img/src=x/onerror=alert(1)>")
 maze_get "/whitespace/level1/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(" ", "&nbsp;")
@@ -12,7 +13,8 @@ maze_get "/whitespace/level1/" do |env|
 end
 
 # Level 2: Tabs stripped, reflected in HTML body — spaces still work for tags
-Xssmaze.push("whitespace-level2", "/whitespace/level2/?query=a", "tabs stripped, body reflection")
+Xssmaze.push("whitespace-level2", "/whitespace/level2/?query=a", "tabs stripped, body reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/whitespace/level2/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("\t", "")
@@ -24,7 +26,8 @@ maze_get "/whitespace/level2/" do |env|
 end
 
 # Level 3: Newlines stripped, reflected in HTML body — single-line payloads work normally
-Xssmaze.push("whitespace-level3", "/whitespace/level3/?query=a", "newlines stripped, body reflection")
+Xssmaze.push("whitespace-level3", "/whitespace/level3/?query=a", "newlines stripped, body reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/whitespace/level3/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("\n", "").gsub("\r", "")
@@ -36,7 +39,8 @@ maze_get "/whitespace/level3/" do |env|
 end
 
 # Level 4: Multiple spaces collapsed to one, reflected in <div> — standard injection works
-Xssmaze.push("whitespace-level4", "/whitespace/level4/?query=a", "multiple spaces collapsed to one in div")
+Xssmaze.push("whitespace-level4", "/whitespace/level4/?query=a", "multiple spaces collapsed to one in div",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/whitespace/level4/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/  +/, " ")
@@ -48,7 +52,8 @@ maze_get "/whitespace/level4/" do |env|
 end
 
 # Level 5: Reflected inside <pre> tag raw (preserves whitespace) — break out with </pre>
-Xssmaze.push("whitespace-level5", "/whitespace/level5/?query=a", "raw reflection inside pre tag")
+Xssmaze.push("whitespace-level5", "/whitespace/level5/?query=a", "raw reflection inside pre tag",
+  vuln: "reflected-html", delivery: ["query"], note: "<pre> is an ordinary element, not raw text, so no </pre> is needed before injecting")
 maze_get "/whitespace/level5/" do |env|
   query = env.params.query["query"]
 
@@ -60,7 +65,8 @@ end
 
 # Level 6: All whitespace (space, tab, newline) stripped, reflected in HTML body
 # Use / as delimiter: <svg/onload=alert(1)>
-Xssmaze.push("whitespace-level6", "/whitespace/level6/?query=a", "all whitespace stripped, body reflection")
+Xssmaze.push("whitespace-level6", "/whitespace/level6/?query=a", "all whitespace stripped, body reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "every whitespace character is stripped; use a slash separator: <svg/onload=alert(1)>")
 maze_get "/whitespace/level6/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/[\s]/, "")


### PR DESCRIPTION
## What changed

Triages **slice T1** of the untriaged catalog: **209 `Xssmaze.push` calls across 34 maze
files** that shipped as `vuln: "unclassified"` / `reach: "unknown"` now carry structured
metadata (`vuln` / `sources` / `sinks` / `delivery` / `exploitable` / `note`).

Every classification was made by reading the handler body, not the maze name or description
— several names are misleading (the `css`, `race`, `manifest`, `modern`, `sink`-style
levels especially). `delivery` was chosen so `reach` derives correctly: fragment- and
postMessage-only levels do **not** list a server channel.

`unclassified` drops **838 → 629 (exactly 209)**; no class name outside `VULN_CLASSES`
appeared. Metadata-only diff — no handler bodies, filters, or HTML touched.

### `params:` fixes (second defect)

Seven pushes declared `params: ["query"]` while the handler reads a different parameter, so
`/map/json` pointed scanners at the wrong field. Fixed against the handler:

| endpoint | was | now |
|---|---|---|
| `modern-level6` | `query` | `wsurl` (URL is `?wsurl=...`, handler reads `wsurl`) |
| `storedpat-level1` | `query` | `body` |
| `storedpat-level2` | `query` | `bio` |
| `storedpat-level3` | `query` | `review` |
| `storedpat-level4` | `query` | `msg` |
| `storedpat-level5` | `query` | `subject` |
| `storedpat-level6` | `query` | `note` |

(`stored-level1..4` kept `["query"]` — their POST body field genuinely *is* `query`.)

### `exploitable: false` (change a benchmark's denominator — please review individually)

- **`stored-level2`** — `Filters.strip_angles` removes `<` and `>` before storage and the
  value renders as `<li>` **text content** (no attribute context), so no markup can be
  introduced. Marked `non-xss-control`. Verified: `POST query=<img src=x onerror=alert(1)>`
  stores and renders `<li>img src=x onerror=alert(1)</li>`.
- **`modern-bypass-level19`** — the inline script does not parse: `/https://xssmaze.com/.test(...)`
  tokenises as a regex literal followed by a `//` line comment, so the `if (` is never
  closed. The whole `<script>` is a `SyntaxError`, the `message` listener is never
  registered, and the `eval(data.code)` sink is unreachable. Marked `non-xss-control`
  (intended class noted as postMessage→eval). `node --check` on the served script confirms
  the `SyntaxError`. **This is an accidental code bug, not a deliberate filter** — if a
  reviewer fixes the regex the level becomes a real request-unreachable `dom` postMessage
  flow; happy to re-classify once that's decided.

## How I verified

```
shards build                     # ok
crystal spec                     # 188 examples, 0 failures
crystal tool format              # clean
crystal run lib/ameba/bin/ameba.cr -- src/mazes/   # 182 inspected, 0 failures
```

`/stats` before → after: `unclassified 838 → 629`; classes present all within
`VULN_CLASSES` (`reflected-html`, `reflected-attr`, `reflected-js`, `dom`, `stored`,
`prototype-pollution`, `csti`, `non-xss-control`); `controls 6 → 8`.

End-to-end spot-checks (payload sent, byte landing confirmed against the label):

| endpoint | class | check |
|---|---|---|
| `basic-level1` | reflected-html | `<script>alert(1)</script>` reflected raw |
| `basic-level5` | reflected-html | `alert(1)` → `alert1` (parens stripped, needs backtick) |
| `charlimit-level4` | reflected-html | `<img src=x onerror=alert` + backtick survives |
| `inattr-xss-level2` | reflected-attr | single-quote breakout out of `class='…'` |
| `inframe-xss-level1` | reflected-attr (`iframe.src`) | `javascript:alert(1)` lands in frame src (param `url`) |
| `mediacontext-level1` | reflected-attr | `"><img onerror>` breaks out of `video src` |
| `jsctx-level1` | reflected-js | value lands raw in `var x = "…"` |
| `encodingedge-level3` | reflected-attr | first `"`→`&quot;`, second raw → attribute breakout |
| `tagattrmix-level6` | reflected-attr | single-quoted `url('…')` inside style attr |
| `decode-level1` | reflected-html | base64 of `<img…>` decodes and reflects |
| `noscript-level2` | dom (`textContent`→`innerHTML`) | raw in `<noscript>`, JS relays to `#out` |
| `modern-level4` | dom (`location.search`→`innerHTML`) | server copy entity-encoded (decoy); client re-reads raw `?query` |
| `modern-level6` | reflected-js | `wsurl` lands raw in `new WebSocket('…')` |
| `regexbypass-level5` | reflected-js | value in single-quoted JS string, `innerHTML` sink |
| `modern-bypass-level20` | reflected-html | double-URL-decode: `%253Cimg…` → `<img…>` past the WAF |
| `css-injection-level1` | reflected-html | `</style><script>` closes the style block |
| `storedpat-level3` | stored | `review=` breaks out of `<meta og:description content="…">` |

## For the reviewer to double-check

- The two `exploitable: false` calls above (they move the scoring denominator).
- **Category-name traps I classified against the handler, not the name:** the `css-injection-*`
  levels are `reflected-html`/`reflected-attr` (a `javascript:`/`expression()` CSS URL does
  **not** execute in a modern browser; the live path is closing `</style>` or breaking out of
  the `data-content` attribute), and the `racecon-*` levels have no actual race — they are
  ordinary raw-text/element reflections.
- `modern-bypass-level13` (SVG path `d=`) — classified `reflected-attr` (single-quoted
  attribute is directly breakable) with `sinks: ["eval"]` noted for the no-breakout
  `d`-contains-`xss:` client path; either reading is defensible.
- A few CSTI/clobbering/prototype-pollution levels depend on an external CDN
  (jsDelivr / googleapis) being reachable to actually fire; noted where relevant.

Files: only the 34 slice-T1 files under `src/mazes/`. No `README`/`CHANGELOG`/`AGENTS.md`
or shared source touched.
