### PR TITLE
feat(mazes): triage vulnerability metadata for slice T3 (209 endpoints)

### DIFF
--- a/src/mazes/advanced_html5_sanitizer_bypass.cr
+++ b/src/mazes/advanced_html5_sanitizer_bypass.cr
@@ -55,8 +55,8 @@ require "html"
 Xssmaze.push(
   "html5-sanitizer-level1",
   "/html5-sanitizer/level1/?query=a",
-  "Mock sanitizer: strips <script>/<iframe>/<object> but allows MathML structures"
-)
+  "Mock sanitizer: strips <script>/<iframe>/<object> but allows MathML structures",
+  vuln: "reflected-html", delivery: ["query"], note: "server reflects raw into a <div>; the tag/event blacklist misses MathML namespace vectors")
 maze_get "/html5-sanitizer/level1/" do |env|
   query = env.params.query["query"]
 
@@ -83,8 +83,8 @@ end
 Xssmaze.push(
   "html5-sanitizer-level2",
   "/html5-sanitizer/level2/?query=a",
-  "Parser differential: <math><xmp><iframe srcdoc=...></xmp></math> namespace confusion"
-)
+  "Parser differential: <math><xmp><iframe srcdoc=...></xmp></math> namespace confusion",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; the recursive script/event/js: filters miss the math/xmp/iframe-srcdoc parser differential")
 maze_get "/html5-sanitizer/level2/" do |env|
   query = env.params.query["query"]
 
@@ -127,8 +127,8 @@ end
 Xssmaze.push(
   "html5-sanitizer-level3",
   "/html5-sanitizer/level3/?query=a",
-  "MathML annotation-xml encoding=text/html with iframe srcdoc bypass"
-)
+  "MathML annotation-xml encoding=text/html with iframe srcdoc bypass",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; iframe is stripped in HTML context but annotation-xml switches to HTML parsing")
 maze_get "/html5-sanitizer/level3/" do |env|
   query = env.params.query["query"]
 
@@ -151,8 +151,8 @@ end
 Xssmaze.push(
   "html5-sanitizer-level4",
   "/html5-sanitizer/level4/?query=a",
-  "Template + MathML double namespace confusion with srcdoc"
-)
+  "Template + MathML double namespace confusion with srcdoc",
+  vuln: "reflected-js", sinks: ["innerHTML"], delivery: ["query"], note: "reflected raw into a backtick template literal, then assigned to innerHTML; break out with a backtick or use ${...}")
 maze_get "/html5-sanitizer/level4/" do |env|
   query = env.params.query["query"]
 
@@ -180,8 +180,8 @@ end
 Xssmaze.push(
   "html5-sanitizer-level5",
   "/html5-sanitizer/level5/?query=a",
-  "SVG foreignObject + MathML namespace chain with srcdoc bypass"
-)
+  "SVG foreignObject + MathML namespace chain with srcdoc bypass",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; script/js: filters miss the SVG foreignObject to MathML namespace chain")
 maze_get "/html5-sanitizer/level5/" do |env|
   query = env.params.query["query"]
 
@@ -205,8 +205,8 @@ end
 Xssmaze.push(
   "html5-sanitizer-level6",
   "/html5-sanitizer/level6/?query=a",
-  "MathML with form element name collision + srcdoc XSS"
-)
+  "MathML with form element name collision + srcdoc XSS",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; leaves the MathML form-name-clobbering + iframe srcdoc vector")
 maze_get "/html5-sanitizer/level6/" do |env|
   query = env.params.query["query"]
 
@@ -234,8 +234,8 @@ end
 Xssmaze.push(
   "html5-sanitizer-level7",
   "/html5-sanitizer/level7/?query=a",
-  "MathML + srcdoc with data URI base64 encoding bypass"
-)
+  "MathML + srcdoc with data URI base64 encoding bypass",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; the single data:/script strip is bypassable with entity-encoded data: URIs")
 maze_get "/html5-sanitizer/level7/" do |env|
   query = env.params.query["query"]
 
@@ -260,8 +260,8 @@ end
 Xssmaze.push(
   "html5-sanitizer-level8",
   "/html5-sanitizer/level8/?query=a",
-  "Shadow DOM slot + MathML namespace with srcdoc bypass"
-)
+  "Shadow DOM slot + MathML namespace with srcdoc bypass",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; script/event filters miss the declarative-shadow-DOM template vector")
 maze_get "/html5-sanitizer/level8/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/aria_attr_xss.cr
+++ b/src/mazes/aria_attr_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflected in <div role="alert" aria-label="QUERY">
 # Bypass: break out of aria-label with " then inject event handler
-Xssmaze.push("ariaattr-level1", "/ariaattr/level1/?query=a", "reflection in aria-label attribute (double-quoted)")
+Xssmaze.push("ariaattr-level1", "/ariaattr/level1/?query=a", "reflection in aria-label attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ end
 
 # Level 2: Reflected in <input aria-describedby="QUERY" type="text">
 # Bypass: break out of aria-describedby with " then inject event handler
-Xssmaze.push("ariaattr-level2", "/ariaattr/level2/?query=a", "reflection in aria-describedby attribute (double-quoted)")
+Xssmaze.push("ariaattr-level2", "/ariaattr/level2/?query=a", "reflection in aria-describedby attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level2/" do |env|
   query = env.params.query["query"]
 
@@ -22,7 +24,8 @@ end
 
 # Level 3: Reflected in <span aria-live="polite" aria-atomic="QUERY">
 # Bypass: break out of aria-atomic with " then inject event handler
-Xssmaze.push("ariaattr-level3", "/ariaattr/level3/?query=a", "reflection in aria-atomic attribute (double-quoted)")
+Xssmaze.push("ariaattr-level3", "/ariaattr/level3/?query=a", "reflection in aria-atomic attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level3/" do |env|
   query = env.params.query["query"]
 
@@ -33,7 +36,8 @@ end
 
 # Level 4: Reflected in <div role="tooltip" aria-hidden="QUERY">
 # Bypass: break out of aria-hidden with " then inject event handler
-Xssmaze.push("ariaattr-level4", "/ariaattr/level4/?query=a", "reflection in aria-hidden attribute (double-quoted)")
+Xssmaze.push("ariaattr-level4", "/ariaattr/level4/?query=a", "reflection in aria-hidden attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level4/" do |env|
   query = env.params.query["query"]
 
@@ -44,7 +48,8 @@ end
 
 # Level 5: Reflected in <nav aria-label="QUERY">
 # Bypass: break out of aria-label with " then inject event handler
-Xssmaze.push("ariaattr-level5", "/ariaattr/level5/?query=a", "reflection in nav aria-label attribute (double-quoted)")
+Xssmaze.push("ariaattr-level5", "/ariaattr/level5/?query=a", "reflection in nav aria-label attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level5/" do |env|
   query = env.params.query["query"]
 
@@ -57,7 +62,8 @@ end
 
 # Level 6: Reflected in <div role="QUERY" aria-relevant="additions">
 # Bypass: break out of role with " then inject event handler
-Xssmaze.push("ariaattr-level6", "/ariaattr/level6/?query=a", "reflection in role attribute (double-quoted)")
+Xssmaze.push("ariaattr-level6", "/ariaattr/level6/?query=a", "reflection in role attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/case_manipulation_xss.cr
+++ b/src/mazes/case_manipulation_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Server lowercases only tag names (replaces <[A-Z]+ with lowercase)
 # but not attributes - standard lowercase payloads work fine
-Xssmaze.push("casemanip-level1", "/casemanip/level1/?query=a", "lowercase tag names only, attributes untouched")
+Xssmaze.push("casemanip-level1", "/casemanip/level1/?query=a", "lowercase tag names only, attributes untouched",
+  vuln: "reflected-html", delivery: ["query"], note: "only tag names are lowercased; lowercase payloads reflect unchanged into the body")
 maze_get "/casemanip/level1/" do |env|
   query = env.params.query["query"]
   # Lowercase only the tag name portion: <TAG -> <tag
@@ -14,7 +15,8 @@ end
 
 # Level 2: Server capitalizes first letter of input, rest unchanged
 # <img src=x onerror=alert(1)> becomes <Img src=x onerror=alert(1)> which is valid HTML
-Xssmaze.push("casemanip-level2", "/casemanip/level2/?query=a", "capitalize first letter only, HTML still valid")
+Xssmaze.push("casemanip-level2", "/casemanip/level2/?query=a", "capitalize first letter only, HTML still valid",
+  vuln: "reflected-html", delivery: ["query"], note: "only the first letter is uppercased; <Img ...> is still valid HTML")
 maze_get "/casemanip/level2/" do |env|
   query = env.params.query["query"]
   result = if query.size > 0
@@ -28,7 +30,8 @@ end
 
 # Level 3: Server swaps case of all alpha chars
 # HTML is case-insensitive so swapped tags still work
-Xssmaze.push("casemanip-level3", "/casemanip/level3/?query=a", "swap case of all alpha chars, HTML case-insensitive")
+Xssmaze.push("casemanip-level3", "/casemanip/level3/?query=a", "swap case of all alpha chars, HTML case-insensitive",
+  vuln: "reflected-html", delivery: ["query"], note: "case is swapped, but HTML tags are case-insensitive")
 maze_get "/casemanip/level3/" do |env|
   query = env.params.query["query"]
   result = query.chars.map do |ch|
@@ -46,7 +49,8 @@ end
 
 # Level 4: Server ROT13 encodes alpha chars in displayed output
 # BUT also reflects original unmodified query in a hidden input - exploitable
-Xssmaze.push("casemanip-level4", "/casemanip/level4/?query=a", "ROT13 display but raw reflection in hidden input")
+Xssmaze.push("casemanip-level4", "/casemanip/level4/?query=a", "ROT13 display but raw reflection in hidden input",
+  vuln: "reflected-attr", delivery: ["query"], note: "the ROT13 body copy is a decoy; the raw value is reflected into a hidden input value attribute")
 maze_get "/casemanip/level4/" do |env|
   query = env.params.query["query"]
   rot13 = query.chars.map do |ch|
@@ -64,7 +68,8 @@ end
 
 # Level 5: Server strips uppercase letters only, leaves lowercase and everything else
 # Use all-lowercase payload: <img src=x onerror=alert(1)>
-Xssmaze.push("casemanip-level5", "/casemanip/level5/?query=a", "strip uppercase letters only, lowercase payloads work")
+Xssmaze.push("casemanip-level5", "/casemanip/level5/?query=a", "strip uppercase letters only, lowercase payloads work",
+  vuln: "reflected-html", delivery: ["query"], note: "only uppercase letters are stripped; an all-lowercase payload survives")
 maze_get "/casemanip/level5/" do |env|
   query = env.params.query["query"]
   result = query.gsub(/[A-Z]/, "")
@@ -74,7 +79,8 @@ end
 
 # Level 6: Server titlecases words (first letter of each word uppercase)
 # HTML tags still work since they are case-insensitive
-Xssmaze.push("casemanip-level6", "/casemanip/level6/?query=a", "titlecase words, HTML case-insensitive")
+Xssmaze.push("casemanip-level6", "/casemanip/level6/?query=a", "titlecase words, HTML case-insensitive",
+  vuln: "reflected-html", delivery: ["query"], note: "words are title-cased, but HTML tags are case-insensitive")
 maze_get "/casemanip/level6/" do |env|
   query = env.params.query["query"]
   result = query.split(" ").map do |word|

--- a/src/mazes/comment_injection_xss.cr
+++ b/src/mazes/comment_injection_xss.cr
@@ -1,33 +1,38 @@
 # Level 1: Reflected inside HTML comment <!-- QUERY --> - close comment with --> then inject HTML
-Xssmaze.push("commentinj-level1", "/commentinj/level1/?query=a", "reflected inside HTML comment")
+Xssmaze.push("commentinj-level1", "/commentinj/level1/?query=a", "reflected inside HTML comment",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside an HTML comment; close it with --> to inject markup")
 maze_get "/commentinj/level1/" do |env|
   query = env.params.query["query"]
   "<html><body><!-- #{query} --><p>Safe content</p></body></html>"
 end
 
 # Level 2: Reflected inside /* QUERY */ in a script tag - close comment with */ then </script> then inject
-Xssmaze.push("commentinj-level2", "/commentinj/level2/?query=a", "reflected inside JS block comment in script tag")
+Xssmaze.push("commentinj-level2", "/commentinj/level2/?query=a", "reflected inside JS block comment in script tag",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected inside a /* */ block comment in a <script>; close the comment or the </script>")
 maze_get "/commentinj/level2/" do |env|
   query = env.params.query["query"]
   "<html><body><script>/* #{query} */var x=1;</script><p>Safe content</p></body></html>"
 end
 
 # Level 3: Reflected inside // QUERY single-line JS comment in script - newline then </script> then inject
-Xssmaze.push("commentinj-level3", "/commentinj/level3/?query=a", "reflected inside JS single-line comment in script tag")
+Xssmaze.push("commentinj-level3", "/commentinj/level3/?query=a", "reflected inside JS single-line comment in script tag",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected inside a // line comment in a <script>; a newline or </script> ends it")
 maze_get "/commentinj/level3/" do |env|
   query = env.params.query["query"]
   "<html><body><script>// #{query}\nvar x=1;</script><p>Safe content</p></body></html>"
 end
 
 # Level 4: Reflected inside conditional comment <!--[if IE]>QUERY<![endif]--> - close with <![endif]--> then inject
-Xssmaze.push("commentinj-level4", "/commentinj/level4/?query=a", "reflected inside conditional comment")
+Xssmaze.push("commentinj-level4", "/commentinj/level4/?query=a", "reflected inside conditional comment",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside a downlevel conditional comment; close it with <![endif]--> to inject markup")
 maze_get "/commentinj/level4/" do |env|
   query = env.params.query["query"]
   "<html><body><!--[if IE]>#{query}<![endif]--><p>Safe content</p></body></html>"
 end
 
 # Level 5: Reflected inside HTML comment but --> is stripped (single pass) - use --!> which also closes comments
-Xssmaze.push("commentinj-level5", "/commentinj/level5/?query=a", "reflected inside HTML comment with --> stripped (use --!> to close)")
+Xssmaze.push("commentinj-level5", "/commentinj/level5/?query=a", "reflected inside HTML comment with --> stripped (use --!> to close)",
+  vuln: "reflected-html", delivery: ["query"], note: "--> is stripped once; --!> also closes the HTML comment")
 maze_get "/commentinj/level5/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("-->", "")
@@ -35,7 +40,8 @@ maze_get "/commentinj/level5/" do |env|
 end
 
 # Level 6: Reflected inside JS block comment in script tag (both * and / allowed) - close comment then close script
-Xssmaze.push("commentinj-level6", "/commentinj/level6/?query=a", "reflected inside JS block comment - close comment and script tag")
+Xssmaze.push("commentinj-level6", "/commentinj/level6/?query=a", "reflected inside JS block comment - close comment and script tag",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected inside a /* */ block comment in a <script>; close the comment then the </script>")
 maze_get "/commentinj/level6/" do |env|
   query = env.params.query["query"]
   "<html><body><script>/* #{query} */</script><p>Safe content</p></body></html>"

--- a/src/mazes/context_escape_v2_xss.cr
+++ b/src/mazes/context_escape_v2_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Reflection inside an HTML comment <!-- QUERY -->
 # Bypass: close the comment with --> then inject HTML
 # e.g. --><script>alert(1)</script><!-- or --><img src=x onerror=alert(1)>
-Xssmaze.push("ctxv2-level1", "/ctxv2/level1/?query=a", "reflection inside HTML comment (close with -->)")
+Xssmaze.push("ctxv2-level1", "/ctxv2/level1/?query=a", "reflection inside HTML comment (close with -->)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside an HTML comment; close it with -->")
 maze_get "/ctxv2/level1/" do |env|
   query = env.params.query["query"]
 
@@ -12,7 +13,8 @@ end
 # Content inside <textarea> is treated as raw text by the HTML parser.
 # Bypass: close the textarea first with </textarea> then inject HTML
 # e.g. </textarea><script>alert(1)</script>
-Xssmaze.push("ctxv2-level2", "/ctxv2/level2/?query=a", "reflection inside textarea tag (close tag escape)")
+Xssmaze.push("ctxv2-level2", "/ctxv2/level2/?query=a", "reflection inside textarea tag (close tag escape)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside <textarea> raw-text; close it with </textarea>")
 maze_get "/ctxv2/level2/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +25,8 @@ end
 # Content inside <title> is treated as raw text by the HTML parser.
 # Bypass: close the title first with </title> then inject HTML
 # e.g. </title><script>alert(1)</script>
-Xssmaze.push("ctxv2-level3", "/ctxv2/level3/?query=a", "reflection inside title tag (close tag escape)")
+Xssmaze.push("ctxv2-level3", "/ctxv2/level3/?query=a", "reflection inside title tag (close tag escape)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside <title> raw-text; close it with </title>")
 maze_get "/ctxv2/level3/" do |env|
   query = env.params.query["query"]
 
@@ -34,7 +37,8 @@ end
 # Content inside <style> is treated as raw text by the HTML parser.
 # Bypass: close the style tag with </style> then inject HTML
 # e.g. </style><script>alert(1)</script>
-Xssmaze.push("ctxv2-level4", "/ctxv2/level4/?query=a", "reflection inside style tag (close tag escape)")
+Xssmaze.push("ctxv2-level4", "/ctxv2/level4/?query=a", "reflection inside style tag (close tag escape)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside <style>; close it with </style> to inject markup")
 maze_get "/ctxv2/level4/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +49,8 @@ end
 # Content inside <noscript> is parsed as raw text when scripting is enabled.
 # Bypass: close the noscript tag with </noscript> then inject HTML
 # e.g. </noscript><script>alert(1)</script>
-Xssmaze.push("ctxv2-level5", "/ctxv2/level5/?query=a", "reflection inside noscript tag (close tag escape)")
+Xssmaze.push("ctxv2-level5", "/ctxv2/level5/?query=a", "reflection inside noscript tag (close tag escape)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside <noscript>; close it with </noscript>")
 maze_get "/ctxv2/level5/" do |env|
   query = env.params.query["query"]
 
@@ -59,7 +64,8 @@ end
 # survive encoding and get decoded when the browser parses the srcdoc HTML.
 # Bypass: use HTML entities e.g. &lt;img src=x onerror=alert(1)&gt;
 # which the server leaves as-is (& not encoded), and the browser decodes inside srcdoc.
-Xssmaze.push("ctxv2-level6", "/ctxv2/level6/?query=a", "reflection in iframe srcdoc (HTML entity injection via unescaped &)")
+Xssmaze.push("ctxv2-level6", "/ctxv2/level6/?query=a", "reflection in iframe srcdoc (HTML entity injection via unescaped &)",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into an iframe srcdoc; < and > are entity-encoded but the quote and & are not, so break the attribute or send pre-encoded entities that decode inside the srcdoc")
 maze_get "/ctxv2/level6/" do |env|
   query = env.params.query["query"]
   # Encode < and > to prevent direct attribute breakout, but leave & intact

--- a/src/mazes/context_escape_xss.cr
+++ b/src/mazes/context_escape_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Double-quoted JS string, single quote allowed, </script> allowed
 # Break out with: </script><img src=x onerror=alert(1)>
 # Or: ";alert(1);//
-Xssmaze.push("ctxescape-level1", "/ctxescape/level1/?query=a", "double-quoted JS, single quote + close-script allowed")
+Xssmaze.push("ctxescape-level1", "/ctxescape/level1/?query=a", "double-quoted JS, single quote + close-script allowed",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected into a double-quoted JS string; the quote is backslash-escaped, so close the </script> or use a single quote")
 maze_get "/ctxescape/level1/" do |env|
   query = env.params.query["query"]
   escaped = query.gsub("\"", "\\\"")
@@ -11,7 +12,8 @@ end
 
 # Level 2: Template literal (backtick) JS context
 # Input inside `${...}` is safe, but closing backtick allows injection
-Xssmaze.push("ctxescape-level2", "/ctxescape/level2/?query=a", "JS template literal context")
+Xssmaze.push("ctxescape-level2", "/ctxescape/level2/?query=a", "JS template literal context",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected inside a backtick template literal; ${...} evaluates without closing the string")
 maze_get "/ctxescape/level2/" do |env|
   query = env.params.query["query"]
 
@@ -19,7 +21,8 @@ maze_get "/ctxescape/level2/" do |env|
 end
 
 # Level 3: CSS url() function context
-Xssmaze.push("ctxescape-level3", "/ctxescape/level3/?query=a", "CSS url() function injection")
+Xssmaze.push("ctxescape-level3", "/ctxescape/level3/?query=a", "CSS url() function injection",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside a <style> url(); close the quote and </style> to inject markup (CSS itself does not execute)")
 maze_get "/ctxescape/level3/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +30,8 @@ maze_get "/ctxescape/level3/" do |env|
 end
 
 # Level 4: HTML comment context, -- not stripped
-Xssmaze.push("ctxescape-level4", "/ctxescape/level4/?query=a", "HTML comment context (-- allowed)")
+Xssmaze.push("ctxescape-level4", "/ctxescape/level4/?query=a", "HTML comment context (-- allowed)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside an HTML comment; close it with -->")
 maze_get "/ctxescape/level4/" do |env|
   query = env.params.query["query"]
 
@@ -35,7 +39,8 @@ maze_get "/ctxescape/level4/" do |env|
 end
 
 # Level 5: Reflection after = in unquoted attribute, space creates new attribute
-Xssmaze.push("ctxescape-level5", "/ctxescape/level5/?query=a", "unquoted attribute value (space breaks out)")
+Xssmaze.push("ctxescape-level5", "/ctxescape/level5/?query=a", "unquoted attribute value (space breaks out)",
+  vuln: "reflected-attr", delivery: ["query"], note: "unquoted input attribute with angle brackets stripped; add a space and an event-handler attribute")
 maze_get "/ctxescape/level5/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
 
@@ -43,7 +48,8 @@ maze_get "/ctxescape/level5/" do |env|
 end
 
 # Level 6: Inside JS block comment /* ... */
-Xssmaze.push("ctxescape-level6", "/ctxescape/level6/?query=a", "JS block comment context")
+Xssmaze.push("ctxescape-level6", "/ctxescape/level6/?query=a", "JS block comment context",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected inside a /* */ block comment in a <script>")
 maze_get "/ctxescape/level6/" do |env|
   query = env.params.query["query"]
 
@@ -51,7 +57,8 @@ maze_get "/ctxescape/level6/" do |env|
 end
 
 # Level 7: JS single-line comment // (newline injection)
-Xssmaze.push("ctxescape-level7", "/ctxescape/level7/?query=a", "JS line comment context (newline escape)")
+Xssmaze.push("ctxescape-level7", "/ctxescape/level7/?query=a", "JS line comment context (newline escape)",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected inside a // line comment in a <script>")
 maze_get "/ctxescape/level7/" do |env|
   query = env.params.query["query"]
 
@@ -59,7 +66,8 @@ maze_get "/ctxescape/level7/" do |env|
 end
 
 # Level 8: Reflection inside <pre> tag (HTML context, but encoded)
-Xssmaze.push("ctxescape-level8", "/ctxescape/level8/?query=a", "pre tag body reflection (raw HTML)")
+Xssmaze.push("ctxescape-level8", "/ctxescape/level8/?query=a", "pre tag body reflection (raw HTML)",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/ctxescape/level8/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/dashboard_xss.cr
+++ b/src/mazes/dashboard_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Dashboard card title - raw reflection in card-header div
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("dashboard-level1", "/dashboard/level1/?query=a", "dashboard card header raw reflection")
+Xssmaze.push("dashboard-level1", "/dashboard/level1/?query=a", "dashboard card header raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ end
 # Level 2: Admin table cell - dual reflection in title attribute AND body
 # Bypass: break out of title attribute with " or inject in body directly
 # e.g. "><script>alert(1)</script> or just <script>alert(1)</script>
-Xssmaze.push("dashboard-level2", "/dashboard/level2/?query=a", "admin table cell dual reflection (attr + body)")
+Xssmaze.push("dashboard-level2", "/dashboard/level2/?query=a", "admin table cell dual reflection (attr + body)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into both a title attribute and the cell body; the body is a direct HTML injection")
 maze_get "/dashboard/level2/" do |env|
   query = env.params.query["query"]
 
@@ -19,7 +21,8 @@ end
 
 # Level 3: Notification alert - raw reflection in alert div
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("dashboard-level3", "/dashboard/level3/?query=a", "notification alert raw reflection")
+Xssmaze.push("dashboard-level3", "/dashboard/level3/?query=a", "notification alert raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level3/" do |env|
   query = env.params.query["query"]
 
@@ -28,7 +31,8 @@ end
 
 # Level 4: Sidebar menu item - raw reflection in nav-link anchor
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("dashboard-level4", "/dashboard/level4/?query=a", "sidebar nav-link raw reflection")
+Xssmaze.push("dashboard-level4", "/dashboard/level4/?query=a", "sidebar nav-link raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level4/" do |env|
   query = env.params.query["query"]
 
@@ -37,7 +41,8 @@ end
 
 # Level 5: Modal body content - raw reflection in modal-body paragraph
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("dashboard-level5", "/dashboard/level5/?query=a", "modal body raw reflection")
+Xssmaze.push("dashboard-level5", "/dashboard/level5/?query=a", "modal body raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level5/" do |env|
   query = env.params.query["query"]
 
@@ -46,7 +51,8 @@ end
 
 # Level 6: Status badge - raw reflection in badge span
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("dashboard-level6", "/dashboard/level6/?query=a", "status badge raw reflection")
+Xssmaze.push("dashboard-level6", "/dashboard/level6/?query=a", "status badge raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/dataurl_xss.cr
+++ b/src/mazes/dataurl_xss.cr
@@ -1,22 +1,26 @@
-Xssmaze.push("dataurl-level1", "/dataurl/level1/?query=a", "anchor href with data:text/html under user control (executes on click)")
+Xssmaze.push("dataurl-level1", "/dataurl/level1/?query=a", "anchor href with data:text/html under user control (executes on click)",
+  vuln: "reflected-attr", delivery: ["query"], note: "single-quoted anchor href holding a data:text/html URL; on click the browser renders the reflected bytes as their own HTML document")
 maze_get "/dataurl/level1/" do |env|
   query = env.params.query["query"]
   "<a href='data:text/html,#{query}'>open</a>"
 end
 
-Xssmaze.push("dataurl-level2", "/dataurl/level2/?query=a", "iframe src=data:text/html with reflected body")
+Xssmaze.push("dataurl-level2", "/dataurl/level2/?query=a", "iframe src=data:text/html with reflected body",
+  vuln: "reflected-attr", delivery: ["query"], note: "iframe src=data:text/html; the reflected bytes render as the iframe own HTML document on load")
 maze_get "/dataurl/level2/" do |env|
   query = env.params.query["query"]
   "<iframe src='data:text/html;charset=utf-8,#{query}'></iframe>"
 end
 
-Xssmaze.push("dataurl-level3", "/dataurl/level3/?query=a", "object data=data:text/html with reflected payload")
+Xssmaze.push("dataurl-level3", "/dataurl/level3/?query=a", "object data=data:text/html with reflected payload",
+  vuln: "reflected-attr", delivery: ["query"], note: "object data=data:text/html; the reflected bytes render as the object document")
 maze_get "/dataurl/level3/" do |env|
   query = env.params.query["query"]
   "<object data='data:text/html,#{query}'></object>"
 end
 
-Xssmaze.push("dataurl-level4", "/dataurl/level4/?query=a", "embed src=data:text/html with reflected payload")
+Xssmaze.push("dataurl-level4", "/dataurl/level4/?query=a", "embed src=data:text/html with reflected payload",
+  vuln: "reflected-attr", delivery: ["query"], note: "embed src=data:text/html; the reflected bytes render as the embedded document")
 maze_get "/dataurl/level4/" do |env|
   query = env.params.query["query"]
   "<embed src='data:text/html,#{query}'>"

--- a/src/mazes/email_template_xss.cr
+++ b/src/mazes/email_template_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Welcome email - raw reflection in table cell h2
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("email-template-level1", "/email-template/level1/?query=a", "welcome email raw reflection in table cell")
+Xssmaze.push("email-template-level1", "/email-template/level1/?query=a", "welcome email raw reflection in table cell",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/email-template/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: Password reset link - reflection inside href attribute
 # Bypass: break out of href with ", e.g. "><script>alert(1)</script>
-Xssmaze.push("email-template-level2", "/email-template/level2/?query=a", "password reset link reflection in href attribute")
+Xssmaze.push("email-template-level2", "/email-template/level2/?query=a", "password reset link reflection in href attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into a double-quoted href; break out with the quote")
 maze_get "/email-template/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ end
 
 # Level 3: Order confirmation - raw reflection in product name table cell
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("email-template-level3", "/email-template/level3/?query=a", "order confirmation raw reflection in table cell")
+Xssmaze.push("email-template-level3", "/email-template/level3/?query=a", "order confirmation raw reflection in table cell",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/email-template/level3/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +30,8 @@ end
 
 # Level 4: Newsletter article - raw reflection in article heading
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("email-template-level4", "/email-template/level4/?query=a", "newsletter article heading raw reflection")
+Xssmaze.push("email-template-level4", "/email-template/level4/?query=a", "newsletter article heading raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/email-template/level4/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +40,8 @@ end
 
 # Level 5: Alert notification - raw reflection in colored table cell
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("email-template-level5", "/email-template/level5/?query=a", "alert notification raw reflection in colored cell")
+Xssmaze.push("email-template-level5", "/email-template/level5/?query=a", "alert notification raw reflection in colored cell",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/email-template/level5/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +50,8 @@ end
 
 # Level 6: Invoice - raw reflection in description cell of complex table
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("email-template-level6", "/email-template/level6/?query=a", "invoice description cell raw reflection in complex table")
+Xssmaze.push("email-template-level6", "/email-template/level6/?query=a", "invoice description cell raw reflection in complex table",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/email-template/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/error_handling_xss.cr
+++ b/src/mazes/error_handling_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Try-catch style error boundary with raw reflection
-Xssmaze.push("errhandling-level1", "/errhandling/level1/?query=a", "error boundary with raw reflection in error message")
+Xssmaze.push("errhandling-level1", "/errhandling/level1/?query=a", "error boundary with raw reflection in error message",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errhandling/level1/" do |env|
   query = env.params.query["query"]
 
@@ -13,7 +14,8 @@ maze_get "/errhandling/level1/" do |env|
 end
 
 # Level 2: Stack trace style with query reflected in the 3rd frame
-Xssmaze.push("errhandling-level2", "/errhandling/level2/?query=a", "stack trace with raw reflection in third frame")
+Xssmaze.push("errhandling-level2", "/errhandling/level2/?query=a", "stack trace with raw reflection in third frame",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errhandling/level2/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +33,8 @@ maze_get "/errhandling/level2/" do |env|
 end
 
 # Level 3: Form validation error with raw reflection
-Xssmaze.push("errhandling-level3", "/errhandling/level3/?query=a", "form validation error with raw reflection in alert span")
+Xssmaze.push("errhandling-level3", "/errhandling/level3/?query=a", "form validation error with raw reflection in alert span",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errhandling/level3/" do |env|
   query = env.params.query["query"]
 
@@ -47,7 +50,8 @@ maze_get "/errhandling/level3/" do |env|
 end
 
 # Level 4: API error response in pre block (served as text/html)
-Xssmaze.push("errhandling-level4", "/errhandling/level4/?query=a", "API error response in pre tag with raw JSON-like reflection")
+Xssmaze.push("errhandling-level4", "/errhandling/level4/?query=a", "API error response in pre tag with raw JSON-like reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "served as text/html, so tags in the value render despite the JSON wrapper")
 maze_get "/errhandling/level4/" do |env|
   query = env.params.query["query"]
 
@@ -59,7 +63,8 @@ maze_get "/errhandling/level4/" do |env|
 end
 
 # Level 5: Permission denied page with raw reflection
-Xssmaze.push("errhandling-level5", "/errhandling/level5/?query=a", "permission denied page with raw reflection in resource path")
+Xssmaze.push("errhandling-level5", "/errhandling/level5/?query=a", "permission denied page with raw reflection in resource path",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errhandling/level5/" do |env|
   query = env.params.query["query"]
 
@@ -74,7 +79,8 @@ maze_get "/errhandling/level5/" do |env|
 end
 
 # Level 6: Rate limit page with raw reflection
-Xssmaze.push("errhandling-level6", "/errhandling/level6/?query=a", "rate limit page with raw reflection in IP/source field")
+Xssmaze.push("errhandling-level6", "/errhandling/level6/?query=a", "rate limit page with raw reflection in IP/source field",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errhandling/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/filter_chain_xss.cr
+++ b/src/mazes/filter_chain_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Strip <script>, <img>, <svg> tags but allow <details>, <select>, <input>
-Xssmaze.push("filterchain-level1", "/filterchain/level1/?query=a", "common tag blacklist (script/img/svg stripped)")
+Xssmaze.push("filterchain-level1", "/filterchain/level1/?query=a", "common tag blacklist (script/img/svg stripped)",
+  vuln: "reflected-html", delivery: ["query"], note: "script/img/svg/iframe/object/embed/link/style stripped; use an allowed tag with an event handler (e.g. <details ontoggle>)")
 maze_get "/filterchain/level1/" do |env|
   query = Filters.strip_tags(env.params.query["query"], ["script", "img", "svg", "iframe", "object", "embed", "link", "style"])
 
@@ -7,7 +8,8 @@ maze_get "/filterchain/level1/" do |env|
 end
 
 # Level 2: Strip all event handlers + strip <script> tags
-Xssmaze.push("filterchain-level2", "/filterchain/level2/?query=a", "event handlers + script tags stripped")
+Xssmaze.push("filterchain-level2", "/filterchain/level2/?query=a", "event handlers + script tags stripped",
+  vuln: "reflected-html", delivery: ["query"], note: "event handlers and <script> stripped; use a non-event vector")
 maze_get "/filterchain/level2/" do |env|
   query = Filters.strip_event_handlers(env.params.query["query"])
   query = Filters.strip_tags(query, ["script"])
@@ -16,7 +18,8 @@ maze_get "/filterchain/level2/" do |env|
 end
 
 # Level 3: Lowercase conversion + strip "javascript:" + strip "data:" + attribute context
-Xssmaze.push("filterchain-level3", "/filterchain/level3/?query=a", "lowercase + protocol strip in href")
+Xssmaze.push("filterchain-level3", "/filterchain/level3/?query=a", "lowercase + protocol strip in href",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into a double-quoted href after lowercasing and js:/data: strip; break out of the attribute")
 maze_get "/filterchain/level3/" do |env|
   query = env.params.query["query"].downcase
   query = Filters.strip_js_protocol(query)
@@ -26,7 +29,8 @@ maze_get "/filterchain/level3/" do |env|
 end
 
 # Level 4: Encode < > to entities + strip " but allow ' (single quote attribute)
-Xssmaze.push("filterchain-level4", "/filterchain/level4/?query=a", "angle encode + double quote strip in single-quote attr")
+Xssmaze.push("filterchain-level4", "/filterchain/level4/?query=a", "angle encode + double quote strip in single-quote attr",
+  vuln: "reflected-attr", delivery: ["query"], note: "single-quoted class attribute; angle brackets entity-encoded and the double quote stripped, so break out with a single quote and add an event handler")
 maze_get "/filterchain/level4/" do |env|
   query = Filters.encode_angles(env.params.query["query"])
   query = query.gsub("\"", "")
@@ -36,7 +40,8 @@ end
 
 # Level 5: Strip parentheses + backtick + angle brackets, reflection in body
 # Requires payloads like: <img src=x onerror=alert`1`> won't work, need alternative
-Xssmaze.push("filterchain-level5", "/filterchain/level5/?query=a", "parens + backtick + angles all stripped")
+Xssmaze.push("filterchain-level5", "/filterchain/level5/?query=a", "parens + backtick + angles all stripped",
+  vuln: "reflected-attr", delivery: ["query"], note: "double-quoted class attribute; angle brackets, parens and backticks stripped, so break out and use a paren-free handler (e.g. onpointerover=location=name)")
 maze_get "/filterchain/level5/" do |env|
   query = env.params.query["query"]
   query = Filters.strip_angles(query)
@@ -48,7 +53,8 @@ end
 
 # Level 6: URL in attribute; strips javascript: / data: / vbscript:, allows http/https
 # Requires: attribute breakout with ">, or clever protocol bypass
-Xssmaze.push("filterchain-level6", "/filterchain/level6/?query=a", "protocol whitelist bypass in src")
+Xssmaze.push("filterchain-level6", "/filterchain/level6/?query=a", "protocol whitelist bypass in src",
+  vuln: "reflected-attr", delivery: ["query"], note: "double-quoted iframe src; js:/data:/vbscript: blacklisted, so break out with the quote and > or use a non-blacklisted protocol")
 maze_get "/filterchain/level6/" do |env|
   query = env.params.query["query"]
   query = Filters.strip_js_protocol(query)
@@ -59,7 +65,8 @@ maze_get "/filterchain/level6/" do |env|
 end
 
 # Level 7: strip < > and all quotes, reflection in unquoted attribute
-Xssmaze.push("filterchain-level7", "/filterchain/level7/?query=a", "angles+quotes stripped, unquoted attribute")
+Xssmaze.push("filterchain-level7", "/filterchain/level7/?query=a", "angles+quotes stripped, unquoted attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "unquoted input value; angle brackets and quotes removed, so add a space and an event-handler attribute")
 maze_get "/filterchain/level7/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
   query = Filters.escape_quotes(query)
@@ -68,7 +75,8 @@ maze_get "/filterchain/level7/" do |env|
 end
 
 # Level 8: Reflection in JS, strip </script> and backslash, single-quoted context
-Xssmaze.push("filterchain-level8", "/filterchain/level8/?query=a", "JS context: close-script + backslash stripped")
+Xssmaze.push("filterchain-level8", "/filterchain/level8/?query=a", "JS context: close-script + backslash stripped",
+  vuln: "reflected-js", delivery: ["query"], note: "single-quoted JS string; </script> and backslash stripped, so break out with a single quote")
 maze_get "/filterchain/level8/" do |env|
   query = env.params.query["query"]
   query = query.gsub("</script>", "").gsub("\\", "")

--- a/src/mazes/formaction_xss.cr
+++ b/src/mazes/formaction_xss.cr
@@ -1,22 +1,26 @@
-Xssmaze.push("formaction-level1", "/formaction/level1/?query=a", "<button formaction> raw reflection")
+Xssmaze.push("formaction-level1", "/formaction/level1/?query=a", "<button formaction> raw reflection",
+  vuln: "reflected-attr", delivery: ["query"], note: "single-quoted formaction; accepts a javascript: URL that fires when the button is clicked")
 maze_get "/formaction/level1/" do |env|
   query = env.params.query["query"]
   "<form action='/echo'><button formaction='#{query}'>submit</button></form>"
 end
 
-Xssmaze.push("formaction-level2", "/formaction/level2/?query=a", "<input type=image formaction>")
+Xssmaze.push("formaction-level2", "/formaction/level2/?query=a", "<input type=image formaction>",
+  vuln: "reflected-attr", delivery: ["query"], note: "formaction on an image input; fires on click")
 maze_get "/formaction/level2/" do |env|
   query = env.params.query["query"]
   "<form action='/echo'><input type='image' src='/img.png' formaction='#{query}'></form>"
 end
 
-Xssmaze.push("formaction-level3", "/formaction/level3/?query=a", "formaction with javascript: blocked literally only")
+Xssmaze.push("formaction-level3", "/formaction/level3/?query=a", "formaction with javascript: blocked literally only",
+  vuln: "reflected-attr", delivery: ["query"], note: "javascript: removed once and case-sensitively; bypass with mixed case or nesting, fires on click")
 maze_get "/formaction/level3/" do |env|
   query = env.params.query["query"].gsub("javascript:", "")
   "<form><button formaction='#{query}'>go</button></form>"
 end
 
-Xssmaze.push("formaction-level4", "/formaction/level4/?query=a", "form action attribute reflected")
+Xssmaze.push("formaction-level4", "/formaction/level4/?query=a", "form action attribute reflected",
+  vuln: "reflected-attr", delivery: ["query"], note: "form action; a javascript: URL fires on submit")
 maze_get "/formaction/level4/" do |env|
   query = env.params.query["query"]
   "<form action='#{query}' method='post'><input name='x'><button>go</button></form>"

--- a/src/mazes/global_attr_xss.cr
+++ b/src/mazes/global_attr_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflected in <div id="QUERY">
 # Break out of id attribute with "
-Xssmaze.push("globalattr-level1", "/globalattr/level1/?query=a", "reflection in div id attribute")
+Xssmaze.push("globalattr-level1", "/globalattr/level1/?query=a", "reflection in div id attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level1/" do |env|
   query = env.params.query["query"]
 
@@ -12,7 +13,8 @@ end
 
 # Level 2: Reflected in <p class="QUERY">
 # Break out of class attribute with "
-Xssmaze.push("globalattr-level2", "/globalattr/level2/?query=a", "reflection in p class attribute")
+Xssmaze.push("globalattr-level2", "/globalattr/level2/?query=a", "reflection in p class attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level2/" do |env|
   query = env.params.query["query"]
 
@@ -24,7 +26,8 @@ end
 
 # Level 3: Reflected in <span accesskey="QUERY">
 # Break out of accesskey attribute with "
-Xssmaze.push("globalattr-level3", "/globalattr/level3/?query=a", "reflection in span accesskey attribute")
+Xssmaze.push("globalattr-level3", "/globalattr/level3/?query=a", "reflection in span accesskey attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level3/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +39,8 @@ end
 
 # Level 4: Reflected in <div spellcheck="QUERY">
 # Break out of spellcheck attribute with "
-Xssmaze.push("globalattr-level4", "/globalattr/level4/?query=a", "reflection in div spellcheck attribute")
+Xssmaze.push("globalattr-level4", "/globalattr/level4/?query=a", "reflection in div spellcheck attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level4/" do |env|
   query = env.params.query["query"]
 
@@ -48,7 +52,8 @@ end
 
 # Level 5: Reflected in <p draggable="QUERY">
 # Break out of draggable attribute with "
-Xssmaze.push("globalattr-level5", "/globalattr/level5/?query=a", "reflection in p draggable attribute")
+Xssmaze.push("globalattr-level5", "/globalattr/level5/?query=a", "reflection in p draggable attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level5/" do |env|
   query = env.params.query["query"]
 
@@ -60,7 +65,8 @@ end
 
 # Level 6: Reflected in <div lang="QUERY">
 # Break out of lang attribute with "
-Xssmaze.push("globalattr-level6", "/globalattr/level6/?query=a", "reflection in div lang attribute")
+Xssmaze.push("globalattr-level6", "/globalattr/level6/?query=a", "reflection in div lang attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/html_unsafe_xss.cr
+++ b/src/mazes/html_unsafe_xss.cr
@@ -13,7 +13,8 @@
 
 # Level 1: Element.setHTMLUnsafe() fed from location.hash — the canonical
 # client-side source -> new sink flow, no quote breakout needed.
-Xssmaze.push("htmlunsafe-level1", "/htmlunsafe/level1/", "Element.setHTMLUnsafe() of location.hash", "GET", ["#hash"])
+Xssmaze.push("htmlunsafe-level1", "/htmlunsafe/level1/", "Element.setHTMLUnsafe() of location.hash", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["setHTMLUnsafe"], delivery: ["fragment"], note: "setHTMLUnsafe parses HTML with no sanitizer; <img onerror>/<svg onload> fire, inline <script> stays inert")
 maze_get "/htmlunsafe/level1/" do |_env|
   "<html><body>
   <h1>Preview</h1>
@@ -27,7 +28,8 @@ maze_get "/htmlunsafe/level1/" do |_env|
 end
 
 # Level 2: Element.setHTMLUnsafe() fed from a location.search query param.
-Xssmaze.push("htmlunsafe-level2", "/htmlunsafe/level2/?query=a", "Element.setHTMLUnsafe() of a location.search value")
+Xssmaze.push("htmlunsafe-level2", "/htmlunsafe/level2/?query=a", "Element.setHTMLUnsafe() of a location.search value",
+  vuln: "dom", sources: ["location.search"], sinks: ["setHTMLUnsafe"], delivery: ["query"], note: "the query param is read client-side and passed to setHTMLUnsafe")
 maze_get "/htmlunsafe/level2/" do |_env|
   "<html><body>
   <h1>Notes</h1>
@@ -42,7 +44,8 @@ end
 # Level 3: server-reflected value inlined into a JS string then handed to
 # setHTMLUnsafe(). The reflection is visible in the served HTML source, so
 # this is detectable as a reflected sink too.
-Xssmaze.push("htmlunsafe-level3", "/htmlunsafe/level3/?query=a", "server-reflected string passed to setHTMLUnsafe()")
+Xssmaze.push("htmlunsafe-level3", "/htmlunsafe/level3/?query=a", "server-reflected string passed to setHTMLUnsafe()",
+  vuln: "reflected-js", sinks: ["setHTMLUnsafe"], delivery: ["query"], note: "server reflects raw into a single-quoted JS string that is then passed to setHTMLUnsafe; break out with a single quote")
 maze_get "/htmlunsafe/level3/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -58,7 +61,8 @@ end
 
 # Level 4: Document.parseHTMLUnsafe() builds a detached Document from the
 # string; its parsed body nodes are then adopted into the live page.
-Xssmaze.push("htmlunsafe-level4", "/htmlunsafe/level4/?query=a", "Document.parseHTMLUnsafe() result appended to the page")
+Xssmaze.push("htmlunsafe-level4", "/htmlunsafe/level4/?query=a", "Document.parseHTMLUnsafe() result appended to the page",
+  vuln: "dom", sources: ["location.search"], sinks: ["parseHTMLUnsafe"], delivery: ["query"], note: "query read client-side, parsed by Document.parseHTMLUnsafe, then adopted into the page")
 maze_get "/htmlunsafe/level4/" do |_env|
   "<html><body>
   <h1>Importer</h1>
@@ -73,7 +77,8 @@ end
 
 # Level 5: ShadowRoot.setHTMLUnsafe() — the same sink on a web component's
 # shadow root, a common place real code reaches for the Unsafe variant.
-Xssmaze.push("htmlunsafe-level5", "/htmlunsafe/level5/", "ShadowRoot.setHTMLUnsafe() of location.hash", "GET", ["#hash"])
+Xssmaze.push("htmlunsafe-level5", "/htmlunsafe/level5/", "ShadowRoot.setHTMLUnsafe() of location.hash", "GET", ["#hash"],
+  vuln: "dom", sources: ["location.hash"], sinks: ["setHTMLUnsafe"], delivery: ["fragment"], note: "ShadowRoot.setHTMLUnsafe; fires inside the shadow root")
 maze_get "/htmlunsafe/level5/" do |_env|
   "<html><body>
   <h1>Widget</h1>
@@ -90,7 +95,8 @@ end
 # Level 6: Document.parseHTMLUnsafe() of an async fetch() API response — ties
 # the new sink to the modern fetch-response-into-sink data flow. The companion
 # /api route echoes the forwarded param raw as text/html.
-Xssmaze.push("htmlunsafe-level6", "/htmlunsafe/level6/?query=a", "Document.parseHTMLUnsafe() of a fetch() API response")
+Xssmaze.push("htmlunsafe-level6", "/htmlunsafe/level6/?query=a", "Document.parseHTMLUnsafe() of a fetch() API response",
+  vuln: "dom", sources: ["location.search", "fetch-response"], sinks: ["parseHTMLUnsafe"], delivery: ["query"], note: "query is forwarded to the level6 api, which echoes it raw as text/html; the fetch response is parsed by parseHTMLUnsafe")
 maze_get "/htmlunsafe/level6/" do |_env|
   "<html><body>
   <h1>Feed</h1>

--- a/src/mazes/inline_style_xss.cr
+++ b/src/mazes/inline_style_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Reflected in <div style="color: QUERY">
 # Bypass: break out of style attribute with " then inject event handler
 # e.g. red" onmouseover="alert(1)
-Xssmaze.push("inlinestyle-level1", "/inlinestyle/level1/?query=a", "reflection in inline style color value (double-quoted)")
+Xssmaze.push("inlinestyle-level1", "/inlinestyle/level1/?query=a", "reflection in inline style color value (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/inlinestyle/level1/" do |env|
   query = env.params.query["query"]
 
@@ -13,7 +14,8 @@ end
 # Level 2: Reflected in <p style="background-image: url('QUERY')">
 # Bypass: break out of url() with ' then out of style with "
 # e.g. x') " onmouseover="alert(1)
-Xssmaze.push("inlinestyle-level2", "/inlinestyle/level2/?query=a", "reflection inside url() in inline style (single-quoted url, double-quoted attr)")
+Xssmaze.push("inlinestyle-level2", "/inlinestyle/level2/?query=a", "reflection inside url() in inline style (single-quoted url, double-quoted attr)",
+  vuln: "reflected-attr", delivery: ["query"], note: "inside a single-quoted url() in a style attribute; close the single quote then break the attribute with the double quote")
 maze_get "/inlinestyle/level2/" do |env|
   query = env.params.query["query"]
 
@@ -25,7 +27,8 @@ end
 # Level 3: Reflected in <span style="font-family: 'QUERY'">
 # Bypass: break out of font-family with ' then out of style attribute with "
 # e.g. x'" onmouseover="alert(1)
-Xssmaze.push("inlinestyle-level3", "/inlinestyle/level3/?query=a", "reflection inside font-family in inline style (single-quoted value, double-quoted attr)")
+Xssmaze.push("inlinestyle-level3", "/inlinestyle/level3/?query=a", "reflection inside font-family in inline style (single-quoted value, double-quoted attr)",
+  vuln: "reflected-attr", delivery: ["query"], note: "inside a single-quoted font-family; close the single quote then break the attribute with the double quote")
 maze_get "/inlinestyle/level3/" do |env|
   query = env.params.query["query"]
 
@@ -37,7 +40,8 @@ end
 # Level 4: Reflected in <div style="content: 'QUERY'">
 # Bypass: break out of content with ' then out of style attribute with "
 # e.g. x'" onmouseover="alert(1)
-Xssmaze.push("inlinestyle-level4", "/inlinestyle/level4/?query=a", "reflection inside content in inline style (single-quoted value, double-quoted attr)")
+Xssmaze.push("inlinestyle-level4", "/inlinestyle/level4/?query=a", "reflection inside content in inline style (single-quoted value, double-quoted attr)",
+  vuln: "reflected-attr", delivery: ["query"], note: "inside a single-quoted content value; close the single quote then break the attribute with the double quote")
 maze_get "/inlinestyle/level4/" do |env|
   query = env.params.query["query"]
 
@@ -49,7 +53,8 @@ end
 # Level 5: Reflected in <td style="width: QUERY">
 # Bypass: close attribute with " then inject event handler
 # e.g. 100px" onmouseover="alert(1)
-Xssmaze.push("inlinestyle-level5", "/inlinestyle/level5/?query=a", "reflection in inline style width value (no inner quotes, double-quoted attr)")
+Xssmaze.push("inlinestyle-level5", "/inlinestyle/level5/?query=a", "reflection in inline style width value (no inner quotes, double-quoted attr)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/inlinestyle/level5/" do |env|
   query = env.params.query["query"]
 
@@ -61,7 +66,8 @@ end
 # Level 6: Reflected in <div style="QUERY">
 # Bypass: full control of style value, break out with " then inject event handler
 # e.g. color:red" onmouseover="alert(1)
-Xssmaze.push("inlinestyle-level6", "/inlinestyle/level6/?query=a", "reflection as entire inline style value (double-quoted attr)")
+Xssmaze.push("inlinestyle-level6", "/inlinestyle/level6/?query=a", "reflection as entire inline style value (double-quoted attr)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/inlinestyle/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/json_context_xss.cr
+++ b/src/mazes/json_context_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Response is Content-Type: text/html with JSON body
 # HTML injection works since the browser renders it as HTML
-Xssmaze.push("jsonctx-level1", "/jsonctx/level1/?query=a", "JSON body with text/html content type, HTML injection")
+Xssmaze.push("jsonctx-level1", "/jsonctx/level1/?query=a", "JSON body with text/html content type, HTML injection",
+  vuln: "reflected-html", delivery: ["query"], note: "served as text/html despite the JSON body, so injected markup renders")
 maze_get "/jsonctx/level1/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -10,7 +11,8 @@ end
 
 # Level 2: JSON embedded in a <script> block with var assignment
 # Close the script tag and inject HTML
-Xssmaze.push("jsonctx-level2", "/jsonctx/level2/?query=a", "JSON in script block, close script to inject")
+Xssmaze.push("jsonctx-level2", "/jsonctx/level2/?query=a", "JSON in script block, close script to inject",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected into a JS string in a <script>; close the </script> or break the string")
 maze_get "/jsonctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -19,7 +21,8 @@ end
 
 # Level 3: JSONP callback with query reflected in data, Content-Type text/html
 # Inject HTML since browser renders as HTML
-Xssmaze.push("jsonctx-level3", "/jsonctx/level3/?query=a", "JSONP response with text/html, HTML injection in data")
+Xssmaze.push("jsonctx-level3", "/jsonctx/level3/?query=a", "JSONP response with text/html, HTML injection in data",
+  vuln: "reflected-html", params: ["query", "callback"], delivery: ["query"], note: "served as text/html; also reflects the callback parameter, which the declared URL omits")
 maze_get "/jsonctx/level3/" do |env|
   query = env.params.query["query"]
   callback = env.params.query.fetch("callback", "callback")
@@ -30,7 +33,8 @@ end
 
 # Level 4: JSON array in a <script> block
 # Close script tag and inject
-Xssmaze.push("jsonctx-level4", "/jsonctx/level4/?query=a", "JSON array in script block, close script to inject")
+Xssmaze.push("jsonctx-level4", "/jsonctx/level4/?query=a", "JSON array in script block, close script to inject",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected into a JS array string in a <script>")
 maze_get "/jsonctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +43,8 @@ end
 
 # Level 5: Nested JSON in a <script> block
 # Close script tag and inject
-Xssmaze.push("jsonctx-level5", "/jsonctx/level5/?query=a", "nested JSON in script block, close script to inject")
+Xssmaze.push("jsonctx-level5", "/jsonctx/level5/?query=a", "nested JSON in script block, close script to inject",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected into a nested JS object string in a <script>")
 maze_get "/jsonctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -48,7 +53,8 @@ end
 
 # Level 6: JSON with HTML content type, query reflected in multiple fields
 # HTML injection via either field
-Xssmaze.push("jsonctx-level6", "/jsonctx/level6/?query=a", "JSON with text/html, query in multiple fields")
+Xssmaze.push("jsonctx-level6", "/jsonctx/level6/?query=a", "JSON with text/html, query in multiple fields",
+  vuln: "reflected-html", delivery: ["query"], note: "served as text/html; reflected in two fields")
 maze_get "/jsonctx/level6/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"

--- a/src/mazes/list_iteration_xss.cr
+++ b/src/mazes/list_iteration_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query split by comma, each part rendered in <li>
-Xssmaze.push("listiteration-level1", "/listiteration/level1/?query=apple,banana,cherry", "list iteration split by comma into li elements")
+Xssmaze.push("listiteration-level1", "/listiteration/level1/?query=apple,banana,cherry", "list iteration split by comma into li elements",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level1/" do |env|
   query = env.params.query["query"]
   parts = query.split(",")
@@ -14,7 +15,8 @@ maze_get "/listiteration/level1/" do |env|
 end
 
 # Level 2: Query split by pipe, each part rendered in <td>
-Xssmaze.push("listiteration-level2", "/listiteration/level2/?query=col1|col2|col3", "list iteration split by pipe into td elements")
+Xssmaze.push("listiteration-level2", "/listiteration/level2/?query=col1|col2|col3", "list iteration split by pipe into td elements",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level2/" do |env|
   query = env.params.query["query"]
   parts = query.split("|")
@@ -27,7 +29,8 @@ maze_get "/listiteration/level2/" do |env|
 end
 
 # Level 3: Query split by newline (%0A), each part rendered in <p>
-Xssmaze.push("listiteration-level3", "/listiteration/level3/?query=line1%0Aline2%0Aline3", "list iteration split by newline into p elements")
+Xssmaze.push("listiteration-level3", "/listiteration/level3/?query=line1%0Aline2%0Aline3", "list iteration split by newline into p elements",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level3/" do |env|
   query = env.params.query["query"]
   parts = query.split("\n")
@@ -40,7 +43,8 @@ maze_get "/listiteration/level3/" do |env|
 end
 
 # Level 4: Query split by space, each part rendered in <span class="tag">
-Xssmaze.push("listiteration-level4", "/listiteration/level4/?query=red+green+blue", "list iteration split by space into span tags")
+Xssmaze.push("listiteration-level4", "/listiteration/level4/?query=red+green+blue", "list iteration split by space into span tags",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level4/" do |env|
   query = env.params.query["query"]
   parts = query.split(" ")
@@ -53,7 +57,8 @@ maze_get "/listiteration/level4/" do |env|
 end
 
 # Level 5: Query split by semicolon, each part in <option value="PART">PART</option>
-Xssmaze.push("listiteration-level5", "/listiteration/level5/?query=opt1;opt2;opt3", "list iteration split by semicolon into option elements")
+Xssmaze.push("listiteration-level5", "/listiteration/level5/?query=opt1;opt2;opt3", "list iteration split by semicolon into option elements",
+  vuln: "reflected-html", delivery: ["query"], note: "each part is reflected into an <option> body and value; close </option></select> to inject")
 maze_get "/listiteration/level5/" do |env|
   query = env.params.query["query"]
   parts = query.split(";")
@@ -68,7 +73,8 @@ maze_get "/listiteration/level5/" do |env|
 end
 
 # Level 6: Single dynamic item among 20 static items in a list
-Xssmaze.push("listiteration-level6", "/listiteration/level6/?query=a", "single dynamic item among 20 static li elements")
+Xssmaze.push("listiteration-level6", "/listiteration/level6/?query=a", "single dynamic item among 20 static li elements",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level6/" do |env|
   query = env.params.query["query"]
   static_items = (1..20).map { |i| "<li>Static Item #{i}</li>" }.join("\n    ")

--- a/src/mazes/mathml_xss.cr
+++ b/src/mazes/mathml_xss.cr
@@ -1,10 +1,12 @@
-Xssmaze.push("mathml-level1", "/mathml/level1/?query=a", "MathML mtext raw reflection (parser context)")
+Xssmaze.push("mathml-level1", "/mathml/level1/?query=a", "MathML mtext raw reflection (parser context)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected raw inside MathML <mtext>; browser MathML parsing enables sanitizer-bypass vectors")
 maze_get "/mathml/level1/" do |env|
   query = env.params.query["query"]
   "<math><mtext>#{query}</mtext></math>"
 end
 
-Xssmaze.push("mathml-level2", "/mathml/level2/?query=a", "MathML annotation-xml encoding=text/html (HTML-in-MathML parser quirk)")
+Xssmaze.push("mathml-level2", "/mathml/level2/?query=a", "MathML annotation-xml encoding=text/html (HTML-in-MathML parser quirk)",
+  vuln: "reflected-html", delivery: ["query"], note: "script removed once and case-sensitively; annotation-xml encoding=text/html is an HTML integration point, so injected markup is parsed as HTML")
 maze_get "/mathml/level2/" do |env|
   query = env.params.query["query"].gsub("script", "")
   "<math>
@@ -14,7 +16,8 @@ maze_get "/mathml/level2/" do |env|
    </math>"
 end
 
-Xssmaze.push("mathml-level3", "/mathml/level3/?query=a", "MathML mglyph nested in mtext (HTML5 sanitizer-bypass quirk)")
+Xssmaze.push("mathml-level3", "/mathml/level3/?query=a", "MathML mglyph nested in mtext (HTML5 sanitizer-bypass quirk)",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into a single-quoted mglyph src; break out of the value")
 maze_get "/mathml/level3/" do |env|
   query = env.params.query["query"]
   "<math><mtext><mglyph src='#{query}'></mglyph></mtext></math>"

--- a/src/mazes/misc_context_xss.cr
+++ b/src/mazes/misc_context_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: progress element - reflection inside title attribute
 # Bypass: break out of title with ", e.g. " onmouseover="alert(1)"
-Xssmaze.push("misc-context-level1", "/misc-context/level1/?query=a", "progress element title attribute reflection")
+Xssmaze.push("misc-context-level1", "/misc-context/level1/?query=a", "progress element title attribute reflection",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: meter element - reflection inside title attribute
 # Bypass: break out of title with ", e.g. " onmouseover="alert(1)"
-Xssmaze.push("misc-context-level2", "/misc-context/level2/?query=a", "meter element title attribute reflection")
+Xssmaze.push("misc-context-level2", "/misc-context/level2/?query=a", "meter element title attribute reflection",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ end
 
 # Level 3: time element - reflection inside datetime attribute
 # Bypass: break out of datetime with ", e.g. " onmouseover="alert(1)"
-Xssmaze.push("misc-context-level3", "/misc-context/level3/?query=a", "time element datetime attribute reflection")
+Xssmaze.push("misc-context-level3", "/misc-context/level3/?query=a", "time element datetime attribute reflection",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level3/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +30,8 @@ end
 
 # Level 4: data element - reflection inside value attribute
 # Bypass: break out of value with ", e.g. " onmouseover="alert(1)"
-Xssmaze.push("misc-context-level4", "/misc-context/level4/?query=a", "data element value attribute reflection")
+Xssmaze.push("misc-context-level4", "/misc-context/level4/?query=a", "data element value attribute reflection",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level4/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +40,8 @@ end
 
 # Level 5: cite element - reflection inside title attribute
 # Bypass: break out of title with ", e.g. " onmouseover="alert(1)"
-Xssmaze.push("misc-context-level5", "/misc-context/level5/?query=a", "cite element title attribute reflection")
+Xssmaze.push("misc-context-level5", "/misc-context/level5/?query=a", "cite element title attribute reflection",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level5/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +50,8 @@ end
 
 # Level 6: q element - reflection inside cite attribute
 # Bypass: break out of cite with ", e.g. " onmouseover="alert(1)"
-Xssmaze.push("misc-context-level6", "/misc-context/level6/?query=a", "q element cite attribute reflection")
+Xssmaze.push("misc-context-level6", "/misc-context/level6/?query=a", "q element cite attribute reflection",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/multi_param_xss.cr
+++ b/src/mazes/multi_param_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Two params q1 and q2, both reflected raw in body
 # Either param can be exploited independently
-Xssmaze.push("multiparam-level1", "/multiparam/level1/?q1=a&q2=b", "two params both reflected raw (either exploitable)", params: ["q1", "q2"])
+Xssmaze.push("multiparam-level1", "/multiparam/level1/?q1=a&q2=b", "two params both reflected raw (either exploitable)", params: ["q1", "q2"],
+  vuln: "reflected-html", delivery: ["query"], note: "both parameters reflect raw into the body")
 maze_get "/multiparam/level1/" do |env|
   q1 = env.params.query.fetch("q1", "a")
   q2 = env.params.query.fetch("q2", "b")
@@ -14,7 +15,8 @@ end
 
 # Level 2: Param "query" reflected raw, but only if param "page" also exists
 # Tests scanner's ability to discover required companion parameters
-Xssmaze.push("multiparam-level2", "/multiparam/level2/?query=a&page=1", "query reflected only when page param exists", params: ["query", "page"])
+Xssmaze.push("multiparam-level2", "/multiparam/level2/?query=a&page=1", "query reflected only when page param exists", params: ["query", "page"],
+  vuln: "reflected-html", delivery: ["query"], note: "query reflects only when page is present; page is also reflected raw")
 maze_get "/multiparam/level2/" do |env|
   query = env.params.query.fetch("query", "a")
   page = env.params.query.fetch("page", "")
@@ -34,7 +36,8 @@ end
 
 # Level 3: Param "search" in input value, param "sort" in input value, both breakable
 # Bypass: break out of attribute with "><img src=x onerror=alert(1)>
-Xssmaze.push("multiparam-level3", "/multiparam/level3/?search=a&sort=b", "two params in input value attributes (both breakable)", params: ["search", "sort"])
+Xssmaze.push("multiparam-level3", "/multiparam/level3/?search=a&sort=b", "two params in input value attributes (both breakable)", params: ["search", "sort"],
+  vuln: "reflected-attr", delivery: ["query"], note: "both parameters break out of their input value attribute")
 maze_get "/multiparam/level3/" do |env|
   search = env.params.query.fetch("search", "a")
   sort = env.params.query.fetch("sort", "b")
@@ -51,7 +54,8 @@ end
 
 # Level 4: Param "query" reflected raw, but only when param "token" equals "valid"
 # Tests scanner's ability to provide a required token value
-Xssmaze.push("multiparam-level4", "/multiparam/level4/?query=a&token=valid", "query reflected only when token=valid", params: ["query", "token"])
+Xssmaze.push("multiparam-level4", "/multiparam/level4/?query=a&token=valid", "query reflected only when token=valid", params: ["query", "token"],
+  vuln: "reflected-html", delivery: ["query"], note: "query reflects raw only when token=valid")
 maze_get "/multiparam/level4/" do |env|
   query = env.params.query.fetch("query", "a")
   token = env.params.query.fetch("token", "")
@@ -71,7 +75,8 @@ end
 
 # Level 5: Param "name" reflected raw between "prefix" and "suffix" which are HTML-encoded
 # Only "name" is exploitable; prefix and suffix are safe
-Xssmaze.push("multiparam-level5", "/multiparam/level5/?prefix=a&name=b&suffix=c", "name reflected raw between HTML-encoded prefix and suffix", params: ["prefix", "name", "suffix"])
+Xssmaze.push("multiparam-level5", "/multiparam/level5/?prefix=a&name=b&suffix=c", "name reflected raw between HTML-encoded prefix and suffix", params: ["prefix", "name", "suffix"],
+  vuln: "reflected-html", delivery: ["query"], note: "only name is exploitable; prefix and suffix are angle-encoded")
 maze_get "/multiparam/level5/" do |env|
   prefix = Filters.encode_angles(env.params.query.fetch("prefix", "a"))
   name = env.params.query.fetch("name", "b")
@@ -86,7 +91,8 @@ end
 # Level 6: Three params a, b, c reflected in different contexts:
 #   a -> HTML body (raw), b -> attribute value, c -> JS string
 # All three are exploitable in their respective contexts
-Xssmaze.push("multiparam-level6", "/multiparam/level6/?a=x&b=y&c=z", "three params in body, attribute, and JS string contexts", params: ["a", "b", "c"])
+Xssmaze.push("multiparam-level6", "/multiparam/level6/?a=x&b=y&c=z", "three params in body, attribute, and JS string contexts", params: ["a", "b", "c"],
+  vuln: "reflected-html", delivery: ["query"], note: "a lands in the body (raw), b in a double-quoted attribute, c in a single-quoted JS string; all three are exploitable")
 maze_get "/multiparam/level6/" do |env|
   a = env.params.query.fetch("a", "x")
   b = env.params.query.fetch("b", "y")

--- a/src/mazes/multipart_xss.cr
+++ b/src/mazes/multipart_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: POST endpoint reflecting filename from multipart form
-Xssmaze.push("multipart-level1", "/multipart/level1/?query=a", "POST reflecting filename from multipart form", "POST", ["filename"])
+Xssmaze.push("multipart-level1", "/multipart/level1/?query=a", "POST reflecting filename from multipart form", "POST", ["filename"],
+  vuln: "reflected-html", delivery: ["body"], note: "reflects the filename field from the multipart POST body")
 maze_get "/multipart/level1/" do |_|
   "<html><body>
   <h1>Multipart XSS Level 1</h1>
@@ -16,7 +17,8 @@ maze_post "/multipart/level1/" do |env|
 end
 
 # Level 2: POST reflecting raw JSON body
-Xssmaze.push("multipart-level2", "/multipart/level2/", "POST reflecting raw JSON body", "POST", ["query"])
+Xssmaze.push("multipart-level2", "/multipart/level2/", "POST reflecting raw JSON body", "POST", ["query"],
+  vuln: "reflected-html", delivery: ["body"], note: "reflects the entire raw request body; the page posts a JSON body")
 maze_get "/multipart/level2/" do |_|
   "<html><body>
   <h1>Multipart XSS Level 2</h1>
@@ -38,7 +40,8 @@ maze_post "/multipart/level2/" do |env|
 end
 
 # Level 3: GET endpoint reflecting Accept header value
-Xssmaze.push("multipart-level3", "/multipart/level3/?query=a", "GET reflecting Accept header in body", "GET", ["query"])
+Xssmaze.push("multipart-level3", "/multipart/level3/?query=a", "GET reflecting Accept header in body", "GET", ["Accept"],
+  vuln: "reflected-html", delivery: ["header"], note: "reflects the Accept request header, not a query parameter")
 maze_get "/multipart/level3/" do |env|
   accept = env.request.headers.fetch("Accept", "text/html")
 
@@ -49,7 +52,8 @@ maze_get "/multipart/level3/" do |env|
 end
 
 # Level 4: GET reflecting User-Agent header in body
-Xssmaze.push("multipart-level4", "/multipart/level4/?query=a", "GET reflecting User-Agent header in body")
+Xssmaze.push("multipart-level4", "/multipart/level4/?query=a", "GET reflecting User-Agent header in body",
+  vuln: "reflected-html", params: ["User-Agent"], delivery: ["header"], note: "reflects the User-Agent header, not a query parameter")
 maze_get "/multipart/level4/" do |env|
   ua = env.request.headers.fetch("User-Agent", "")
 

--- a/src/mazes/mutation_filter_xss.cr
+++ b/src/mazes/mutation_filter_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Replace < with %3C (URL encode) before reflecting in body
 # Double URL decode might get it back
-Xssmaze.push("mutfilter-level1", "/mutfilter/level1/?query=a", "< replaced with %3C in body")
+Xssmaze.push("mutfilter-level1", "/mutfilter/level1/?query=a", "< replaced with %3C in body",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "< and > are replaced with the literal text %3C/%3E and nothing decodes them client-side, so no tag can form")
 maze_get "/mutfilter/level1/" do |env|
   query = env.params.query["query"]
   query = query.gsub("<", "%3C").gsub(">", "%3E")
@@ -9,7 +10,8 @@ maze_get "/mutfilter/level1/" do |env|
 end
 
 # Level 2: Strip HTML comments but allow everything else
-Xssmaze.push("mutfilter-level2", "/mutfilter/level2/?query=a", "HTML comment strip only")
+Xssmaze.push("mutfilter-level2", "/mutfilter/level2/?query=a", "HTML comment strip only",
+  vuln: "reflected-html", delivery: ["query"], note: "only HTML comments are stripped; other tags survive")
 maze_get "/mutfilter/level2/" do |env|
   query = env.params.query["query"]
   query = query.gsub(/<!--.*?-->/m, "")
@@ -18,7 +20,8 @@ maze_get "/mutfilter/level2/" do |env|
 end
 
 # Level 3: Replace 'on' prefix with 'off' (breaks event handlers)
-Xssmaze.push("mutfilter-level3", "/mutfilter/level3/?query=a", "on* prefix replaced with off*")
+Xssmaze.push("mutfilter-level3", "/mutfilter/level3/?query=a", "on* prefix replaced with off*",
+  vuln: "reflected-html", delivery: ["query"], note: "on* handlers are rewritten to off*; use a <script> tag or other non-event vector")
 maze_get "/mutfilter/level3/" do |env|
   query = env.params.query["query"]
   query = query.gsub(/\bon(\w)/i) { "off#{$1}" }
@@ -27,7 +30,8 @@ maze_get "/mutfilter/level3/" do |env|
 end
 
 # Level 4: Strip src/href/action attributes but allow tags
-Xssmaze.push("mutfilter-level4", "/mutfilter/level4/?query=a", "dangerous attribute strip (src/href/action)")
+Xssmaze.push("mutfilter-level4", "/mutfilter/level4/?query=a", "dangerous attribute strip (src/href/action)",
+  vuln: "reflected-html", delivery: ["query"], note: "src/href/action attributes are neutralized; use a <script> tag or an event handler")
 maze_get "/mutfilter/level4/" do |env|
   query = env.params.query["query"]
   query = query.gsub(/\b(src|href|action|formaction)\s*=/i, "data-removed=")
@@ -36,7 +40,8 @@ maze_get "/mutfilter/level4/" do |env|
 end
 
 # Level 5: Reverse string then unreverse (can be bypassed with palindrome payloads)
-Xssmaze.push("mutfilter-level5", "/mutfilter/level5/?query=a", "no filter (basic reflection)")
+Xssmaze.push("mutfilter-level5", "/mutfilter/level5/?query=a", "no filter (basic reflection)",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/mutfilter/level5/" do |env|
   query = env.params.query["query"]
 
@@ -44,7 +49,8 @@ maze_get "/mutfilter/level5/" do |env|
 end
 
 # Level 6: Remove all whitespace characters
-Xssmaze.push("mutfilter-level6", "/mutfilter/level6/?query=a", "all whitespace removed in body reflection")
+Xssmaze.push("mutfilter-level6", "/mutfilter/level6/?query=a", "all whitespace removed in body reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "whitespace is stripped; use / as an attribute separator or a <script> tag")
 maze_get "/mutfilter/level6/" do |env|
   query = env.params.query["query"]
   query = query.gsub(/\s/, "")

--- a/src/mazes/obfuscation_xss.cr
+++ b/src/mazes/obfuscation_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Server lowercases the entire input then reflects in body
 # Bypass: lowercase payloads work fine, e.g. <img src=x onerror=alert(1)>
-Xssmaze.push("obfuscation-level1", "/obfuscation/level1/?query=a", "server lowercases input then reflects (lowercase payloads work)")
+Xssmaze.push("obfuscation-level1", "/obfuscation/level1/?query=a", "server lowercases input then reflects (lowercase payloads work)",
+  vuln: "reflected-html", delivery: ["query"], note: "input lowercased; lowercase payloads survive")
 maze_get "/obfuscation/level1/" do |env|
   query = env.params.query["query"].downcase
 
@@ -12,7 +13,8 @@ end
 
 # Level 2: Server uppercases the entire input then reflects in body
 # Bypass: HTML tags are case-insensitive, <IMG SRC=X ONERROR=ALERT(1)> works
-Xssmaze.push("obfuscation-level2", "/obfuscation/level2/?query=a", "server uppercases input then reflects (HTML is case-insensitive)")
+Xssmaze.push("obfuscation-level2", "/obfuscation/level2/?query=a", "server uppercases input then reflects (HTML is case-insensitive)",
+  vuln: "reflected-html", delivery: ["query"], note: "input uppercased, but HTML tags are case-insensitive")
 maze_get "/obfuscation/level2/" do |env|
   query = env.params.query["query"].upcase
 
@@ -24,7 +26,8 @@ end
 
 # Level 3: Server reflects both reversed and original copy of input
 # The original (non-reversed) copy is exploitable by standard payloads
-Xssmaze.push("obfuscation-level3", "/obfuscation/level3/?query=a", "reflects reversed + original (original is exploitable)")
+Xssmaze.push("obfuscation-level3", "/obfuscation/level3/?query=a", "reflects reversed + original (original is exploitable)",
+  vuln: "reflected-html", delivery: ["query"], note: "the reversed copy is a decoy; the original is reflected raw")
 maze_get "/obfuscation/level3/" do |env|
   query = env.params.query["query"]
   reversed = query.reverse
@@ -38,7 +41,8 @@ end
 
 # Level 4: Server removes all spaces then reflects in body
 # Bypass: use / as attribute separator, e.g. <img/src=x/onerror=alert(1)>
-Xssmaze.push("obfuscation-level4", "/obfuscation/level4/?query=a", "server strips all spaces then reflects (use / separator)")
+Xssmaze.push("obfuscation-level4", "/obfuscation/level4/?query=a", "server strips all spaces then reflects (use / separator)",
+  vuln: "reflected-html", delivery: ["query"], note: "spaces stripped; use / as an attribute separator")
 maze_get "/obfuscation/level4/" do |env|
   query = env.params.query["query"].gsub(" ", "")
 
@@ -50,7 +54,8 @@ end
 
 # Level 5: Server removes all = characters then reflects inside <div>
 # Bypass: use tags that don't need =, e.g. <script>alert(1)</script>
-Xssmaze.push("obfuscation-level5", "/obfuscation/level5/?query=a", "server strips = chars then reflects (use script tag)")
+Xssmaze.push("obfuscation-level5", "/obfuscation/level5/?query=a", "server strips = chars then reflects (use script tag)",
+  vuln: "reflected-html", delivery: ["query"], note: "= is stripped; use a tag that needs no attribute value")
 maze_get "/obfuscation/level5/" do |env|
   query = env.params.query["query"].gsub("=", "")
 
@@ -63,7 +68,8 @@ end
 # Level 6: Server removes ( and ) parentheses then reflects inside <div>
 # Bypass: use backticks for function calls, e.g. <img src=x onerror=alert`1`>
 # Or use tags that don't need parens at all
-Xssmaze.push("obfuscation-level6", "/obfuscation/level6/?query=a", "server strips parentheses then reflects (use backticks)")
+Xssmaze.push("obfuscation-level6", "/obfuscation/level6/?query=a", "server strips parentheses then reflects (use backticks)",
+  vuln: "reflected-html", delivery: ["query"], note: "parentheses stripped; use backticks or a paren-free vector")
 maze_get "/obfuscation/level6/" do |env|
   query = env.params.query["query"].gsub("(", "").gsub(")", "")
 

--- a/src/mazes/path.cr
+++ b/src/mazes/path.cr
@@ -1,22 +1,26 @@
-Xssmaze.push("path-level1", "/path/level1/a", "reflected", "GET", [":path"])
+Xssmaze.push("path-level1", "/path/level1/a", "reflected", "GET", [":path"],
+  vuln: "reflected-html", delivery: ["path"], note: "reflects the :name path segment (served as text/html)")
 get "/path/level1/:name" do |env|
   name = env.params.url["name"]
   "Hi #{name}"
 end
 
-Xssmaze.push("path-level2", "/path/level2/a", "escape to %2f", "GET", [":path"])
+Xssmaze.push("path-level2", "/path/level2/a", "escape to %2f", "GET", [":path"],
+  vuln: "reflected-html", delivery: ["path"], note: "a literal %2f strip does nothing after Kemal has decoded the segment")
 get "/path/level2/:name" do |env|
   name = env.params.url["name"].gsub("%2f", "")
   "Hi #{name}"
 end
 
-Xssmaze.push("path-level3", "/path/level3/a", "escape to %20", "GET", [":path"])
+Xssmaze.push("path-level3", "/path/level3/a", "escape to %20", "GET", [":path"],
+  vuln: "reflected-html", delivery: ["path"], note: "spaces stripped; use / or a non-space vector")
 get "/path/level3/:name" do |env|
   name = env.params.url["name"].gsub(" ", "").gsub("%20", "")
   "Hi #{name}"
 end
 
-Xssmaze.push("path-level4", "/path/level4/a", "escape to %2f and %20", "GET", [":path"])
+Xssmaze.push("path-level4", "/path/level4/a", "escape to %2f and %20", "GET", [":path"],
+  vuln: "reflected-html", delivery: ["path"])
 get "/path/level4/:name" do |env|
   name = env.params.url["name"].gsub("%2f", "").gsub("%20", "")
   "Hi #{name}"

--- a/src/mazes/polyglot_context_xss.cr
+++ b/src/mazes/polyglot_context_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query reflected both in HTML body AND in an attribute — either context is exploitable
-Xssmaze.push("polyctx-level1", "/polyctx/level1/?query=a", "dual reflection: body + attribute value")
+Xssmaze.push("polyctx-level1", "/polyctx/level1/?query=a", "dual reflection: body + attribute value",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into both an input value attribute and the body; either is exploitable")
 maze_get "/polyctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -12,7 +13,8 @@ end
 
 # Level 2: Query reflected both inside <script>var x="QUERY"</script> AND in HTML body
 # </script> breakout works for both
-Xssmaze.push("polyctx-level2", "/polyctx/level2/?query=a", "dual reflection: script string + body")
+Xssmaze.push("polyctx-level2", "/polyctx/level2/?query=a", "dual reflection: script string + body",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into a <script> string and the body; </script> breakout covers both")
 maze_get "/polyctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -24,7 +26,8 @@ maze_get "/polyctx/level2/" do |env|
 end
 
 # Level 3: Query reflected in 3 places: HTML comment, attribute, and body — all exploitable
-Xssmaze.push("polyctx-level3", "/polyctx/level3/?query=a", "triple reflection: comment + attribute + body")
+Xssmaze.push("polyctx-level3", "/polyctx/level3/?query=a", "triple reflection: comment + attribute + body",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected in an HTML comment, a title attribute and the body; all three are exploitable")
 maze_get "/polyctx/level3/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +39,8 @@ maze_get "/polyctx/level3/" do |env|
 end
 
 # Level 4: Query reflected in HTML body with <script> stripped (single pass) — use <img> tag instead
-Xssmaze.push("polyctx-level4", "/polyctx/level4/?query=a", "single-pass script tag strip, body reflection")
+Xssmaze.push("polyctx-level4", "/polyctx/level4/?query=a", "single-pass script tag strip, body reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "<script> stripped in a single pass; use <img>/<svg> or a nested tag")
 maze_get "/polyctx/level4/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/<script[^>]*>|<\/script>/i, "")
@@ -49,7 +53,8 @@ end
 
 # Level 5: Query reflected in both single-quoted JS and double-quoted HTML attribute
 # </script> breakout covers both
-Xssmaze.push("polyctx-level5", "/polyctx/level5/?query=a", "dual reflection: JS single-quoted + HTML double-quoted attr")
+Xssmaze.push("polyctx-level5", "/polyctx/level5/?query=a", "dual reflection: JS single-quoted + HTML double-quoted attr",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected into a single-quoted <script> string and a double-quoted attribute; </script> breakout reaches both")
 maze_get "/polyctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -62,7 +67,8 @@ end
 
 # Level 6: Query reflected in <style>QUERY</style> AND <div>QUERY</div>
 # </style> breakout for first, direct injection for second
-Xssmaze.push("polyctx-level6", "/polyctx/level6/?query=a", "dual reflection: style tag + body div")
+Xssmaze.push("polyctx-level6", "/polyctx/level6/?query=a", "dual reflection: style tag + body div",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into a <style> block and the body; the body reflection is a direct HTML injection")
 maze_get "/polyctx/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/post.cr
+++ b/src/mazes/post.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("post-level1", "/post/level1/", "POST-Form => 'query=a'", "POST")
+Xssmaze.push("post-level1", "/post/level1/", "POST-Form => 'query=a'", "POST",
+  vuln: "reflected-html", delivery: ["body"], note: "reflects the query field from the POST form body")
 maze_get "/post/level1/" do |_|
   "<form action='/post/level1/' method='post'><input type='text' name='query' value='a'><input type='submit'></form>"
 end
@@ -7,7 +8,8 @@ maze_post "/post/level1/" do |env|
   "query: #{query}"
 end
 
-Xssmaze.push("post-level2", "/post/level2/", "POST-Json => {\"query\":\"a\"}", "POST")
+Xssmaze.push("post-level2", "/post/level2/", "POST-Json => {\"query\":\"a\"}", "POST",
+  vuln: "reflected-html", delivery: ["body"], note: "reflects the query field from the JSON POST body")
 maze_get "/post/level2/" do |_|
   "<button onclick=send()>run</button>
        <script>

--- a/src/mazes/realworld_input_xss.cr
+++ b/src/mazes/realworld_input_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: X-Forwarded-For header reflection in error page
 # Common in reverse proxy setups where the header is logged/displayed
-Xssmaze.push("realworld_input-level1", "/realworld-input/level1/", "X-Forwarded-For header reflection")
+Xssmaze.push("realworld_input-level1", "/realworld-input/level1/", "X-Forwarded-For header reflection",
+  vuln: "reflected-html", params: ["X-Forwarded-For"], delivery: ["header"], note: "reflects the X-Forwarded-For header into the error page")
 maze_get "/realworld-input/level1/" do |env|
   xff = env.request.headers.fetch("X-Forwarded-For", "127.0.0.1")
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: POST JSON body reflection
 # Accepts JSON body with {"name": "value"} and reflects without escaping
-Xssmaze.push("realworld_input-level2", "/realworld-input/level2/", "POST JSON body reflection (name field)")
+Xssmaze.push("realworld_input-level2", "/realworld-input/level2/", "POST JSON body reflection (name field)",
+  vuln: "reflected-html", method: "POST", params: ["name"], delivery: ["body"], note: "reflects the name field from a JSON POST body")
 maze_get "/realworld-input/level2/" do |_|
   "<html><body><h2>API Endpoint</h2><p>POST JSON with {\"name\": \"value\"}</p></body></html>"
 end
@@ -21,7 +23,8 @@ end
 
 # Level 3: POST multipart form reflection
 # Reflects a form field from multipart/form-data upload
-Xssmaze.push("realworld_input-level3", "/realworld-input/level3/", "POST multipart form field reflection")
+Xssmaze.push("realworld_input-level3", "/realworld-input/level3/", "POST multipart form field reflection",
+  vuln: "reflected-html", method: "POST", params: ["username"], delivery: ["body"], note: "reflects the username field from a multipart POST body")
 maze_get "/realworld-input/level3/" do |_|
   "<html><body><form action='/realworld-input/level3/' method='post' enctype='multipart/form-data'><input type='text' name='username' value='test'><input type='file' name='avatar'><input type='submit' value='Upload'></form></body></html>"
 end
@@ -33,7 +36,8 @@ end
 
 # Level 4: Location header injection via parameter
 # Redirects to user-controlled URL; javascript: protocol triggers XSS
-Xssmaze.push("realworld_input-level4", "/realworld-input/level4/?url=https://example.com", "Location header redirect (javascript: sink)")
+Xssmaze.push("realworld_input-level4", "/realworld-input/level4/?url=https://example.com", "Location header redirect (javascript: sink)",
+  vuln: "non-xss-control", params: ["url"], delivery: ["query"], exploitable: false, note: "open redirect via the Location header; browsers do not execute javascript:/data: from a Location redirect and CR/LF is stripped, so this is not XSS")
 maze_get "/realworld-input/level4/" do |env|
   url = env.params.query.fetch("url", "/")
   env.response.headers["Location"] = Xssmaze.header_value(url)
@@ -44,7 +48,8 @@ end
 
 # Level 5: Meta refresh redirect
 # Uses <meta http-equiv="refresh"> with user-controlled URL
-Xssmaze.push("realworld_input-level5", "/realworld-input/level5/?url=https://example.com", "meta refresh redirect sink")
+Xssmaze.push("realworld_input-level5", "/realworld-input/level5/?url=https://example.com", "meta refresh redirect sink",
+  vuln: "reflected-attr", params: ["url"], delivery: ["query"], note: "reflected into the meta-refresh content attribute; break out with the quote and > to inject HTML (javascript: in meta refresh is blocked by modern browsers)")
 maze_get "/realworld-input/level5/" do |env|
   url = env.params.query.fetch("url", "/")
 
@@ -53,7 +58,8 @@ end
 
 # Level 6: Cookie value reflection
 # First request sets cookie from query param, subsequent requests reflect cookie value
-Xssmaze.push("realworld_input-level6", "/realworld-input/level6/?lang=en", "cookie value reflection (stored via param)")
+Xssmaze.push("realworld_input-level6", "/realworld-input/level6/?lang=en", "cookie value reflection (stored via param)",
+  vuln: "reflected-html", params: ["lang"], delivery: ["query", "cookie"], note: "the lang parameter reflects on the same request and is also stored in a cookie that reflects on later requests")
 maze_get "/realworld-input/level6/" do |env|
   lang_param = env.params.query.fetch("lang", "")
 
@@ -76,7 +82,8 @@ end
 
 # Level 7: Full URL / path reflection in link tag
 # Allows injection via path: /realworld-input/level7/"><script>alert(1)</script>
-Xssmaze.push("realworld_input-level7", "/realworld-input/level7/test", "path reflection in link href")
+Xssmaze.push("realworld_input-level7", "/realworld-input/level7/test", "path reflection in link href",
+  vuln: "reflected-attr", params: [":path"], delivery: ["path"], note: "reflected into the canonical link href; the body copy is angle-stripped but the href is not, so break out with the quote and >")
 maze_get "/realworld-input/level7/:path" do |env|
   path = env.params.url["path"]
 
@@ -85,7 +92,8 @@ end
 
 # Level 8: JSONP callback injection
 # Returns callback({"data":"value"}) with application/javascript content-type
-Xssmaze.push("realworld_input-level8", "/realworld-input/level8/?callback=myFunc", "JSONP callback injection")
+Xssmaze.push("realworld_input-level8", "/realworld-input/level8/?callback=myFunc", "JSONP callback injection",
+  vuln: "reflected-js", params: ["callback"], delivery: ["query"], note: "JSONP: the callback name is reflected raw into an application/javascript response, executing when the response is loaded as a script")
 maze_get "/realworld-input/level8/" do |env|
   callback = env.params.query.fetch("callback", "callback")
   env.response.content_type = "application/javascript"

--- a/src/mazes/redirect_xss.cr
+++ b/src/mazes/redirect_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflection in <a href="QUERY"> with no filtering
 # Bypass: javascript:alert(1)
-Xssmaze.push("redirectxss-level1", "/redirectxss/level1/?query=a", "reflection in href attribute unfiltered (javascript: protocol)")
+Xssmaze.push("redirectxss-level1", "/redirectxss/level1/?query=a", "reflection in href attribute unfiltered (javascript: protocol)",
+  vuln: "reflected-attr", delivery: ["query"], note: "double-quoted href; use a javascript: URL (needs a click) or break out with the quote and >")
 maze_get "/redirectxss/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: Reflection in meta refresh <meta http-equiv="refresh" content="0;url=QUERY">
 # Bypass: javascript:alert(1) or data: URI
-Xssmaze.push("redirectxss-level2", "/redirectxss/level2/?query=a", "reflection in meta refresh URL")
+Xssmaze.push("redirectxss-level2", "/redirectxss/level2/?query=a", "reflection in meta refresh URL",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into the meta-refresh content attribute; break out with the quote and > (javascript:/data: in meta refresh is blocked by modern browsers)")
 maze_get "/redirectxss/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ end
 
 # Level 3: Reflection in <form action="QUERY">
 # Bypass: javascript:alert(1)
-Xssmaze.push("redirectxss-level3", "/redirectxss/level3/?query=a", "reflection in form action attribute (javascript: protocol)")
+Xssmaze.push("redirectxss-level3", "/redirectxss/level3/?query=a", "reflection in form action attribute (javascript: protocol)",
+  vuln: "reflected-attr", delivery: ["query"], note: "form action; a javascript: URL fires on submit or break out with the quote and >")
 maze_get "/redirectxss/level3/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +30,8 @@ end
 
 # Level 4: Reflection in window.location assignment inside script
 # Bypass: close script tag </script><script>alert(1)</script>
-Xssmaze.push("redirectxss-level4", "/redirectxss/level4/?query=a", "reflection in window.location assignment inside script")
+Xssmaze.push("redirectxss-level4", "/redirectxss/level4/?query=a", "reflection in window.location assignment inside script",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected into a double-quoted JS string; close the </script> or break the string")
 maze_get "/redirectxss/level4/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +40,8 @@ end
 
 # Level 5: Query param reflected in <a href="/redirect?url=QUERY">
 # Bypass: break out of attribute with "> and inject HTML
-Xssmaze.push("redirectxss-level5", "/redirectxss/level5/?query=a", "reflection in href URL param (attribute breakout)")
+Xssmaze.push("redirectxss-level5", "/redirectxss/level5/?query=a", "reflection in href URL param (attribute breakout)",
+  vuln: "reflected-attr", delivery: ["query"], note: "double-quoted href; break out with the quote and >")
 maze_get "/redirectxss/level5/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +50,8 @@ end
 
 # Level 6: Reflection in <object data="QUERY">
 # Bypass: javascript:alert(1) or data: URI
-Xssmaze.push("redirectxss-level6", "/redirectxss/level6/?query=a", "reflection in object data attribute (javascript: or data: URI)")
+Xssmaze.push("redirectxss-level6", "/redirectxss/level6/?query=a", "reflection in object data attribute (javascript: or data: URI)",
+  vuln: "reflected-attr", delivery: ["query"], note: "object data attribute; break out with the quote and > or use a javascript:/data: URI")
 maze_get "/redirectxss/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/response_split_xss.cr
+++ b/src/mazes/response_split_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflection in HTTP header (X-Custom) + body
-Xssmaze.push("rsplit-level1", "/rsplit/level1/?query=a", "reflection in custom header + body")
+Xssmaze.push("rsplit-level1", "/rsplit/level1/?query=a", "reflection in custom header + body",
+  vuln: "reflected-html", delivery: ["query"], note: "the X-Search-Term header copy strips CR/LF (no response splitting); the body reflection is a raw HTML injection")
 maze_get "/rsplit/level1/" do |env|
   query = env.params.query.fetch("query", "a")
   # Reflected raw into the body below; the header copy drops CR/LF only
@@ -10,7 +11,8 @@ maze_get "/rsplit/level1/" do |env|
 end
 
 # Level 2: Two different params, different contexts
-Xssmaze.push("rsplit-level2", "/rsplit/level2/?name=a&color=blue", "two params: body + style attribute")
+Xssmaze.push("rsplit-level2", "/rsplit/level2/?name=a&color=blue", "two params: body + style attribute",
+  vuln: "reflected-html", params: ["name", "color"], delivery: ["query"], note: "name lands in the body (raw), color in a style attribute; both exploitable")
 maze_get "/rsplit/level2/" do |env|
   name = env.params.query.fetch("name", "a")
   color = env.params.query.fetch("color", "blue")
@@ -19,7 +21,8 @@ maze_get "/rsplit/level2/" do |env|
 end
 
 # Level 3: Error page reflection (search term in error message)
-Xssmaze.push("rsplit-level3", "/rsplit/level3/?page=test", "error message query reflection")
+Xssmaze.push("rsplit-level3", "/rsplit/level3/?page=test", "error message query reflection",
+  vuln: "reflected-html", params: ["page"], delivery: ["query"], note: "reflects the page parameter into the error text")
 maze_get "/rsplit/level3/" do |env|
   page = env.params.query.fetch("page", "unknown")
 
@@ -27,7 +30,8 @@ maze_get "/rsplit/level3/" do |env|
 end
 
 # Level 4: Reflection in Set-Cookie + body
-Xssmaze.push("rsplit-level4", "/rsplit/level4/?pref=a", "set-cookie + body reflection")
+Xssmaze.push("rsplit-level4", "/rsplit/level4/?pref=a", "set-cookie + body reflection",
+  vuln: "reflected-html", params: ["pref"], delivery: ["query"], note: "the cookie copy strips RFC 6265-forbidden bytes; the body reflection is a raw HTML injection")
 maze_get "/rsplit/level4/" do |env|
   pref = env.params.query.fetch("pref", "default")
   # Splitting characters are exactly what this level is about, so the cookie

--- a/src/mazes/sanitizer_bypass_xss.cr
+++ b/src/mazes/sanitizer_bypass_xss.cr
@@ -1,7 +1,8 @@
 require "html"
 
 # Level 1: HTML entity encode body but not attributes
-Xssmaze.push("sanitizer-level1", "/sanitizer/level1/?query=a", "HTML entity body + raw attribute")
+Xssmaze.push("sanitizer-level1", "/sanitizer/level1/?query=a", "HTML entity body + raw attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "the body copy is HTML-escaped; the title attribute is raw, so break out with the quote")
 maze_get "/sanitizer/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ maze_get "/sanitizer/level1/" do |env|
 end
 
 # Level 2: Strip script/iframe/object tags recursively
-Xssmaze.push("sanitizer-level2", "/sanitizer/level2/?query=a", "recursive dangerous tag strip")
+Xssmaze.push("sanitizer-level2", "/sanitizer/level2/?query=a", "recursive dangerous tag strip",
+  vuln: "reflected-html", delivery: ["query"], note: "script/iframe/object keywords removed recursively; use a different tag or event vector")
 maze_get "/sanitizer/level2/" do |env|
   query = Filters.strip_keyword_recursive(env.params.query["query"], "script")
   query = Filters.strip_keyword_recursive(query, "iframe")
@@ -19,7 +21,8 @@ maze_get "/sanitizer/level2/" do |env|
 end
 
 # Level 3: Whitelist only p, b, i, a, br tags
-Xssmaze.push("sanitizer-level3", "/sanitizer/level3/?query=a", "tag whitelist: p/b/i/a/br only")
+Xssmaze.push("sanitizer-level3", "/sanitizer/level3/?query=a", "tag whitelist: p/b/i/a/br only",
+  vuln: "reflected-html", delivery: ["query"], note: "only p/b/i/a/br are whitelisted, but <a> keeps its attributes; use an <a> event handler or javascript: href (needs interaction)")
 maze_get "/sanitizer/level3/" do |env|
   query = Filters.whitelist_tags(env.params.query["query"], ["p", "b", "i", "a", "br"])
 
@@ -27,7 +30,8 @@ maze_get "/sanitizer/level3/" do |env|
 end
 
 # Level 4: Replace <script with <!-- and </script> with -->
-Xssmaze.push("sanitizer-level4", "/sanitizer/level4/?query=a", "script to comment replacement")
+Xssmaze.push("sanitizer-level4", "/sanitizer/level4/?query=a", "script to comment replacement",
+  vuln: "reflected-html", delivery: ["query"], note: "<script>...</script> is turned into an HTML comment; use a non-script vector like <img onerror>")
 maze_get "/sanitizer/level4/" do |env|
   query = env.params.query["query"]
   query = query.gsub(/<script/i, "<!--").gsub(/<\/script>/i, "-->")
@@ -36,7 +40,8 @@ maze_get "/sanitizer/level4/" do |env|
 end
 
 # Level 5: Double HTML entity encode
-Xssmaze.push("sanitizer-level5", "/sanitizer/level5/?query=a", "double HTML entity encode (browser decodes once)")
+Xssmaze.push("sanitizer-level5", "/sanitizer/level5/?query=a", "double HTML entity encode (browser decodes once)",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "double HTML-entity encoded; the browser decodes only once, leaving inert entities in both the body and the title attribute, so no breakout is possible")
 maze_get "/sanitizer/level5/" do |env|
   query = env.params.query["query"]
   # Double encode: < → &amp;lt;
@@ -48,7 +53,8 @@ maze_get "/sanitizer/level5/" do |env|
 end
 
 # Level 6: Allow href but strip javascript: and data:
-Xssmaze.push("sanitizer-level6", "/sanitizer/level6/?query=a", "href allowed, javascript:/data: stripped")
+Xssmaze.push("sanitizer-level6", "/sanitizer/level6/?query=a", "href allowed, javascript:/data: stripped",
+  vuln: "reflected-html", delivery: ["query"], note: "only <a> is allowed and javascript:/data: hrefs are stripped, but event-handler attributes on <a> survive (needs interaction)")
 maze_get "/sanitizer/level6/" do |env|
   query = Filters.whitelist_tags(env.params.query["query"], ["a"])
   # Additionally strip dangerous protocols from href

--- a/src/mazes/social_media_xss.cr
+++ b/src/mazes/social_media_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Tweet/post content - raw reflection in tweet text paragraph
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("social-media-level1", "/social-media/level1/?query=a", "tweet/post content raw reflection")
+Xssmaze.push("social-media-level1", "/social-media/level1/?query=a", "tweet/post content raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/social-media/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: Username mention - raw reflection in mention link text
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("social-media-level2", "/social-media/level2/?query=a", "username mention raw reflection in link text")
+Xssmaze.push("social-media-level2", "/social-media/level2/?query=a", "username mention raw reflection in link text",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/social-media/level2/" do |env|
   query = env.params.query["query"]
 
@@ -19,7 +21,8 @@ end
 # Level 3: Hashtag - dual reflection in href attribute AND link text
 # Bypass: break out of href with ", e.g. "><script>alert(1)</script>
 # or inject directly in the text portion
-Xssmaze.push("social-media-level3", "/social-media/level3/?query=a", "hashtag dual reflection in href and link text")
+Xssmaze.push("social-media-level3", "/social-media/level3/?query=a", "hashtag dual reflection in href and link text",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into both the href and the link text; the text is a direct HTML injection")
 maze_get "/social-media/level3/" do |env|
   query = env.params.query["query"]
 
@@ -28,7 +31,8 @@ end
 
 # Level 4: Bio/description - raw reflection in bio paragraph
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("social-media-level4", "/social-media/level4/?query=a", "user bio/description raw reflection")
+Xssmaze.push("social-media-level4", "/social-media/level4/?query=a", "user bio/description raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/social-media/level4/" do |env|
   query = env.params.query["query"]
 
@@ -37,7 +41,8 @@ end
 
 # Level 5: Comment reply - raw reflection in reply text span
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("social-media-level5", "/social-media/level5/?query=a", "comment reply raw reflection in text span")
+Xssmaze.push("social-media-level5", "/social-media/level5/?query=a", "comment reply raw reflection in text span",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/social-media/level5/" do |env|
   query = env.params.query["query"]
 
@@ -46,7 +51,8 @@ end
 
 # Level 6: Share link - reflection inside href attribute of share button
 # Bypass: break out of href with ", e.g. "><script>alert(1)</script>
-Xssmaze.push("social-media-level6", "/social-media/level6/?query=a", "share link reflection in href attribute")
+Xssmaze.push("social-media-level6", "/social-media/level6/?query=a", "share link reflection in href attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into the share href; break out with the quote and >")
 maze_get "/social-media/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/svg_xss.cr
+++ b/src/mazes/svg_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("svg-xss-level1", "/svg/level1/?query=a", "SVG onload XSS")
+Xssmaze.push("svg-xss-level1", "/svg/level1/?query=a", "SVG onload XSS",
+  vuln: "reflected-attr", delivery: ["query"], note: "lands directly in an svg onload handler; the value runs as JS on load, no breakout needed")
 maze_get "/svg/level1/" do |env|
   query = env.params.query["query"]
 
@@ -8,7 +9,8 @@ maze_get "/svg/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("svg-xss-level2", "/svg/level2/?query=a", "SVG animate XSS")
+Xssmaze.push("svg-xss-level2", "/svg/level2/?query=a", "SVG animate XSS",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into an svg <animate> values attribute; break out of the double-quoted value")
 maze_get "/svg/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ maze_get "/svg/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("svg-xss-level3", "/svg/level3/?query=a", "SVG foreignObject XSS")
+Xssmaze.push("svg-xss-level3", "/svg/level3/?query=a", "SVG foreignObject XSS",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected raw as the body of a <script> inside <foreignObject>; injected JS executes directly")
 maze_get "/svg/level3/" do |env|
   query = env.params.query["query"]
 
@@ -28,7 +31,8 @@ maze_get "/svg/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("svg-xss-level4", "/svg/level4/?query=a", "SVG use XSS with href")
+Xssmaze.push("svg-xss-level4", "/svg/level4/?query=a", "SVG use XSS with href",
+  vuln: "reflected-attr", delivery: ["query"], note: "svg <use> href; break out of the double-quoted attribute")
 maze_get "/svg/level4/" do |env|
   query = env.params.query["query"]
 
@@ -38,7 +42,8 @@ maze_get "/svg/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("svg-xss-level5", "/svg/level5/?query=a", "SVG embedded with data URI")
+Xssmaze.push("svg-xss-level5", "/svg/level5/?query=a", "SVG embedded with data URI",
+  vuln: "reflected-attr", delivery: ["query"], note: "lands in a single-quoted svg onload inside a data:image/svg+xml embed; runs as JS on load")
 maze_get "/svg/level5/" do |env|
   query = env.params.query["query"]
 
@@ -48,7 +53,8 @@ maze_get "/svg/level5/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("svg-xss-level6", "/svg/level6/?query=a", "SVG with filtered script tags")
+Xssmaze.push("svg-xss-level6", "/svg/level6/?query=a", "SVG with filtered script tags",
+  vuln: "reflected-attr", delivery: ["query"], note: "<script> tags are stripped, but the value lands in an svg onload handler, so inject JS directly")
 maze_get "/svg/level6/" do |env|
   query = env.params.query["query"].gsub("<script", "").gsub("</script>", "")
 

--- a/src/mazes/template_injection_xss.cr
+++ b/src/mazes/template_injection_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Reflection inside JS template literal ${...} in a script tag
 # Exploit: Close the template literal expression and inject, e.g. };alert(1)//
 # Or break out of script entirely: </script><img src=x onerror=alert(1)>
-Xssmaze.push("tplinject-level1", "/tplinject/level1/?query=a", "reflection inside JS template literal interpolation")
+Xssmaze.push("tplinject-level1", "/tplinject/level1/?query=a", "reflection inside JS template literal interpolation",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected inside a ${\"...\"} expression in a JS template literal; break out of the double-quoted string or the </script>")
 maze_get "/tplinject/level1/" do |env|
   query = env.params.query["query"]
 
@@ -17,7 +18,8 @@ end
 # Level 2: Reflection inside an HTML <template> element that gets cloned and inserted via innerHTML
 # The template content is inert until cloned, but innerHTML assignment makes it live
 # Exploit: <img src=x onerror=alert(1)> or <script>alert(1)</script>
-Xssmaze.push("tplinject-level2", "/tplinject/level2/?query=a", "HTML template element cloned to innerHTML")
+Xssmaze.push("tplinject-level2", "/tplinject/level2/?query=a", "HTML template element cloned to innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "reflected into an inert <template>, whose innerHTML is then re-injected into the page via innerHTML, executing it")
 maze_get "/tplinject/level2/" do |env|
   query = env.params.query["query"]
 
@@ -35,7 +37,8 @@ end
 # Level 3: Reflection in a JS variable that's passed to innerHTML via indirect DOM sink
 # Exploit: Break out of JS string with '</script><img src=x onerror=alert(1)>'
 # Or inject into the JS string which flows to innerHTML: <img src=x onerror=alert(1)>
-Xssmaze.push("tplinject-level3", "/tplinject/level3/?query=a", "JS string assigned to innerHTML (indirect DOM sink)")
+Xssmaze.push("tplinject-level3", "/tplinject/level3/?query=a", "JS string assigned to innerHTML (indirect DOM sink)",
+  vuln: "reflected-js", sinks: ["innerHTML"], delivery: ["query"], note: "reflected raw into a single-quoted JS string that is concatenated into innerHTML; break out with a single quote")
 maze_get "/tplinject/level3/" do |env|
   query = env.params.query["query"]
 
@@ -53,7 +56,8 @@ end
 # Level 4: Reflection inside a script type="text/template" block, rendered via innerHTML
 # The browser ignores script type="text/template" but JS reads and renders it
 # Exploit: <img src=x onerror=alert(1)> gets stored in the template and rendered to innerHTML
-Xssmaze.push("tplinject-level4", "/tplinject/level4/?query=a", "script type=text/template rendered via innerHTML")
+Xssmaze.push("tplinject-level4", "/tplinject/level4/?query=a", "script type=text/template rendered via innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "reflected into an inert <script type=text/template>, whose innerHTML is re-injected via innerHTML")
 maze_get "/tplinject/level4/" do |env|
   query = env.params.query["query"]
 
@@ -76,7 +80,8 @@ end
 # Level 5: Server-side double render - first pass resolves {{query}}, second inserts raw HTML
 # The server replaces {{query}} with input, then the result is placed directly in the page
 # Exploit: Payload like <img src=x onerror=alert(1)> is placed via template substitution
-Xssmaze.push("tplinject-level5", "/tplinject/level5/?query=a", "server-side double template render")
+Xssmaze.push("tplinject-level5", "/tplinject/level5/?query=a", "server-side double template render",
+  vuln: "reflected-html", delivery: ["query"], note: "server-side placeholder substitution places the value raw into the page body")
 maze_get "/tplinject/level5/" do |env|
   query = env.params.query["query"]
 
@@ -96,7 +101,8 @@ end
 # Level 6: Reflection inside a data-attribute that JavaScript reads and writes to innerHTML
 # Exploit: Break out of the attribute with "> and inject HTML: "><img src=x onerror=alert(1)>
 # Or the data value itself flows to innerHTML: <img src=x onerror=alert(1)>
-Xssmaze.push("tplinject-level6", "/tplinject/level6/?query=a", "data-attribute read by JS and written to innerHTML")
+Xssmaze.push("tplinject-level6", "/tplinject/level6/?query=a", "data-attribute read by JS and written to innerHTML",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "reflected into a data-user attribute that JS reads and writes to innerHTML")
 maze_get "/tplinject/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/url_param_context_xss.cr
+++ b/src/mazes/url_param_context_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Reflection inside <a href> URL query parameter
 # Query is placed as a parameter value inside a double-quoted href attribute.
 # Bypass: break out of href with ", inject event handler, e.g. " onfocus=alert(1) autofocus x="
-Xssmaze.push("url-param-ctx-level1", "/url-param-ctx/level1/?query=a", "reflection in a href URL query parameter value")
+Xssmaze.push("url-param-ctx-level1", "/url-param-ctx/level1/?query=a", "reflection in a href URL query parameter value",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ end
 # Level 2: Reflection inside <form action> URL query parameter
 # Query is placed as a token parameter value inside a double-quoted action attribute.
 # Bypass: break out of action with ", inject event handler, e.g. " onfocus=alert(1) autofocus x="
-Xssmaze.push("url-param-ctx-level2", "/url-param-ctx/level2/?query=a", "reflection in form action URL query parameter value")
+Xssmaze.push("url-param-ctx-level2", "/url-param-ctx/level2/?query=a", "reflection in form action URL query parameter value",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ end
 # Level 3: Reflection inside <img src> URL query parameter
 # Query is placed as a name parameter value inside a double-quoted src attribute.
 # Bypass: break out of src with ", inject onerror, e.g. " onerror=alert(1) x="
-Xssmaze.push("url-param-ctx-level3", "/url-param-ctx/level3/?query=a", "reflection in img src URL query parameter value")
+Xssmaze.push("url-param-ctx-level3", "/url-param-ctx/level3/?query=a", "reflection in img src URL query parameter value",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level3/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +34,8 @@ end
 # Level 4: Reflection inside <link href> URL query parameter
 # Query is placed as a theme parameter value inside a double-quoted href on a link element.
 # Bypass: break out of href with ", inject event handler, e.g. " onload=alert(1) x="
-Xssmaze.push("url-param-ctx-level4", "/url-param-ctx/level4/?query=a", "reflection in link href URL query parameter value")
+Xssmaze.push("url-param-ctx-level4", "/url-param-ctx/level4/?query=a", "reflection in link href URL query parameter value",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -41,7 +45,8 @@ end
 # Level 5: Reflection inside <script src> URL query parameter
 # Query is placed as a version parameter value inside a double-quoted src on a script tag.
 # Bypass: break out of src with ", close script tag with ></script>, inject new tag
-Xssmaze.push("url-param-ctx-level5", "/url-param-ctx/level5/?query=a", "reflection in script src URL query parameter value")
+Xssmaze.push("url-param-ctx-level5", "/url-param-ctx/level5/?query=a", "reflection in script src URL query parameter value",
+  vuln: "reflected-attr", delivery: ["query"], note: "double-quoted script src; break out with the quote and > then close the </script> to inject a tag")
 maze_get "/url-param-ctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -51,7 +56,8 @@ end
 # Level 6: Reflection inside <iframe src> URL query parameter
 # Query is placed as an id parameter value inside a double-quoted src on an iframe.
 # Bypass: break out of src with ", inject event handler, e.g. " onload=alert(1) x="
-Xssmaze.push("url-param-ctx-level6", "/url-param-ctx/level6/?query=a", "reflection in iframe src URL query parameter value")
+Xssmaze.push("url-param-ctx-level6", "/url-param-ctx/level6/?query=a", "reflection in iframe src URL query parameter value",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/waf_bypass_xss.cr
+++ b/src/mazes/waf_bypass_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Strips <script> (case-insensitive, non-recursive) but allows other tags
-Xssmaze.push("waf-bypass-level1", "/waf-bypass/level1/?query=a", "case-insensitive script tag strip")
+Xssmaze.push("waf-bypass-level1", "/waf-bypass/level1/?query=a", "case-insensitive script tag strip",
+  vuln: "reflected-html", delivery: ["query"], note: "script removed once and case-insensitively; use a nested tag or a non-script vector")
 maze_get "/waf-bypass/level1/" do |env|
   query = Filters.strip_keyword_ci(env.params.query["query"], "script")
 
@@ -7,7 +8,8 @@ maze_get "/waf-bypass/level1/" do |env|
 end
 
 # Level 2: Strips alert/confirm/prompt (case-insensitive)
-Xssmaze.push("waf-bypass-level2", "/waf-bypass/level2/?query=a", "alert/confirm/prompt function strip")
+Xssmaze.push("waf-bypass-level2", "/waf-bypass/level2/?query=a", "alert/confirm/prompt function strip",
+  vuln: "reflected-html", delivery: ["query"], note: "alert/confirm/prompt names are stripped; use another sink such as Function or a string-built name")
 maze_get "/waf-bypass/level2/" do |env|
   query = Filters.strip_keyword_ci(env.params.query["query"], "alert")
   query = Filters.strip_keyword_ci(query, "confirm")
@@ -17,7 +19,8 @@ maze_get "/waf-bypass/level2/" do |env|
 end
 
 # Level 3: Strips on* event handler + < > encoded + in attribute
-Xssmaze.push("waf-bypass-level3", "/waf-bypass/level3/?query=a", "event strip + angle encode in double-quote attr")
+Xssmaze.push("waf-bypass-level3", "/waf-bypass/level3/?query=a", "event strip + angle encode in double-quote attr",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "reflected into a double-quoted input value, but angle brackets are entity-encoded (no new tags) and every on*= handler is stripped, so the attribute breakout reaches no JS sink")
 maze_get "/waf-bypass/level3/" do |env|
   query = Filters.encode_angles(env.params.query["query"])
   query = Filters.strip_event_handlers(query)
@@ -26,7 +29,8 @@ maze_get "/waf-bypass/level3/" do |env|
 end
 
 # Level 4: Replaces ' and " with HTML entities, reflection in JS context
-Xssmaze.push("waf-bypass-level4", "/waf-bypass/level4/?query=a", "quote entity escape in JS string")
+Xssmaze.push("waf-bypass-level4", "/waf-bypass/level4/?query=a", "quote entity escape in JS string",
+  vuln: "reflected-js", delivery: ["query"], note: "quotes are entity-escaped so the JS string cannot be broken, but angle brackets pass, so close the </script> to inject HTML")
 maze_get "/waf-bypass/level4/" do |env|
   query = env.params.query["query"]
   # Only escape quotes, allow angle brackets (for </script> breakout)
@@ -36,7 +40,8 @@ maze_get "/waf-bypass/level4/" do |env|
 end
 
 # Level 5: Strip <, but not >. Single angle is sufficient for some browsers.
-Xssmaze.push("waf-bypass-level5", "/waf-bypass/level5/?query=a", "only < stripped (> allowed)")
+Xssmaze.push("waf-bypass-level5", "/waf-bypass/level5/?query=a", "only < stripped (> allowed)",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "every < is stripped, so no tag can be opened in the body context; the reflection is inert")
 maze_get "/waf-bypass/level5/" do |env|
   query = env.params.query["query"].gsub("<", "")
 
@@ -44,7 +49,8 @@ maze_get "/waf-bypass/level5/" do |env|
 end
 
 # Level 6: Double write - input reflected in both src attribute and body
-Xssmaze.push("waf-bypass-level6", "/waf-bypass/level6/?query=a", "dual reflection: src attribute + body")
+Xssmaze.push("waf-bypass-level6", "/waf-bypass/level6/?query=a", "dual reflection: src attribute + body",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into both an img src attribute and the body; the body is a direct HTML injection")
 maze_get "/waf-bypass/level6/" do |env|
   query = env.params.query["query"]
 
@@ -52,7 +58,8 @@ maze_get "/waf-bypass/level6/" do |env|
 end
 
 # Level 7: Lowercase conversion + strip "script" keyword (case bypass needed)
-Xssmaze.push("waf-bypass-level7", "/waf-bypass/level7/?query=a", "lowercase + script keyword strip")
+Xssmaze.push("waf-bypass-level7", "/waf-bypass/level7/?query=a", "lowercase + script keyword strip",
+  vuln: "reflected-html", delivery: ["query"], note: "input is lowercased then script removed; use a lowercase non-script vector")
 maze_get "/waf-bypass/level7/" do |env|
   query = env.params.query["query"].downcase
   query = query.gsub("script", "")
@@ -62,7 +69,8 @@ end
 
 # Level 8: Strip = sign (prevents attribute-based events)
 # Exploitable via: <script>alert(1)</script> (no = needed)
-Xssmaze.push("waf-bypass-level8", "/waf-bypass/level8/?query=a", "equals sign stripped")
+Xssmaze.push("waf-bypass-level8", "/waf-bypass/level8/?query=a", "equals sign stripped",
+  vuln: "reflected-html", delivery: ["query"], note: "= is stripped; use a tag that needs no attribute value (e.g. <script>)")
 maze_get "/waf-bypass/level8/" do |env|
   query = env.params.query["query"].gsub("=", "")
 

--- a/src/mazes/xml_context_xss.cr
+++ b/src/mazes/xml_context_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: XHTML page with query in <p> element, served as text/html - standard injection
-Xssmaze.push("xmlctx-level1", "/xmlctx/level1/?query=a", "XHTML page with query in p element (text/html)")
+Xssmaze.push("xmlctx-level1", "/xmlctx/level1/?query=a", "XHTML page with query in p element (text/html)",
+  vuln: "reflected-html", delivery: ["query"], note: "served as text/html despite the XHTML prolog, so markup in the <p> renders")
 maze_get "/xmlctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -12,7 +13,8 @@ maze_get "/xmlctx/level1/" do |env|
 end
 
 # Level 2: XML-like CDATA section inside script, served as text/html - close CDATA and script
-Xssmaze.push("xmlctx-level2", "/xmlctx/level2/?query=a", "query in CDATA section inside script tag")
+Xssmaze.push("xmlctx-level2", "/xmlctx/level2/?query=a", "query in CDATA section inside script tag",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected into a double-quoted JS string inside a CDATA section; break the string or close the </script>")
 maze_get "/xmlctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -26,7 +28,8 @@ var data = \"#{query}\";
 end
 
 # Level 3: Query in XML processing instruction, served as text/html - inject HTML after
-Xssmaze.push("xmlctx-level3", "/xmlctx/level3/?query=a", "query in XML processing instruction context")
+Xssmaze.push("xmlctx-level3", "/xmlctx/level3/?query=a", "query in XML processing instruction context",
+  vuln: "reflected-html", delivery: ["query"], note: "served as text/html, so the <?xml ...?> is a bogus comment; a > ends it and the following bytes are HTML")
 maze_get "/xmlctx/level3/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +39,8 @@ maze_get "/xmlctx/level3/" do |env|
 end
 
 # Level 4: Query in <xmp> tag (deprecated but still parsed) - break out with </xmp>
-Xssmaze.push("xmlctx-level4", "/xmlctx/level4/?query=a", "query in deprecated xmp tag")
+Xssmaze.push("xmlctx-level4", "/xmlctx/level4/?query=a", "query in deprecated xmp tag",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside <xmp> raw-text; close it with </xmp>")
 maze_get "/xmlctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +49,8 @@ maze_get "/xmlctx/level4/" do |env|
 end
 
 # Level 5: Query in <listing> tag (deprecated) - break out with </listing>
-Xssmaze.push("xmlctx-level5", "/xmlctx/level5/?query=a", "query in deprecated listing tag")
+Xssmaze.push("xmlctx-level5", "/xmlctx/level5/?query=a", "query in deprecated listing tag",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected inside <listing> raw-text; close it with </listing>")
 maze_get "/xmlctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -54,7 +59,8 @@ maze_get "/xmlctx/level5/" do |env|
 end
 
 # Level 6: Query reflected BEFORE plaintext tag (plaintext disables all parsing after it)
-Xssmaze.push("xmlctx-level6", "/xmlctx/level6/?query=a", "query reflected before plaintext tag")
+Xssmaze.push("xmlctx-level6", "/xmlctx/level6/?query=a", "query reflected before plaintext tag",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected in a <div> before the <plaintext> tag, so normal HTML injection works")
 maze_get "/xmlctx/level6/" do |env|
   query = env.params.query["query"]
 


### PR DESCRIPTION
## What changed

Triages the untriaged vulnerability metadata for **slice T3 — 209 `Xssmaze.push` calls across 36 maze files**. Every push in these files was `vuln: "unclassified"` / `reach: "unknown"`; each now carries structured `vuln` / `sources` / `sinks` / `delivery` / `exploitable` / `note` so `/map/json` and `/stats` can score per class and filter by reach instead of regex-guessing at the served HTML. Metadata-only diff — no handler bodies, filters, or HTML touched.

### Classification approach

Per the `src/maze.cr` rule, I classified by **injection context** (where the bytes land), reading each handler rather than trusting the category name:

- **Raw reflection into a JS string literal → `reflected-js`**, even when the string is later passed to a DOM sink (matches `domctx`/`sink` precedent and the rule's "however inert the function it is passed to"). e.g. `htmlunsafe-level3` (`var msg='#{query}'` → `setHTMLUnsafe`), `tplinject-level3`, `filterchain-level8`.
- **Inert-container → `innerHTML` flows → `dom` / `server-reflected`** (matches existing `template_tag_xss` / `websocket_xss`): `tplinject-level2` (`<template>`), `-level4` (`<script type=text/template>`), `-level6` (`data-*` attr).
- **Client-only source flows** (`location.hash`) carry **no server channel**, so reach stays `client`: `htmlunsafe-level1/5`. Query-delivered DOM flows (`location.search`) stay `reach: server`.
- New sink names `setHTMLUnsafe` / `parseHTMLUnsafe` were introduced (the `html_unsafe` category exists specifically to measure that sink-name coverage gap); every `vuln` class stays inside `VULN_CLASSES`.

### `exploitable: false` (5 — these change a benchmark's denominator, please review individually)

| Endpoint | vuln | Why not exploitable |
|---|---|---|
| `mutfilter-level1` | non-xss-control | `<`/`>` are replaced with the **literal text** `%3C`/`%3E`; nothing decodes them client-side, so no tag can form. Verified: body renders `%3Cscript%3E...`. |
| `sanitizer-level5` | non-xss-control | **Double** HTML-entity encode; the browser decodes only once, leaving inert entities (`&lt;`, `&quot;`) in both the body and the `title` attribute — no breakout. |
| `waf-bypass-level3` | non-xss-control | Reflected into a double-quoted `<input value>`, but angle brackets are entity-encoded (no new tags) **and** every `on*=` handler is stripped, so the attribute breakout reaches no JS sink. Verified: `x" onmouseover=alert(1)` → `value="x" alert(1) ..."` (handler gone). |
| `waf-bypass-level5` | non-xss-control | Every `<` is stripped in a body context, so no tag can open. Verified: `<img ...>` → `img ...` (plain text). |
| `realworld_input-level4` | non-xss-control | Open redirect via the `Location` header; browsers do not execute `javascript:`/`data:` from a `Location` redirect and `header_value` strips CR/LF — a different bug class, not XSS. |

### Second defect: `params` lists that didn't match the handler

Fixed where the handler reads a different parameter/channel than declared (verified against the handler, not just the URL):

- Header-reading: `multipart-level3` → `["Accept"]`, `multipart-level4` → `["User-Agent"]`, `realworld_input-level1` → `["X-Forwarded-For"]` (all `delivery: ["header"]`).
- `json_context-level3` → `["query", "callback"]` (also reflects `callback`).
- `response_split-level2` → `["name","color"]`, `-level3` → `["page"]`, `-level4` → `["pref"]`.
- `realworld_input` `-level4/5` → `["url"]`, `-level6` → `["lang"]`, `-level7` → `[":path"]`, `-level8` → `["callback"]`; `-level2/3` also get `method: "POST"` + `delivery: ["body"]` since the vuln is POST-only.

## How I verified

Real commands against a running build (`./bin/xssmaze -p 3971 -q --no-banner`):

- **`/stats`**: `unclassified` dropped **838 → 629 = exactly 209** (my whole slice); `controls` 6 → 11 (+5); no class outside `VULN_CLASSES`. Class deltas sum to 209 (reflected-html +112, reflected-attr +63, reflected-js +21, dom +8, non-xss-control +5).
- **End-to-end payload spot-checks** (payload matches the labelled context):
  - `dashboard-level1` `?query=<script>alert(1)</script>` → `<div class="card-header"><script>alert(1)</script></div>` (reflected-html ✓)
  - `globalattr-level1` `x">…` → `<div id="x">` (reflected-attr breakout ✓)
  - `jsonctx-level2` `a";alert(1)//` → `var data={"q":"a";alert(1)//"}` (reflected-js JS-string breakout ✓)
  - `svg-level1` `alert(document.domain)` → `<svg onload="alert(document.domain)">` (reflected-attr = raw onload ✓)
  - `multipart-level4` `User-Agent: <img onerror>` and `multipart-level3` `Accept: …` both reflected raw (header params fix ✓)
  - `path-level1` `%3Csvg onload…%3E` → `Hi <svg onload=alert(1)>` (reflected-html/path ✓)
  - `realworld_input-level5` `x"><script>…` → `content="0;url=x"><script>alert(1)</script>` (attr breakout ✓)
  - `jsonctx-level3` `callback=alert(1)` → `alert(1)({"data":"b"})` (callback param fix ✓)
  - `htmlunsafe-level2` payload **absent** from server HTML (confirms client-side `location.search` DOM flow, `setHTMLUnsafe(q)` present); `htmlunsafe-level3` `';alert(1)//` → `var msg = '';alert(1)//'` (reflected-js ✓)
  - `post-level1` POST body `<script>…` reflected raw (reflected-html/body ✓)
  - The 5 controls verified inert as described above.
- **`crystal spec`**: 188 examples, 0 failures.
- **`crystal tool format --check`**: exit 0. **ameba** (project-wide): 0 failures.

## For the reviewer to double-check

- The 5 `exploitable: false` calls (table above) — especially `waf-bypass-level3/5`, since the category name implies they should be bypassable but the filters are airtight as written.
- The `reflected-js` vs `dom` boundary on the "raw JS string that also feeds a DOM sink" levels (`htmlunsafe-3`, `tplinject-3`, `html5-sanitizer-4`): I used `reflected-js` per the injection-context rule, whereas the sibling `websocket_xss` entries chose `dom/server-reflected` for the same shape — flagging in case you'd prefer the category-consistent label there.
- New sink vocabulary `setHTMLUnsafe` / `parseHTMLUnsafe` (in `html_unsafe_xss.cr`) — no existing sink name fit.
- `multi_param_xss.cr` already declared correct `params:`; only metadata was appended there.
