### PR TITLE
feat(mazes): triage vulnerability metadata for slice T2 (210 endpoints)

### DIFF
--- a/src/mazes/advanced_xss.cr
+++ b/src/mazes/advanced_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("advanced-xss-level1", "/advanced/level1/?query=a", "XSS with WAF bypass using encoding")
+Xssmaze.push("advanced-xss-level1", "/advanced/level1/?query=a", "XSS with WAF bypass using encoding",
+  vuln: "reflected-html", delivery: ["query"], note: "the filter strips script/javascript/onload in a single pass, so scrscriptipt survives; onerror is not filtered at all")
 maze_get "/advanced/level1/" do |env|
   query = env.params.query["query"]
   # Simulate basic WAF filtering
@@ -10,7 +11,8 @@ maze_get "/advanced/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("advanced-xss-level2", "/advanced/level2/?query=a", "XSS with mutation observer")
+Xssmaze.push("advanced-xss-level2", "/advanced/level2/?query=a", "XSS with mutation observer",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined into a JS string; a MutationObserver then re-applies the added text node's textContent as innerHTML")
 maze_get "/advanced/level2/" do |env|
   query = env.params.query["query"]
 
@@ -42,7 +44,8 @@ maze_get "/advanced/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("advanced-xss-level3", "/advanced/level3/?query=a", "XSS with Service Worker")
+Xssmaze.push("advanced-xss-level3", "/advanced/level3/?query=a", "XSS with Service Worker",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "no service worker is ever registered; the value is server-inlined into a JS object literal and written to innerHTML on load")
 maze_get "/advanced/level3/" do |env|
   query = env.params.query["query"]
 
@@ -64,7 +67,8 @@ maze_get "/advanced/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("advanced-xss-level4", "/advanced/level4/?query=a", "XSS with Web Components")
+Xssmaze.push("advanced-xss-level4", "/advanced/level4/?query=a", "XSS with Web Components",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined into the custom element's connectedCallback innerHTML string")
 maze_get "/advanced/level4/" do |env|
   query = env.params.query["query"]
 
@@ -88,7 +92,8 @@ maze_get "/advanced/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("advanced-xss-level5", "/advanced/level5/?query=a", "XSS with Trusted Types bypass")
+Xssmaze.push("advanced-xss-level5", "/advanced/level5/?query=a", "XSS with Trusted Types bypass",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["trustedtypes.createHTML", "innerHTML"], delivery: ["query"], note: "the policy returns its input unchanged, and browsers without Trusted Types take an identical unguarded innerHTML path")
 maze_get "/advanced/level5/" do |env|
   query = env.params.query["query"]
 
@@ -118,7 +123,8 @@ maze_get "/advanced/level5/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("advanced-xss-level6", "/advanced/level6/?query=a", "XSS with Proxy object manipulation")
+Xssmaze.push("advanced-xss-level6", "/advanced/level6/?query=a", "XSS with Proxy object manipulation",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined into a JS string that a Proxy get trap forwards to innerHTML")
 maze_get "/advanced/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/api_response_xss.cr
+++ b/src/mazes/api_response_xss.cr
@@ -2,7 +2,8 @@
 # The query is reflected inside a JSON string value, but since Content-Type is text/html,
 # the browser will parse HTML tags embedded in the JSON.
 # Bypass: break out of JSON string with ", inject HTML like <img src=x onerror=alert(1)>
-Xssmaze.push("api-response-level1", "/api-response/level1/?query=a", "JSON-like response with text/html content type")
+Xssmaze.push("api-response-level1", "/api-response/level1/?query=a", "JSON-like response with text/html content type",
+  vuln: "reflected-html", delivery: ["query"], note: "JSON-shaped body served as text/html, so markup inside the string value is parsed as HTML")
 maze_get "/api-response/level1/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -14,7 +15,8 @@ end
 # The query is reflected inside an XML element, but Content-Type is text/html so
 # the browser renders HTML tags within the XML structure.
 # Bypass: inject <script>alert(1)</script> or <img src=x onerror=alert(1)>
-Xssmaze.push("api-response-level2", "/api-response/level2/?query=a", "XML response with text/html content type")
+Xssmaze.push("api-response-level2", "/api-response/level2/?query=a", "XML response with text/html content type",
+  vuln: "reflected-html", delivery: ["query"], note: "XML-shaped body served as text/html, so the element text is parsed as HTML")
 maze_get "/api-response/level2/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -26,7 +28,8 @@ end
 # The query is reflected in a CSV-formatted body, but Content-Type is text/html,
 # so the browser treats the entire body as HTML.
 # Bypass: inject <script>alert(1)</script> directly
-Xssmaze.push("api-response-level3", "/api-response/level3/?query=a", "CSV-like response with text/html content type")
+Xssmaze.push("api-response-level3", "/api-response/level3/?query=a", "CSV-like response with text/html content type",
+  vuln: "reflected-html", delivery: ["query"], note: "CSV-shaped body served as text/html")
 maze_get "/api-response/level3/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -38,7 +41,8 @@ end
 # The query is reflected inside JSONP data, but since Content-Type is text/html
 # the browser will parse any HTML injected into the data string.
 # Bypass: break out of JS string with ", inject </script><img src=x onerror=alert(1)>
-Xssmaze.push("api-response-level4", "/api-response/level4/?query=a", "JSONP callback response with text/html content type")
+Xssmaze.push("api-response-level4", "/api-response/level4/?query=a", "JSONP callback response with text/html content type",
+  vuln: "reflected-html", delivery: ["query"], note: "JSONP-shaped body served as text/html; it is never executed as script, so inject markup instead of breaking out of the JS string")
 maze_get "/api-response/level4/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -49,7 +53,8 @@ end
 # Level 5: HTML fragment response (no doctype/html/body tags)
 # The query is reflected inside a bare HTML fragment with no wrapping document structure.
 # Bypass: inject <script>alert(1)</script> or event handlers to break out of div
-Xssmaze.push("api-response-level5", "/api-response/level5/?query=a", "HTML fragment response without full document structure")
+Xssmaze.push("api-response-level5", "/api-response/level5/?query=a", "HTML fragment response without full document structure",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/api-response/level5/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -61,7 +66,8 @@ end
 # A simple error string with the query reflected, but Content-Type is text/html
 # so the browser will render HTML tags embedded in the error text.
 # Bypass: inject <script>alert(1)</script> directly
-Xssmaze.push("api-response-level6", "/api-response/level6/?query=a", "Plain text error response with text/html content type")
+Xssmaze.push("api-response-level6", "/api-response/level6/?query=a", "Plain text error response with text/html content type",
+  vuln: "reflected-html", delivery: ["query"], note: "plain-text-looking body, but the response is served as text/html")
 maze_get "/api-response/level6/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"

--- a/src/mazes/boolean_attr_xss.cr
+++ b/src/mazes/boolean_attr_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflected in checkbox checked attribute value (double-quoted)
-Xssmaze.push("booleanattr-level1", "/booleanattr/level1/?query=true", "boolean attr context in checkbox checked")
+Xssmaze.push("booleanattr-level1", "/booleanattr/level1/?query=true", "boolean attr context in checkbox checked",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/booleanattr/level1/" do |env|
 end
 
 # Level 2: Reflected in select multiple attribute value (double-quoted)
-Xssmaze.push("booleanattr-level2", "/booleanattr/level2/?query=true", "boolean attr context in select multiple")
+Xssmaze.push("booleanattr-level2", "/booleanattr/level2/?query=true", "boolean attr context in select multiple",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ maze_get "/booleanattr/level2/" do |env|
 end
 
 # Level 3: Reflected in input readonly attribute value (double-quoted)
-Xssmaze.push("booleanattr-level3", "/booleanattr/level3/?query=true", "boolean attr context in input readonly")
+Xssmaze.push("booleanattr-level3", "/booleanattr/level3/?query=true", "boolean attr context in input readonly",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level3/" do |env|
   query = env.params.query["query"]
 
@@ -32,7 +35,8 @@ maze_get "/booleanattr/level3/" do |env|
 end
 
 # Level 4: Reflected in button disabled attribute value (double-quoted)
-Xssmaze.push("booleanattr-level4", "/booleanattr/level4/?query=true", "boolean attr context in button disabled")
+Xssmaze.push("booleanattr-level4", "/booleanattr/level4/?query=true", "boolean attr context in button disabled",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level4/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +47,8 @@ maze_get "/booleanattr/level4/" do |env|
 end
 
 # Level 5: Reflected in details open attribute value (double-quoted)
-Xssmaze.push("booleanattr-level5", "/booleanattr/level5/?query=true", "boolean attr context in details open")
+Xssmaze.push("booleanattr-level5", "/booleanattr/level5/?query=true", "boolean attr context in details open",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level5/" do |env|
   query = env.params.query["query"]
 
@@ -54,7 +59,8 @@ maze_get "/booleanattr/level5/" do |env|
 end
 
 # Level 6: Reflected in input autofocus attribute value (double-quoted)
-Xssmaze.push("booleanattr-level6", "/booleanattr/level6/?query=true", "boolean attr context in input autofocus")
+Xssmaze.push("booleanattr-level6", "/booleanattr/level6/?query=true", "boolean attr context in input autofocus",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/bugbounty_pattern_xss.cr
+++ b/src/mazes/bugbounty_pattern_xss.cr
@@ -7,7 +7,8 @@
 # Mirrors CVE-2020-12625 / countless reports against IdP login pages
 # that echo the raw `redirect_uri` into a "Continue to ..." link or
 # a hidden form. The attribute is single-quoted and unencoded.
-Xssmaze.push("bugbounty-level1", "/bugbounty/level1/?redirect_uri=https://app.example.com/cb", "OAuth redirect_uri reflected in login form action", "GET", ["redirect_uri"])
+Xssmaze.push("bugbounty-level1", "/bugbounty/level1/?redirect_uri=https://app.example.com/cb", "OAuth redirect_uri reflected in login form action", "GET", ["redirect_uri"],
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into two single-quoted attributes: an anchor href and a hidden input value")
 maze_get "/bugbounty/level1/" do |env|
   redirect_uri = env.params.query.fetch("redirect_uri", "/")
 
@@ -27,7 +28,8 @@ end
 # raw `error_description` query param into the error page. Bug bounty
 # reports against these flows are still common — see HackerOne reports
 # under the OAuth/SSO tag.
-Xssmaze.push("bugbounty-level2", "/bugbounty/level2/?error=invalid_request&error_description=bad+input", "OAuth error_description reflected on callback", "GET", ["error_description"])
+Xssmaze.push("bugbounty-level2", "/bugbounty/level2/?error=invalid_request&error_description=bad+input", "OAuth error_description reflected on callback", "GET", ["error", "error_description"],
+  vuln: "reflected-html", delivery: ["query"], note: "both error and error_description are reflected raw into the body")
 maze_get "/bugbounty/level2/" do |env|
   err = env.params.query.fetch("error", "unknown_error")
   desc = env.params.query.fetch("error_description", "")
@@ -46,7 +48,8 @@ end
 # the user's query into the page title without escaping. Quick wins
 # for any scanner: `</title><script>alert(1)</script>` breaks out and
 # executes. Direct reflection, no chain required.
-Xssmaze.push("bugbounty-level3", "/bugbounty/level3/?q=widget", "search query reflected into <title>", "GET", ["q"])
+Xssmaze.push("bugbounty-level3", "/bugbounty/level3/?q=widget", "search query reflected into <title>", "GET", ["q"],
+  vuln: "reflected-html", delivery: ["query"], note: "lands inside <title>, an RCDATA context; close the title tag before injecting markup")
 maze_get "/bugbounty/level3/" do |env|
   q = env.params.query.fetch("q", "")
 
@@ -63,7 +66,8 @@ end
 # build the form server-side with naive string concat allow attribute
 # breakout — historically observed in WordPress plugins, Laravel
 # apps, and several Drupal modules.
-Xssmaze.push("bugbounty-level4", "/bugbounty/level4/?token=abc123", "password reset token in hidden input (attribute breakout)", "GET", ["token"])
+Xssmaze.push("bugbounty-level4", "/bugbounty/level4/?token=abc123", "password reset token in hidden input (attribute breakout)", "GET", ["token"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the input is type=hidden, so an event handler added to it never fires; break out into a new tag")
 maze_get "/bugbounty/level4/" do |env|
   token = env.params.query.fetch("token", "")
 
@@ -82,7 +86,8 @@ end
 # name back to the user. The filename arrives from the multipart
 # `filename` parameter (Content-Disposition) — attacker-controlled.
 # Both attribute and body contexts are exploitable.
-Xssmaze.push("bugbounty-level5", "/bugbounty/level5/?filename=cat.png", "upload filename reflected in img alt + caption", "GET", ["filename"])
+Xssmaze.push("bugbounty-level5", "/bugbounty/level5/?filename=cat.png", "upload filename reflected in img alt + caption", "GET", ["filename"],
+  vuln: "reflected-html", delivery: ["query"], note: "reflected twice: a single-quoted img alt attribute and the figcaption body text")
 maze_get "/bugbounty/level5/" do |env|
   filename = env.params.query.fetch("filename", "image.png")
 
@@ -101,7 +106,8 @@ end
 # let a user pick this value via querystring (admin preview, multi-
 # tenant dashboards) leak the attribute context into an inline script
 # block.
-Xssmaze.push("bugbounty-level6", "/bugbounty/level6/?shortname=test", "third-party embed snippet with reflected data attr", "GET", ["shortname"])
+Xssmaze.push("bugbounty-level6", "/bugbounty/level6/?shortname=test", "third-party embed snippet with reflected data attr", "GET", ["shortname"],
+  vuln: "reflected-js", delivery: ["query"], note: "lands in two single-quoted JS strings inside an inline script, one of them a script src being built")
 maze_get "/bugbounty/level6/" do |env|
   shortname = env.params.query.fetch("shortname", "demo")
 
@@ -126,7 +132,8 @@ end
 # an attacker injects via X-Forwarded-Host and the resulting <base>
 # rewrites every subsequent relative resource. Documented by James
 # Kettle's PortSwigger research and replicated in many bounty reports.
-Xssmaze.push("bugbounty-level7", "/bugbounty/level7/", "X-Forwarded-Host reflected in <base href> (cache poison chain)", "GET", ["X-Forwarded-Host"])
+Xssmaze.push("bugbounty-level7", "/bugbounty/level7/", "X-Forwarded-Host reflected in <base href> (cache poison chain)", "GET", ["X-Forwarded-Host"],
+  vuln: "reflected-attr", delivery: ["header"], note: "the payload arrives in the X-Forwarded-Host request header, not the query string; it lands in a double-quoted <base href> and a <link> href")
 maze_get "/bugbounty/level7/" do |env|
   host = env.request.headers.fetch("X-Forwarded-Host", env.request.headers.fetch("Host", "localhost"))
 
@@ -143,7 +150,8 @@ end
 # GitLab, Gitea, and self-hosted Git UIs have repeatedly shipped XSS
 # via branch / tag / ref parameters (CVE-2021-22214 lineage). The ref
 # lands in a breadcrumb link plus a header.
-Xssmaze.push("bugbounty-level8", "/bugbounty/level8/?ref=main", "git ref/branch name reflected in breadcrumb + header", "GET", ["ref"])
+Xssmaze.push("bugbounty-level8", "/bugbounty/level8/?ref=main", "git ref/branch name reflected in breadcrumb + header", "GET", ["ref"],
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into a single-quoted href and again as body text")
 maze_get "/bugbounty/level8/" do |env|
   ref = env.params.query.fetch("ref", "main")
 
@@ -160,7 +168,8 @@ end
 # bad value back in the form. Quote-only escaping is applied, but
 # angle brackets pass through — exactly the regression seen in many
 # SaaS signup pages.
-Xssmaze.push("bugbounty-level9", "/bugbounty/level9/?email=bad", "validation error reflecting bad input (angle brackets unfiltered)", "GET", ["email"])
+Xssmaze.push("bugbounty-level9", "/bugbounty/level9/?email=bad", "validation error reflecting bad input (angle brackets unfiltered)", "GET", ["email"],
+  vuln: "reflected-html", delivery: ["query"], note: "both quote characters are entity-encoded, so the input value attribute cannot be broken out of; the alert body reflection still takes raw angle brackets")
 maze_get "/bugbounty/level9/" do |env|
   email = Filters.escape_quotes(env.params.query.fetch("email", ""))
 
@@ -180,7 +189,8 @@ end
 # endpoint sets content-type to application/json but the response is
 # HTML-flavoured and browsers sniff it when navigated to directly.
 # Several CVEs against image/file servers match this shape.
-Xssmaze.push("bugbounty-level10", "/bugbounty/level10/?msg=hi", "JSON endpoint sniffable as HTML (no nosniff)", "GET", ["msg"])
+Xssmaze.push("bugbounty-level10", "/bugbounty/level10/?msg=hi", "JSON endpoint sniffable as HTML (no nosniff)", "GET", ["msg"],
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "the body is HTML but the response is served as application/json; no modern browser sniffs that into a document, so the markup never executes")
 maze_get "/bugbounty/level10/" do |env|
   msg = env.params.query.fetch("msg", "")
   env.response.content_type = "application/json"

--- a/src/mazes/callback_xss.cr
+++ b/src/mazes/callback_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: JSONP callback with alphanumeric filter only
-Xssmaze.push("callback-level1", "/callback/level1/?callback=myFunc", "JSONP with no callback filter")
+Xssmaze.push("callback-level1", "/callback/level1/?callback=myFunc", "JSONP with no callback filter", "GET", ["callback"],
+  vuln: "reflected-js", delivery: ["query"], note: "served as application/javascript, so it executes in a page that loads this URL with <script src>, not on direct navigation")
 maze_get "/callback/level1/" do |env|
   callback = env.params.query.fetch("callback", "callback")
   env.response.content_type = "application/javascript"
@@ -8,7 +9,8 @@ maze_get "/callback/level1/" do |env|
 end
 
 # Level 2: JSONP with ( ) stripped from callback
-Xssmaze.push("callback-level2", "/callback/level2/?callback=myFunc", "JSONP with parens stripped from callback")
+Xssmaze.push("callback-level2", "/callback/level2/?callback=myFunc", "JSONP with parens stripped from callback", "GET", ["callback"],
+  vuln: "reflected-js", delivery: ["query"], note: "same script-include reach as level1; parens are stripped, so call through tagged-template syntax instead")
 maze_get "/callback/level2/" do |env|
   callback = Filters.strip_parens(env.params.query.fetch("callback", "callback"))
   env.response.content_type = "application/javascript"
@@ -17,7 +19,8 @@ maze_get "/callback/level2/" do |env|
 end
 
 # Level 3: Callback in script tag (HTML context)
-Xssmaze.push("callback-level3", "/callback/level3/?fn=render", "callback in inline script tag")
+Xssmaze.push("callback-level3", "/callback/level3/?fn=render", "callback in inline script tag", "GET", ["fn"],
+  vuln: "reflected-js", delivery: ["query"], note: "the injectable parameter is fn; it lands as a bare statement in an inline script of an HTML page, so no quote breakout is needed")
 maze_get "/callback/level3/" do |env|
   fn_name = env.params.query.fetch("fn", "render")
 
@@ -30,7 +33,8 @@ maze_get "/callback/level3/" do |env|
 end
 
 # Level 4: Event stream callback name injection
-Xssmaze.push("callback-level4", "/callback/level4/?handler=onData", "event handler name injection")
+Xssmaze.push("callback-level4", "/callback/level4/?handler=onData", "event handler name injection", "GET", ["handler"],
+  vuln: "reflected-js", delivery: ["query"], note: "the injectable parameter is handler; it lands inside a single-quoted property name in window['...']")
 maze_get "/callback/level4/" do |env|
   handler = env.params.query.fetch("handler", "onData")
 

--- a/src/mazes/cms_pattern_xss.cr
+++ b/src/mazes/cms_pattern_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: WordPress post title - raw reflection in entry-title h1
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("cmspattern-level1", "/cmspattern/level1/?query=a", "WordPress post title raw reflection")
+Xssmaze.push("cmspattern-level1", "/cmspattern/level1/?query=a", "WordPress post title raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: WordPress widget title - raw reflection in widget-title h3
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("cmspattern-level2", "/cmspattern/level2/?query=a", "WordPress widget title raw reflection")
+Xssmaze.push("cmspattern-level2", "/cmspattern/level2/?query=a", "WordPress widget title raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ end
 
 # Level 3: Drupal field body - raw reflection in field paragraph
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("cmspattern-level3", "/cmspattern/level3/?query=a", "Drupal field body raw reflection")
+Xssmaze.push("cmspattern-level3", "/cmspattern/level3/?query=a", "Drupal field body raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level3/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +30,8 @@ end
 
 # Level 4: Joomla module - raw reflection in module heading
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("cmspattern-level4", "/cmspattern/level4/?query=a", "Joomla module heading raw reflection")
+Xssmaze.push("cmspattern-level4", "/cmspattern/level4/?query=a", "Joomla module heading raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level4/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +40,8 @@ end
 
 # Level 5: Ghost blog excerpt - raw reflection in post-card-excerpt
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("cmspattern-level5", "/cmspattern/level5/?query=a", "Ghost blog excerpt raw reflection")
+Xssmaze.push("cmspattern-level5", "/cmspattern/level5/?query=a", "Ghost blog excerpt raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level5/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +50,8 @@ end
 
 # Level 6: Medium-style article section - raw reflection in nested article content
 # Bypass: direct HTML injection, e.g. <script>alert(1)</script>
-Xssmaze.push("cmspattern-level6", "/cmspattern/level6/?query=a", "Medium-style article content raw reflection")
+Xssmaze.push("cmspattern-level6", "/cmspattern/level6/?query=a", "Medium-style article content raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/content_type_xss.cr
+++ b/src/mazes/content_type_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: text/xml content type with raw reflection
-Xssmaze.push("ctype-level1", "/ctype/level1/?query=a", "text/xml content type with raw reflection")
+Xssmaze.push("ctype-level1", "/ctype/level1/?query=a", "text/xml content type with raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "parsed as an XML document: the payload must stay well-formed and carry the XHTML namespace on its script element")
 maze_get "/ctype/level1/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/xml"
@@ -8,7 +9,8 @@ maze_get "/ctype/level1/" do |env|
 end
 
 # Level 2: application/xhtml+xml content type with raw reflection
-Xssmaze.push("ctype-level2", "/ctype/level2/?query=a", "application/xhtml+xml with raw reflection")
+Xssmaze.push("ctype-level2", "/ctype/level2/?query=a", "application/xhtml+xml with raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "parsed as XHTML, so the payload must be well-formed XML or the document fails to render at all")
 maze_get "/ctype/level2/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "application/xhtml+xml"
@@ -21,7 +23,8 @@ maze_get "/ctype/level2/" do |env|
 end
 
 # Level 3: text/html with reflection inside XML CDATA section
-Xssmaze.push("ctype-level3", "/ctype/level3/?query=a", "text/html with CDATA section reflection")
+Xssmaze.push("ctype-level3", "/ctype/level3/?query=a", "text/html with CDATA section reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "the HTML parser treats <![CDATA[ as a bogus comment that ends at the first >, so lead the payload with > to escape it")
 maze_get "/ctype/level3/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -30,7 +33,8 @@ maze_get "/ctype/level3/" do |env|
 end
 
 # Level 4: JSONP response with callback parameter
-Xssmaze.push("ctype-level4", "/ctype/level4/?callback=func", "JSONP callback with application/javascript")
+Xssmaze.push("ctype-level4", "/ctype/level4/?callback=func", "JSONP callback with application/javascript", "GET", ["callback"],
+  vuln: "reflected-js", delivery: ["query"], note: "the injectable parameter is callback, not query; served as application/javascript, so it runs in a page that loads this URL with <script src> rather than on direct navigation")
 maze_get "/ctype/level4/" do |env|
   callback = env.params.query.fetch("callback", "func")
   env.response.content_type = "application/javascript"
@@ -39,7 +43,8 @@ maze_get "/ctype/level4/" do |env|
 end
 
 # Level 5: image/svg+xml with reflection inside SVG text element
-Xssmaze.push("ctype-level5", "/ctype/level5/?query=a", "image/svg+xml with SVG text reflection")
+Xssmaze.push("ctype-level5", "/ctype/level5/?query=a", "image/svg+xml with SVG text reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "standalone SVG document: scripts run on direct navigation but not when the URL is used as an <img> source, and the payload must be well-formed XML")
 maze_get "/ctype/level5/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "image/svg+xml"
@@ -48,7 +53,8 @@ maze_get "/ctype/level5/" do |env|
 end
 
 # Level 6: text/html with X-Content-Type-Options: nosniff and raw reflection
-Xssmaze.push("ctype-level6", "/ctype/level6/?query=a", "text/html with nosniff and raw reflection")
+Xssmaze.push("ctype-level6", "/ctype/level6/?query=a", "text/html with nosniff and raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "the nosniff header is not a control here: the response really is text/html, so the reflection executes")
 maze_get "/ctype/level6/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"

--- a/src/mazes/custom_tag_xss.cr
+++ b/src/mazes/custom_tag_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Raw reflection inside a custom element
 # Bypass: inject arbitrary HTML since no escaping is applied
 # e.g. <script>alert(1)</script>
-Xssmaze.push("customtag-level1", "/customtag/level1/?query=a", "raw reflection in custom element")
+Xssmaze.push("customtag-level1", "/customtag/level1/?query=a", "raw reflection in custom element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/customtag/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ end
 # Level 2: Reflection in data-value attribute of custom element
 # Bypass: break out of attribute with " then inject new tag
 # e.g. "><script>alert(1)</script>
-Xssmaze.push("customtag-level2", "/customtag/level2/?query=a", "reflection in custom element data-value attribute")
+Xssmaze.push("customtag-level2", "/customtag/level2/?query=a", "reflection in custom element data-value attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/customtag/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ end
 # Level 3: Raw reflection inside div with is= custom element extension
 # Bypass: inject arbitrary HTML since no escaping is applied
 # e.g. <script>alert(1)</script>
-Xssmaze.push("customtag-level3", "/customtag/level3/?query=a", "raw reflection in customized built-in element (is= attribute)")
+Xssmaze.push("customtag-level3", "/customtag/level3/?query=a", "raw reflection in customized built-in element (is= attribute)",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/customtag/level3/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +34,8 @@ end
 # Level 4: Reflection in slot name attribute
 # Bypass: break out of name attribute with " then inject new tag
 # e.g. "><script>alert(1)</script>
-Xssmaze.push("customtag-level4", "/customtag/level4/?query=a", "reflection in slot name attribute")
+Xssmaze.push("customtag-level4", "/customtag/level4/?query=a", "reflection in slot name attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/customtag/level4/" do |env|
   query = env.params.query["query"]
 
@@ -42,7 +46,8 @@ end
 # Template contents are inert in browser but visible in response source
 # Bypass: inject arbitrary HTML (detectable by response-body scanner)
 # e.g. <script>alert(1)</script>
-Xssmaze.push("customtag-level5", "/customtag/level5/?query=a", "raw reflection inside template element")
+Xssmaze.push("customtag-level5", "/customtag/level5/?query=a", "raw reflection inside template element",
+  vuln: "reflected-html", delivery: ["query"], note: "content parsed inside <template> is inert and never executes; close the template tag first, then inject")
 maze_get "/customtag/level5/" do |env|
   query = env.params.query["query"]
 
@@ -52,7 +57,8 @@ end
 # Level 6: Raw reflection inside output element
 # Bypass: inject arbitrary HTML since no escaping is applied
 # e.g. <script>alert(1)</script>
-Xssmaze.push("customtag-level6", "/customtag/level6/?query=a", "raw reflection in output element")
+Xssmaze.push("customtag-level6", "/customtag/level6/?query=a", "raw reflection in output element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/customtag/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/double_encoding_xss.cr
+++ b/src/mazes/double_encoding_xss.cr
@@ -3,7 +3,8 @@ require "base64"
 # Level 1: Server performs double URL decode before reflection
 # Exploit: Send double-URL-encoded payload e.g. %253Cscript%253Ealert(1)%253C/script%253E
 # First decode: %3Cscript%3Ealert(1)%3C/script%3E, second decode: <script>alert(1)</script>
-Xssmaze.push("dblenc-level1", "/dblenc/level1/?query=a", "double URL decode before reflection")
+Xssmaze.push("dblenc-level1", "/dblenc/level1/?query=a", "double URL decode before reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "two extra URL decodes on top of the framework's own, so percent-encoded payloads arrive as raw markup")
 maze_get "/dblenc/level1/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +22,8 @@ end
 
 # Level 2: Server HTML-decodes entities then reflects raw
 # Exploit: Send &lt;script&gt;alert(1)&lt;/script&gt; which becomes <script>alert(1)</script>
-Xssmaze.push("dblenc-level2", "/dblenc/level2/?query=a", "HTML entity decode before reflection")
+Xssmaze.push("dblenc-level2", "/dblenc/level2/?query=a", "HTML entity decode before reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "&lt; and &gt; are decoded back to angle brackets before reflection")
 maze_get "/dblenc/level2/" do |env|
   query = env.params.query["query"]
 
@@ -40,7 +42,8 @@ end
 
 # Level 3: Server base64-decodes query then reflects raw
 # Exploit: Send base64-encoded payload e.g. PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==
-Xssmaze.push("dblenc-level3", "/dblenc/level3/?query=YQ==", "base64 decode before reflection")
+Xssmaze.push("dblenc-level3", "/dblenc/level3/?query=YQ==", "base64 decode before reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "the parameter must be base64; anything that fails to decode is replaced with a fixed error string, so a raw payload never reaches the page")
 maze_get "/dblenc/level3/" do |env|
   query = env.params.query["query"]
 
@@ -58,7 +61,8 @@ end
 
 # Level 4: Server performs single URL decode then reflects raw
 # Exploit: Send %3Cscript%3Ealert(1)%3C/script%3E which decodes to <script>alert(1)</script>
-Xssmaze.push("dblenc-level4", "/dblenc/level4/?query=a", "single URL decode before reflection")
+Xssmaze.push("dblenc-level4", "/dblenc/level4/?query=a", "single URL decode before reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "the server URL-decodes once before reflecting")
 maze_get "/dblenc/level4/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/edge_filter_xss.cr
+++ b/src/mazes/edge_filter_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Strips 'script' keyword (case-insensitive) but allows everything else - use <img onerror>
-Xssmaze.push("edgefilter-level1", "/edgefilter/level1/?query=a", "strips script keyword but allows other tags and event handlers")
+Xssmaze.push("edgefilter-level1", "/edgefilter/level1/?query=a", "strips script keyword but allows other tags and event handlers",
+  vuln: "reflected-html", delivery: ["query"], note: "script is stripped case-insensitively; other tags and their event handlers pass through untouched")
 maze_get "/edgefilter/level1/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/script/i, "")
@@ -12,7 +13,8 @@ end
 
 # Level 2: Strips all tags matching <[^>]+> pattern once, but double-wrapped tags survive
 # Outer angle brackets get consumed, leaving inner tag intact
-Xssmaze.push("edgefilter-level2", "/edgefilter/level2/?query=a", "single-pass tag regex strip (double-wrap bypass)")
+Xssmaze.push("edgefilter-level2", "/edgefilter/level2/?query=a", "single-pass tag regex strip (double-wrap bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "one pass of a <...> regex; nest a throwaway tag inside the payload so the surviving halves rejoin")
 maze_get "/edgefilter/level2/" do |env|
   query = env.params.query["query"]
   # Single-pass strip: matches <...> greedily
@@ -26,7 +28,8 @@ end
 
 # Level 3: Reflection in an attribute value="QUERY" - < encoded only when followed by alpha char
 # Break out of attribute with double-quote instead
-Xssmaze.push("edgefilter-level3", "/edgefilter/level3/?query=a", "angle bracket filter only before alpha chars, reflection in attribute")
+Xssmaze.push("edgefilter-level3", "/edgefilter/level3/?query=a", "angle bracket filter only before alpha chars, reflection in attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "< is only encoded when a letter follows it; break out of the double-quoted value attribute rather than injecting a tag")
 maze_get "/edgefilter/level3/" do |env|
   query = env.params.query["query"]
   # Encode < only when followed by a letter (tries to block tags but misses attribute escape)
@@ -39,7 +42,8 @@ maze_get "/edgefilter/level3/" do |env|
 end
 
 # Level 4: Strips event handlers (on[a-z]+=) but doesn't strip tags - use <script>alert(1)</script>
-Xssmaze.push("edgefilter-level4", "/edgefilter/level4/?query=a", "strips event handlers but allows script tags")
+Xssmaze.push("edgefilter-level4", "/edgefilter/level4/?query=a", "strips event handlers but allows script tags",
+  vuln: "reflected-html", delivery: ["query"], note: "event-handler attributes are stripped, but tags are not")
 maze_get "/edgefilter/level4/" do |env|
   query = env.params.query["query"]
   # Remove event handler attributes like onclick=, onerror=, onload=, etc.
@@ -53,7 +57,8 @@ end
 
 # Level 5: Strips < > " ' but reflected inside <script>var x=QUERY;</script> (no quotes around QUERY)
 # Inject raw JS like 1;alert(1) since no quotes to break out of and no angle brackets needed
-Xssmaze.push("edgefilter-level5", "/edgefilter/level5/?query=a", "strips angle brackets and quotes but reflects in raw JS context")
+Xssmaze.push("edgefilter-level5", "/edgefilter/level5/?query=a", "strips angle brackets and quotes but reflects in raw JS context",
+  vuln: "reflected-js", delivery: ["query"], note: "angle brackets and both quote characters are stripped, but the value lands unquoted in a JS statement, so plain code such as 1;alert(1) runs")
 maze_get "/edgefilter/level5/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("<", "").gsub(">", "").gsub("\"", "").gsub("'", "")
@@ -65,7 +70,8 @@ maze_get "/edgefilter/level5/" do |env|
 end
 
 # Level 6: HTML encodes < > " ' & but only in first 20 chars of input, rest is raw
-Xssmaze.push("edgefilter-level6", "/edgefilter/level6/?query=a", "HTML encode first 20 chars only, rest is raw reflection")
+Xssmaze.push("edgefilter-level6", "/edgefilter/level6/?query=a", "HTML encode first 20 chars only, rest is raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "only the first 20 characters are entity-encoded; pad the payload past that offset")
 maze_get "/edgefilter/level6/" do |env|
   query = env.params.query["query"]
   if query.size > 20

--- a/src/mazes/encoding_bypass_xss.cr
+++ b/src/mazes/encoding_bypass_xss.cr
@@ -1,7 +1,8 @@
 require "base64"
 
 # Level 1: Strips <script> recursively but allows other tags
-Xssmaze.push("encoding-bypass-level1", "/encoding-bypass/level1/?query=a", "recursive script strip (other tags allowed)")
+Xssmaze.push("encoding-bypass-level1", "/encoding-bypass/level1/?query=a", "recursive script strip (other tags allowed)",
+  vuln: "reflected-html", delivery: ["query"], note: "script is stripped recursively so nesting does not help; every other tag and event handler is untouched")
 maze_get "/encoding-bypass/level1/" do |env|
   query = Filters.strip_keyword_recursive(env.params.query["query"], "script")
 
@@ -9,7 +10,8 @@ maze_get "/encoding-bypass/level1/" do |env|
 end
 
 # Level 2: Strips < > but only first occurrence each
-Xssmaze.push("encoding-bypass-level2", "/encoding-bypass/level2/?query=a", "single < > strip (only first occurrence)")
+Xssmaze.push("encoding-bypass-level2", "/encoding-bypass/level2/?query=a", "single < > strip (only first occurrence)",
+  vuln: "reflected-html", delivery: ["query"], note: "only the first < and the first > are removed; double them up")
 maze_get "/encoding-bypass/level2/" do |env|
   query = env.params.query["query"]
   query = query.sub("<", "")
@@ -19,7 +21,8 @@ maze_get "/encoding-bypass/level2/" do |env|
 end
 
 # Level 3: Replaces 'alert' with empty string (non-recursive)
-Xssmaze.push("encoding-bypass-level3", "/encoding-bypass/level3/?query=a", "alert keyword strip (non-recursive)")
+Xssmaze.push("encoding-bypass-level3", "/encoding-bypass/level3/?query=a", "alert keyword strip (non-recursive)",
+  vuln: "reflected-html", delivery: ["query"], note: "only the literal alert keyword is stripped, in a single pass; alalertert survives, and any other sink is untouched")
 maze_get "/encoding-bypass/level3/" do |env|
   query = Filters.strip_keyword_ci(env.params.query["query"], "alert")
 
@@ -27,7 +30,8 @@ maze_get "/encoding-bypass/level3/" do |env|
 end
 
 # Level 4: Strips on* event handlers but not from within quoted strings
-Xssmaze.push("encoding-bypass-level4", "/encoding-bypass/level4/?query=a", "event handler strip + tag allowed")
+Xssmaze.push("encoding-bypass-level4", "/encoding-bypass/level4/?query=a", "event handler strip + tag allowed",
+  vuln: "reflected-html", delivery: ["query"], note: "on*= handlers are stripped, but tags are not")
 maze_get "/encoding-bypass/level4/" do |env|
   query = Filters.strip_event_handlers(env.params.query["query"])
 
@@ -35,7 +39,8 @@ maze_get "/encoding-bypass/level4/" do |env|
 end
 
 # Level 5: Lowercase + strip javascript: but allows data: protocol
-Xssmaze.push("encoding-bypass-level5", "/encoding-bypass/level5/?query=a", "javascript: strip but data: allowed in href")
+Xssmaze.push("encoding-bypass-level5", "/encoding-bypass/level5/?query=a", "javascript: strip but data: allowed in href",
+  vuln: "reflected-attr", delivery: ["query"], note: "javascript: is stripped and data: is not, but the double-quoted href can simply be broken out of")
 maze_get "/encoding-bypass/level5/" do |env|
   query = Filters.strip_js_protocol(env.params.query["query"])
 
@@ -43,7 +48,8 @@ maze_get "/encoding-bypass/level5/" do |env|
 end
 
 # Level 6: URL decode then strip < > (double URL encode bypass)
-Xssmaze.push("encoding-bypass-level6", "/encoding-bypass/level6/?query=a", "URL decode + angle strip (double encode bypass)")
+Xssmaze.push("encoding-bypass-level6", "/encoding-bypass/level6/?query=a", "URL decode + angle strip (double encode bypass)",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "the description promises a double-encoding bypass, but the angle-bracket strip runs after the decode, so no < or > can reach the body context")
 maze_get "/encoding-bypass/level6/" do |env|
   query = URI.decode(env.params.query["query"])
   query = Filters.strip_angles(query)
@@ -54,7 +60,8 @@ rescue
 end
 
 # Level 7: Whitelist img/div/span tags, strip everything else
-Xssmaze.push("encoding-bypass-level7", "/encoding-bypass/level7/?query=a", "tag whitelist (img/div/span only)")
+Xssmaze.push("encoding-bypass-level7", "/encoding-bypass/level7/?query=a", "tag whitelist (img/div/span only)",
+  vuln: "reflected-html", delivery: ["query"], note: "only img/div/span survive the whitelist, and img carries onerror")
 maze_get "/encoding-bypass/level7/" do |env|
   query = Filters.whitelist_tags(env.params.query["query"], ["img", "div", "span"])
 
@@ -62,7 +69,8 @@ maze_get "/encoding-bypass/level7/" do |env|
 end
 
 # Level 8: Length limit 60 chars + no quote escape
-Xssmaze.push("encoding-bypass-level8", "/encoding-bypass/level8/?query=a", "60 char length limit in attribute")
+Xssmaze.push("encoding-bypass-level8", "/encoding-bypass/level8/?query=a", "60 char length limit in attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "the value is truncated to 60 characters, so the whole breakout has to fit")
 maze_get "/encoding-bypass/level8/" do |env|
   query = env.params.query["query"][0, 60]
 

--- a/src/mazes/encoding_mix_xss.cr
+++ b/src/mazes/encoding_mix_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: UTF-7 Content-Type allowing +ADw-script+AD4- injection
 # Exploit: +ADw-script+AD4-alert(1)+ADw-/script+AD4- which is UTF-7 for <script>alert(1)</script>
 # Or just use raw <script>alert(1)</script> since the body is not encoded
-Xssmaze.push("encmix-level1", "/encmix/level1/?query=a", "UTF-7 charset in Content-Type with raw reflection")
+Xssmaze.push("encmix-level1", "/encmix/level1/?query=a", "UTF-7 charset in Content-Type with raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "no modern browser decodes UTF-7, but the reflection is raw, so a plain payload works regardless of the declared charset")
 maze_get "/encmix/level1/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html; charset=utf-7"
@@ -16,7 +17,8 @@ end
 # The server encodes < to &lt; and > to &gt;, but & is left raw
 # Exploit: &#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e; — server does not re-encode the &
 # so the HTML entities are preserved and the browser decodes them to <script>alert(1)</script>
-Xssmaze.push("encmix-level2", "/encmix/level2/?query=a", "HTML entity encode < > but not & (double-entity bypass)")
+Xssmaze.push("encmix-level2", "/encmix/level2/?query=a", "HTML entity encode < > but not & (double-entity bypass)",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "both angle brackets are entity-encoded before reflection, and an entity in a text node decodes to a character rather than markup, so the numeric-entity payload only renders as visible text")
 maze_get "/encmix/level2/" do |env|
   query = env.params.query["query"]
   # Only encode literal < and > but leave & untouched
@@ -32,7 +34,8 @@ end
 # The server escapes ' with \' but does not filter \uXXXX sequences
 # Exploit: \u003cimg src=x onerror=alert(1)\u003e — JS interprets unicode escapes in strings
 # Or break out with: </script><img src=x onerror=alert(1)>
-Xssmaze.push("encmix-level3", "/encmix/level3/?query=a", "JS string with backslash escape but no unicode filtering")
+Xssmaze.push("encmix-level3", "/encmix/level3/?query=a", "JS string with backslash escape but no unicode filtering",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "backslashes and single quotes are escaped, so neither a string breakout nor a unicode escape survives; the value still reaches innerHTML as raw HTML")
 maze_get "/encmix/level3/" do |env|
   query = env.params.query["query"]
   # Escape single quotes and backslashes for the JS string
@@ -52,7 +55,8 @@ end
 # The server builds a JSON response but serves it as text/html
 # Exploit: Break out of JSON string value and inject HTML tags
 # e.g. </script><img src=x onerror=alert(1)> or just raw HTML in the JSON context
-Xssmaze.push("encmix-level4", "/encmix/level4/?query=a", "JSON context served as text/html")
+Xssmaze.push("encmix-level4", "/encmix/level4/?query=a", "JSON context served as text/html",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined raw into a double-quoted JS string and then written to innerHTML; closing the <script> block works too")
 maze_get "/encmix/level4/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -74,7 +78,8 @@ end
 # Second occurrence of < > remains raw
 # Exploit: Use two sets of angle brackets — first pair gets encoded, second pair is raw
 # e.g. <x><img src=x onerror=alert(1)>
-Xssmaze.push("encmix-level5", "/encmix/level5/?query=a", "HTML encode only first < and > (second reflection raw)")
+Xssmaze.push("encmix-level5", "/encmix/level5/?query=a", "HTML encode only first < and > (second reflection raw)",
+  vuln: "reflected-html", delivery: ["query"], note: "the server URL-decodes once, then entity-encodes only the first < and the first >")
 maze_get "/encmix/level5/" do |env|
   query = env.params.query["query"]
 
@@ -97,7 +102,8 @@ end
 # Serves content with charset=iso-8859-1 and reflects input without encoding
 # This can cause character interpretation differences with high-byte characters
 # Exploit: Standard XSS payloads work since there is no filtering: <script>alert(1)</script>
-Xssmaze.push("encmix-level6", "/encmix/level6/?query=a", "ISO-8859-1 charset with raw reflection")
+Xssmaze.push("encmix-level6", "/encmix/level6/?query=a", "ISO-8859-1 charset with raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "the iso-8859-1 charset is incidental; the reflection itself is raw")
 maze_get "/encmix/level6/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html; charset=iso-8859-1"

--- a/src/mazes/framework_output_xss.cr
+++ b/src/mazes/framework_output_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Django-style error message - raw reflection inside alert div
-Xssmaze.push("fwoutput-level1", "/fwoutput/level1/?query=a", "Django-style error message, raw reflection in alert div")
+Xssmaze.push("fwoutput-level1", "/fwoutput/level1/?query=a", "Django-style error message, raw reflection in alert div",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/fwoutput/level1/" do |env|
   query = env.params.query["query"]
 
@@ -17,7 +18,8 @@ maze_get "/fwoutput/level1/" do |env|
 end
 
 # Level 2: Rails-style search form - reflection in input value attribute (attr breakout)
-Xssmaze.push("fwoutput-level2", "/fwoutput/level2/?query=a", "Rails-style search form, reflection in input value attribute")
+Xssmaze.push("fwoutput-level2", "/fwoutput/level2/?query=a", "Rails-style search form, reflection in input value attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/fwoutput/level2/" do |env|
   query = env.params.query["query"]
 
@@ -38,7 +40,8 @@ maze_get "/fwoutput/level2/" do |env|
 end
 
 # Level 3: Express-style JSON error - raw reflection inside <pre> served as text/html
-Xssmaze.push("fwoutput-level3", "/fwoutput/level3/?query=a", "Express-style JSON error in pre tag, served as text/html")
+Xssmaze.push("fwoutput-level3", "/fwoutput/level3/?query=a", "Express-style JSON error in pre tag, served as text/html",
+  vuln: "reflected-html", delivery: ["query"], note: "JSON-shaped text inside <pre>, which is ordinary parsed content rather than raw text")
 maze_get "/fwoutput/level3/" do |env|
   query = env.params.query["query"]
 
@@ -53,7 +56,8 @@ maze_get "/fwoutput/level3/" do |env|
 end
 
 # Level 4: Spring-style Thymeleaf template - raw reflection in span with th:text
-Xssmaze.push("fwoutput-level4", "/fwoutput/level4/?query=a", "Spring/Thymeleaf-style span, raw reflection in span element")
+Xssmaze.push("fwoutput-level4", "/fwoutput/level4/?query=a", "Spring/Thymeleaf-style span, raw reflection in span element",
+  vuln: "reflected-attr", delivery: ["query"], note: "no Thymeleaf runs here; th:text is an inert attribute, so break out of its double-quoted value")
 maze_get "/fwoutput/level4/" do |env|
   query = env.params.query["query"]
 
@@ -74,7 +78,8 @@ maze_get "/fwoutput/level4/" do |env|
 end
 
 # Level 5: Laravel-style breadcrumb - raw reflection in breadcrumb item
-Xssmaze.push("fwoutput-level5", "/fwoutput/level5/?query=a", "Laravel-style breadcrumb, raw reflection in breadcrumb item")
+Xssmaze.push("fwoutput-level5", "/fwoutput/level5/?query=a", "Laravel-style breadcrumb, raw reflection in breadcrumb item",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/fwoutput/level5/" do |env|
   query = env.params.query["query"]
 
@@ -98,7 +103,8 @@ maze_get "/fwoutput/level5/" do |env|
 end
 
 # Level 6: .NET-style asp:Label - raw reflection (asp: prefix is just a namespace, doesn't prevent XSS)
-Xssmaze.push("fwoutput-level6", "/fwoutput/level6/?query=a", ".NET-style asp:Label, raw reflection in label element")
+Xssmaze.push("fwoutput-level6", "/fwoutput/level6/?query=a", ".NET-style asp:Label, raw reflection in label element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/fwoutput/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/hidden_reflection_xss.cr
+++ b/src/mazes/hidden_reflection_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflected in hidden input — change type, add autofocus/onfocus
-Xssmaze.push("hidden-reflection-level1", "/hidden-reflection/level1/?query=a", "reflection in hidden input (type override)")
+Xssmaze.push("hidden-reflection-level1", "/hidden-reflection/level1/?query=a", "reflection in hidden input (type override)",
+  vuln: "reflected-attr", delivery: ["query"], note: "type=hidden, and the parser drops a duplicate type attribute, so an injected handler never fires; break out into a new tag instead")
 maze_get "/hidden-reflection/level1/" do |env|
   query = env.params.query["query"]
 
@@ -7,7 +8,8 @@ maze_get "/hidden-reflection/level1/" do |env|
 end
 
 # Level 2: Reflected in meta refresh URL — close attribute, inject tag
-Xssmaze.push("hidden-reflection-level2", "/hidden-reflection/level2/?query=a", "reflection in meta refresh URL")
+Xssmaze.push("hidden-reflection-level2", "/hidden-reflection/level2/?query=a", "reflection in meta refresh URL",
+  vuln: "reflected-attr", delivery: ["query"], note: "browsers refuse javascript: in a meta refresh; break out of the double-quoted content attribute instead")
 maze_get "/hidden-reflection/level2/" do |env|
   query = env.params.query["query"]
 
@@ -15,7 +17,8 @@ maze_get "/hidden-reflection/level2/" do |env|
 end
 
 # Level 3: Reflected in img data-original attribute — break out of attribute
-Xssmaze.push("hidden-reflection-level3", "/hidden-reflection/level3/?query=a", "reflection in img data-original attribute")
+Xssmaze.push("hidden-reflection-level3", "/hidden-reflection/level3/?query=a", "reflection in img data-original attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/hidden-reflection/level3/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +26,8 @@ maze_get "/hidden-reflection/level3/" do |env|
 end
 
 # Level 4: Reflected in application/json script block — close script tag to break out
-Xssmaze.push("hidden-reflection-level4", "/hidden-reflection/level4/?query=a", "reflection in JSON script block (close script tag)")
+Xssmaze.push("hidden-reflection-level4", "/hidden-reflection/level4/?query=a", "reflection in JSON script block (close script tag)",
+  vuln: "reflected-html", delivery: ["query"], note: "the block is type=application/json and never executes as JS; close it with </script> and inject markup")
 maze_get "/hidden-reflection/level4/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +35,8 @@ maze_get "/hidden-reflection/level4/" do |env|
 end
 
 # Level 5: Reflected in CSS style block — close style tag to break out
-Xssmaze.push("hidden-reflection-level5", "/hidden-reflection/level5/?query=a", "reflection in CSS style block (close style tag)")
+Xssmaze.push("hidden-reflection-level5", "/hidden-reflection/level5/?query=a", "reflection in CSS style block (close style tag)",
+  vuln: "reflected-html", delivery: ["query"], note: "CSS text does not execute; close the </style> block and inject markup")
 maze_get "/hidden-reflection/level5/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +44,8 @@ maze_get "/hidden-reflection/level5/" do |env|
 end
 
 # Level 6: Reflected inside noscript tag — close noscript to inject
-Xssmaze.push("hidden-reflection-level6", "/hidden-reflection/level6/?query=a", "reflection in noscript tag (close noscript to inject)")
+Xssmaze.push("hidden-reflection-level6", "/hidden-reflection/level6/?query=a", "reflection in noscript tag (close noscript to inject)",
+  vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled the noscript content is raw text; close </noscript> before injecting")
 maze_get "/hidden-reflection/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/hidden_xss.cr
+++ b/src/mazes/hidden_xss.cr
@@ -1,18 +1,21 @@
-Xssmaze.push("hidden-xss-level1", "/hidden/level1/?query=a", "input-hidden")
+Xssmaze.push("hidden-xss-level1", "/hidden/level1/?query=a", "input-hidden",
+  vuln: "reflected-attr", delivery: ["query"], note: "type=hidden, so break out of the value attribute into a new tag rather than adding a handler to this element")
 maze_get "/hidden/level1/" do |env|
   query = env.params.query["query"]
 
   "<input type=\"hidden\" value=\"#{query}\">"
 end
 
-Xssmaze.push("hidden-xss-level2", "/hidden/level2/?query=a", "input-hidden and escape < >")
+Xssmaze.push("hidden-xss-level2", "/hidden/level2/?query=a", "input-hidden and escape < >",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped and the input is type=hidden, whose duplicate type attribute the parser drops; the remaining vector is an injected accesskey plus a handler, which needs Firefox and an Alt+Shift keypress")
 maze_get "/hidden/level2/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
 
   "<input type=\"hidden\" value=\"#{query}\">"
 end
 
-Xssmaze.push("hidden-xss-level3", "/hidden/level3/?query=a", "input-hidden and escape < > and space")
+Xssmaze.push("hidden-xss-level3", "/hidden/level3/?query=a", "input-hidden and escape < > and space",
+  vuln: "reflected-attr", delivery: ["query"], note: "as level2, plus spaces are stripped, so separate the injected attributes with / or a tab")
 maze_get "/hidden/level3/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
   query = Filters.strip_spaces(query)

--- a/src/mazes/injs_xss.cr
+++ b/src/mazes/injs_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("injs-xss-level1", "/injs/level1/?query=a", "injs-xss")
+Xssmaze.push("injs-xss-level1", "/injs/level1/?query=a", "injs-xss",
+  vuln: "reflected-js", delivery: ["query"], note: "unquoted JS expression context, so a bare statement runs")
 maze_get "/injs/level1/" do |env|
   query = env.params.query["query"]
 
@@ -7,7 +8,8 @@ maze_get "/injs/level1/" do |env|
   </script>"
 end
 
-Xssmaze.push("injs-xss-level2", "/injs/level2/?query=a", "injs-xss - in single quote")
+Xssmaze.push("injs-xss-level2", "/injs/level2/?query=a", "injs-xss - in single quote",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/injs/level2/" do |env|
   query = env.params.query["query"]
 
@@ -16,7 +18,8 @@ maze_get "/injs/level2/" do |env|
   </script>"
 end
 
-Xssmaze.push("injs-xss-level3", "/injs/level3/?query=a", "injs-xss - in double quote")
+Xssmaze.push("injs-xss-level3", "/injs/level3/?query=a", "injs-xss - in double quote",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/injs/level3/" do |env|
   query = env.params.query["query"]
 
@@ -25,7 +28,8 @@ maze_get "/injs/level3/" do |env|
   </script>"
 end
 
-Xssmaze.push("injs-xss-level4", "/injs/level4/?query=a", "injs-xss - in single quote and double quote")
+Xssmaze.push("injs-xss-level4", "/injs/level4/?query=a", "injs-xss - in single quote and double quote",
+  vuln: "reflected-js", delivery: ["query"], note: "single quotes are stripped, so close the <script> block instead of the string")
 maze_get "/injs/level4/" do |env|
   query = env.params.query["query"].gsub("'", "")
 
@@ -34,7 +38,8 @@ maze_get "/injs/level4/" do |env|
   </script>"
 end
 
-Xssmaze.push("injs-xss-level5", "/injs/level5/?query=a", "injs-xss - in comments style 1")
+Xssmaze.push("injs-xss-level5", "/injs/level5/?query=a", "injs-xss - in comments style 1",
+  vuln: "reflected-js", delivery: ["query"], note: "inside a block comment; close it with */ first")
 maze_get "/injs/level5/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +48,8 @@ maze_get "/injs/level5/" do |env|
   </script>"
 end
 
-Xssmaze.push("injs-xss-level6", "/injs/level6/?query=a", "injs-xss - in comments style 2")
+Xssmaze.push("injs-xss-level6", "/injs/level6/?query=a", "injs-xss - in comments style 2",
+  vuln: "reflected-js", delivery: ["query"], note: "inside a line comment; a newline (%0a) ends it")
 maze_get "/injs/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/js_string_escape_xss.cr
+++ b/src/mazes/js_string_escape_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: JS double-quoted string with " escaped to \" but </script> not blocked
 # Bypass: can't break out of JS string with ", but can close the script tag
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsescape-level1", "/jsescape/level1/?query=a", "JS string double-quote escaped but script tag not blocked")
+Xssmaze.push("jsescape-level1", "/jsescape/level1/?query=a", "JS string double-quote escaped but script tag not blocked",
+  vuln: "reflected-js", delivery: ["query"], note: "double quotes are backslash-escaped; close the <script> block instead of the string")
 maze_get "/jsescape/level1/" do |env|
   query = env.params.query["query"].gsub("\"", "\\\"")
 
@@ -11,7 +12,8 @@ end
 # Level 2: JS single-quoted string with ' escaped to \' but </script> not blocked
 # Bypass: can't break out of JS string with ', but can close the script tag
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsescape-level2", "/jsescape/level2/?query=a", "JS string single-quote escaped but script tag not blocked")
+Xssmaze.push("jsescape-level2", "/jsescape/level2/?query=a", "JS string single-quote escaped but script tag not blocked",
+  vuln: "reflected-js", delivery: ["query"], note: "the backslash itself is not escaped, so a leading backslash neutralises the quote escape and closes the string; closing the <script> block also works")
 maze_get "/jsescape/level2/" do |env|
   query = env.params.query["query"].gsub("'", "\\'")
 
@@ -21,7 +23,8 @@ end
 # Level 3: JS template literal with " and ' escaped, but backtick not escaped, </script> not blocked
 # Bypass: close script tag and inject HTML
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsescape-level3", "/jsescape/level3/?query=a", "JS template literal quotes escaped but backtick and script tag not blocked")
+Xssmaze.push("jsescape-level3", "/jsescape/level3/?query=a", "JS template literal quotes escaped but backtick and script tag not blocked",
+  vuln: "reflected-js", delivery: ["query"], note: "template literal: the backtick is not escaped, and a ${...} substitution evaluates without any breakout")
 maze_get "/jsescape/level3/" do |env|
   query = env.params.query["query"].gsub("\"", "\\\"").gsub("'", "\\'")
 
@@ -35,7 +38,8 @@ end
 # Real vulnerability: just close script tag (</script> is not blocked, and neither
 # \ nor " escaping affects angle brackets)
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsescape-level4", "/jsescape/level4/?query=a", "JS string with backslash and quote both escaped but script tag not blocked")
+Xssmaze.push("jsescape-level4", "/jsescape/level4/?query=a", "JS string with backslash and quote both escaped but script tag not blocked",
+  vuln: "reflected-js", delivery: ["query"], note: "backslashes are escaped before quotes, so the string itself holds; close the <script> block")
 maze_get "/jsescape/level4/" do |env|
   query = env.params.query["query"]
   query = query.gsub("\\", "\\\\") # \ -> \\
@@ -48,7 +52,8 @@ end
 # but query is also reflected raw in the HTML body
 # Bypass: exploit the body reflection with raw HTML injection
 # e.g. <script>alert(1)</script>
-Xssmaze.push("jsescape-level5", "/jsescape/level5/?query=a", "JS string with < encoded but raw reflection in body")
+Xssmaze.push("jsescape-level5", "/jsescape/level5/?query=a", "JS string with < encoded but raw reflection in body",
+  vuln: "reflected-html", delivery: ["query"], note: "the script-string copy encodes < and the quote, but the same value is reflected raw into the div just after it")
 maze_get "/jsescape/level5/" do |env|
   query = env.params.query["query"]
   js_query = query.gsub("<", "\\x3c").gsub("\"", "\\\"")
@@ -60,7 +65,8 @@ end
 # The HTML entity &#39; does NOT function as a JS escape - it's literal text in JS
 # Bypass: close script tag (</script> not blocked)
 # e.g. </script><script>alert(1)</script>
-Xssmaze.push("jsescape-level6", "/jsescape/level6/?query=a", "JS string single-quote HTML-entity escaped (ineffective in JS)")
+Xssmaze.push("jsescape-level6", "/jsescape/level6/?query=a", "JS string single-quote HTML-entity escaped (ineffective in JS)",
+  vuln: "reflected-js", delivery: ["query"], note: "quotes are replaced with an HTML entity, which is literal text inside a script element and never decodes; close the <script> block")
 maze_get "/jsescape/level6/" do |env|
   query = env.params.query["query"].gsub("'", "&#39;")
 

--- a/src/mazes/link_context_xss.cr
+++ b/src/mazes/link_context_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflected in <a href="QUERY">
-Xssmaze.push("linkcontext-level1", "/linkcontext/level1/?query=a", "reflection in a href attribute")
+Xssmaze.push("linkcontext-level1", "/linkcontext/level1/?query=a", "reflection in a href attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "an anchor href takes a javascript: URL, but that needs a click; a quote breakout does not")
 maze_get "/linkcontext/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/linkcontext/level1/" do |env|
 end
 
 # Level 2: Reflected in <link rel="stylesheet" href="QUERY">
-Xssmaze.push("linkcontext-level2", "/linkcontext/level2/?query=a", "reflection in link href attribute")
+Xssmaze.push("linkcontext-level2", "/linkcontext/level2/?query=a", "reflection in link href attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "a stylesheet href does not run javascript: URLs; break out of the double-quoted attribute")
 maze_get "/linkcontext/level2/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +25,8 @@ maze_get "/linkcontext/level2/" do |env|
 end
 
 # Level 3: Reflected in <a ping="QUERY">
-Xssmaze.push("linkcontext-level3", "/linkcontext/level3/?query=a", "reflection in a ping attribute")
+Xssmaze.push("linkcontext-level3", "/linkcontext/level3/?query=a", "reflection in a ping attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "the ping attribute only fires a background POST and never executes; break out of the quote")
 maze_get "/linkcontext/level3/" do |env|
   query = env.params.query["query"]
 
@@ -34,7 +37,8 @@ maze_get "/linkcontext/level3/" do |env|
 end
 
 # Level 4: Reflected in <area href="QUERY"> inside <map>
-Xssmaze.push("linkcontext-level4", "/linkcontext/level4/?query=a", "reflection in area href attribute inside map")
+Xssmaze.push("linkcontext-level4", "/linkcontext/level4/?query=a", "reflection in area href attribute inside map",
+  vuln: "reflected-attr", delivery: ["query"], note: "the usemap image does not exist, so the area is not clickable; break out of the quoted attribute instead of using a javascript: URL")
 maze_get "/linkcontext/level4/" do |env|
   query = env.params.query["query"]
 
@@ -46,7 +50,8 @@ maze_get "/linkcontext/level4/" do |env|
 end
 
 # Level 5: Reflected in <base href="QUERY">
-Xssmaze.push("linkcontext-level5", "/linkcontext/level5/?query=a", "reflection in base href attribute")
+Xssmaze.push("linkcontext-level5", "/linkcontext/level5/?query=a", "reflection in base href attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/linkcontext/level5/" do |env|
   query = env.params.query["query"]
 
@@ -59,7 +64,8 @@ maze_get "/linkcontext/level5/" do |env|
 end
 
 # Level 6: Reflected in <a href="/page" title="QUERY">
-Xssmaze.push("linkcontext-level6", "/linkcontext/level6/?query=a", "reflection in a title attribute")
+Xssmaze.push("linkcontext-level6", "/linkcontext/level6/?query=a", "reflection in a title attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/linkcontext/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/meta_refresh_xss.cr
+++ b/src/mazes/meta_refresh_xss.cr
@@ -1,22 +1,26 @@
-Xssmaze.push("metarefresh-level1", "/metarefresh/level1/?url=a", "<meta http-equiv=refresh> url unfiltered", "GET", ["url"])
+Xssmaze.push("metarefresh-level1", "/metarefresh/level1/?url=a", "<meta http-equiv=refresh> url unfiltered", "GET", ["url"],
+  vuln: "reflected-attr", delivery: ["query"], note: "browsers refuse javascript: in a meta refresh; break out of the single-quoted content attribute")
 maze_get "/metarefresh/level1/" do |env|
   url = env.params.query["url"]
   "<meta http-equiv='refresh' content='0;url=#{url}'>"
 end
 
-Xssmaze.push("metarefresh-level2", "/metarefresh/level2/?url=a", "meta refresh with quote-strip filter", "GET", ["url"])
+Xssmaze.push("metarefresh-level2", "/metarefresh/level2/?url=a", "meta refresh with quote-strip filter", "GET", ["url"],
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "both quote characters are stripped so the single-quoted content attribute cannot be broken out of, and browsers refuse both javascript: and top-level data: navigation from a meta refresh; only an open redirect is left")
 maze_get "/metarefresh/level2/" do |env|
   url = env.params.query["url"].gsub("'", "").gsub("\"", "")
   "<meta http-equiv='refresh' content='0;url=#{url}'>"
 end
 
-Xssmaze.push("metarefresh-level3", "/metarefresh/level3/?url=a", "meta refresh blocking literal javascript: only", "GET", ["url"])
+Xssmaze.push("metarefresh-level3", "/metarefresh/level3/?url=a", "meta refresh blocking literal javascript: only", "GET", ["url"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the javascript: strip is a red herring, since browsers refuse that scheme in a meta refresh anyway; the single-quoted content attribute is what breaks out")
 maze_get "/metarefresh/level3/" do |env|
   url = env.params.query["url"].gsub("javascript:", "")
   "<meta http-equiv='refresh' content='2;url=#{url}'>"
 end
 
-Xssmaze.push("metarefresh-level4", "/metarefresh/level4/?url=a", "meta refresh content fully under user control", "GET", ["url"])
+Xssmaze.push("metarefresh-level4", "/metarefresh/level4/?url=a", "meta refresh content fully under user control", "GET", ["url"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the whole content attribute is user-controlled, but it is still an attribute: break out of the double quote")
 maze_get "/metarefresh/level4/" do |env|
   url = env.params.query["url"]
   "<meta http-equiv='refresh' content=\"#{url}\">"

--- a/src/mazes/microdata_xss.cr
+++ b/src/mazes/microdata_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflected in <div itemscope itemtype="QUERY">
 # Bypass: break out of itemtype with " then inject event handler
-Xssmaze.push("microdata-level1", "/microdata/level1/?query=a", "reflection in itemtype attribute (double-quoted)")
+Xssmaze.push("microdata-level1", "/microdata/level1/?query=a", "reflection in itemtype attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/microdata/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ end
 
 # Level 2: Reflected in <span itemprop="QUERY">
 # Bypass: break out of itemprop with " then inject event handler
-Xssmaze.push("microdata-level2", "/microdata/level2/?query=a", "reflection in itemprop attribute (double-quoted)")
+Xssmaze.push("microdata-level2", "/microdata/level2/?query=a", "reflection in itemprop attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/microdata/level2/" do |env|
   query = env.params.query["query"]
 
@@ -24,7 +26,8 @@ end
 
 # Level 3: Reflected in <meta itemprop="name" content="QUERY">
 # Bypass: break out of content with " then inject event handler
-Xssmaze.push("microdata-level3", "/microdata/level3/?query=a", "reflection in meta itemprop content attribute (double-quoted)")
+Xssmaze.push("microdata-level3", "/microdata/level3/?query=a", "reflection in meta itemprop content attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/microdata/level3/" do |env|
   query = env.params.query["query"]
 
@@ -38,7 +41,8 @@ end
 
 # Level 4: Reflected in <link itemprop="url" href="QUERY">
 # Bypass: use javascript: protocol or break out with " then inject event handler
-Xssmaze.push("microdata-level4", "/microdata/level4/?query=a", "reflection in link itemprop href attribute (double-quoted)")
+Xssmaze.push("microdata-level4", "/microdata/level4/?query=a", "reflection in link itemprop href attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"], note: "a <link> href does not run javascript: URLs; break out of the double-quoted attribute")
 maze_get "/microdata/level4/" do |env|
   query = env.params.query["query"]
 
@@ -52,7 +56,8 @@ end
 
 # Level 5: Reflected in <div property="name" content="QUERY"> (RDFa)
 # Bypass: break out of content with " then inject event handler
-Xssmaze.push("microdata-level5", "/microdata/level5/?query=a", "reflection in RDFa property content attribute (double-quoted)")
+Xssmaze.push("microdata-level5", "/microdata/level5/?query=a", "reflection in RDFa property content attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/microdata/level5/" do |env|
   query = env.params.query["query"]
 
@@ -65,7 +70,8 @@ end
 
 # Level 6: Reflected in <span typeof="QUERY"> (RDFa)
 # Bypass: break out of typeof with " then inject event handler
-Xssmaze.push("microdata-level6", "/microdata/level6/?query=a", "reflection in RDFa typeof attribute (double-quoted)")
+Xssmaze.push("microdata-level6", "/microdata/level6/?query=a", "reflection in RDFa typeof attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/microdata/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/multi_context_xss.cr
+++ b/src/mazes/multi_context_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflection in textarea (safe) + body (exploitable)
 # Scanner must not stop at safe context; the second reflection is dangerous
-Xssmaze.push("multicontext-level1", "/multicontext/level1/?query=a", "textarea (safe) + body (unsafe) dual reflection")
+Xssmaze.push("multicontext-level1", "/multicontext/level1/?query=a", "textarea (safe) + body (unsafe) dual reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected twice: the textarea copy needs its tag closed first, the div copy takes markup directly")
 maze_get "/multicontext/level1/" do |env|
   query = env.params.query["query"]
 
@@ -8,7 +9,8 @@ maze_get "/multicontext/level1/" do |env|
 end
 
 # Level 2: Reflection in title (safe) + img src attribute (exploitable via javascript:)
-Xssmaze.push("multicontext-level2", "/multicontext/level2/?query=a", "title (safe) + attribute URL sink")
+Xssmaze.push("multicontext-level2", "/multicontext/level2/?query=a", "title (safe) + attribute URL sink",
+  vuln: "reflected-html", delivery: ["query"], note: "the <title> copy is not safe, only RCDATA: close the tag and inject; the anchor href copy is the same value in an attribute")
 maze_get "/multicontext/level2/" do |env|
   query = env.params.query["query"]
 
@@ -16,7 +18,8 @@ maze_get "/multicontext/level2/" do |env|
 end
 
 # Level 3: Reflection in noscript (safe for JS-enabled) + script context
-Xssmaze.push("multicontext-level3", "/multicontext/level3/?query=a", "noscript + script dual context")
+Xssmaze.push("multicontext-level3", "/multicontext/level3/?query=a", "noscript + script dual context",
+  vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled the noscript copy is raw text and takes a </noscript> breakout; the script-string copy escapes quotes but not backslashes, so it breaks out too")
 maze_get "/multicontext/level3/" do |env|
   query = env.params.query["query"]
   escaped = query.gsub("'", "\\'")
@@ -25,7 +28,8 @@ maze_get "/multicontext/level3/" do |env|
 end
 
 # Level 4: Same param in 3 attributes - class (no break), id (no break), onclick (dangerous)
-Xssmaze.push("multicontext-level4", "/multicontext/level4/?query=a", "triple attribute reflection (class + id + onclick)")
+Xssmaze.push("multicontext-level4", "/multicontext/level4/?query=a", "triple attribute reflection (class + id + onclick)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped, so no tag can be injected; break out of one of the three quoted attributes, or out of the JS string inside the onclick handler. Either way it needs a click or a hover")
 maze_get "/multicontext/level4/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
 
@@ -33,7 +37,8 @@ maze_get "/multicontext/level4/" do |env|
 end
 
 # Level 5: Reflection in HTML comment + unquoted attribute
-Xssmaze.push("multicontext-level5", "/multicontext/level5/?query=a", "HTML comment + unquoted attribute reflection")
+Xssmaze.push("multicontext-level5", "/multicontext/level5/?query=a", "HTML comment + unquoted attribute reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into an HTML comment, which --> closes, and again into an unquoted attribute value, where a space starts a new attribute")
 maze_get "/multicontext/level5/" do |env|
   query = env.params.query["query"]
 
@@ -41,7 +46,8 @@ maze_get "/multicontext/level5/" do |env|
 end
 
 # Level 6: Two params - one safe in attribute, one unsafe in body
-Xssmaze.push("multicontext-level6", "/multicontext/level6/?q1=a&q2=b", "two params: safe attr + unsafe body")
+Xssmaze.push("multicontext-level6", "/multicontext/level6/?q1=a&q2=b", "two params: safe attr + unsafe body", "GET", ["q1", "q2"],
+  vuln: "reflected-html", delivery: ["query"], note: "q1 is angle-encoded into the title attribute; q2 is the raw body reflection")
 maze_get "/multicontext/level6/" do |env|
   q1 = Filters.encode_angles(env.params.query.fetch("q1", "a"))
   q2 = env.params.query.fetch("q2", "b")

--- a/src/mazes/multiple_output_xss.cr
+++ b/src/mazes/multiple_output_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Query in <div> (raw) and <span> (HTML encoded)
 # The div is exploitable; the span is safe
-Xssmaze.push("multipleoutput-level1", "/multipleoutput/level1/?query=a", "raw div + encoded span")
+Xssmaze.push("multipleoutput-level1", "/multipleoutput/level1/?query=a", "raw div + encoded span",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/multipleoutput/level1/" do |env|
   query = env.params.query["query"]
   encoded = HTML.escape(query)
@@ -10,7 +11,8 @@ end
 
 # Level 2: Query in <script> (JS escaped) and <p> (raw)
 # The p tag is exploitable; the script context is escaped
-Xssmaze.push("multipleoutput-level2", "/multipleoutput/level2/?query=a", "JS-escaped script var + raw p tag")
+Xssmaze.push("multipleoutput-level2", "/multipleoutput/level2/?query=a", "JS-escaped script var + raw p tag",
+  vuln: "reflected-html", delivery: ["query"], note: "the script-string copy escapes quotes, backslashes and angle brackets; the <p> copy is untouched")
 maze_get "/multipleoutput/level2/" do |env|
   query = env.params.query["query"]
   js_escaped = query.gsub("\\", "\\\\").gsub("'", "\\'").gsub("\"", "\\\"").gsub("<", "\\x3c").gsub(">", "\\x3e")
@@ -20,7 +22,8 @@ end
 
 # Level 3: Query in <input> (HTML encoded) and in HTML comment (raw)
 # Break out of the comment with -->
-Xssmaze.push("multipleoutput-level3", "/multipleoutput/level3/?query=a", "encoded attribute + raw HTML comment")
+Xssmaze.push("multipleoutput-level3", "/multipleoutput/level3/?query=a", "encoded attribute + raw HTML comment",
+  vuln: "reflected-html", delivery: ["query"], note: "the raw copy sits in an HTML comment, so close it with --> before injecting")
 maze_get "/multipleoutput/level3/" do |env|
   query = env.params.query["query"]
   encoded = HTML.escape(query)
@@ -30,7 +33,8 @@ end
 
 # Level 4: Three outputs — encoded in attribute, encoded in title, raw in div
 # The div is exploitable
-Xssmaze.push("multipleoutput-level4", "/multipleoutput/level4/?query=a", "triple output: encoded attr + encoded title + raw div")
+Xssmaze.push("multipleoutput-level4", "/multipleoutput/level4/?query=a", "triple output: encoded attr + encoded title + raw div",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/multipleoutput/level4/" do |env|
   query = env.params.query["query"]
   encoded = HTML.escape(query)
@@ -40,7 +44,8 @@ end
 
 # Level 5: Query in <style> (with <> encoded) and <p> (raw)
 # The p tag is exploitable; the style context encodes angle brackets
-Xssmaze.push("multipleoutput-level5", "/multipleoutput/level5/?query=a", "encoded style comment + raw p tag")
+Xssmaze.push("multipleoutput-level5", "/multipleoutput/level5/?query=a", "encoded style comment + raw p tag",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/multipleoutput/level5/" do |env|
   query = env.params.query["query"]
   style_safe = query.gsub("<", "&lt;").gsub(">", "&gt;")
@@ -50,7 +55,8 @@ end
 
 # Level 6: Four outputs — 3 encoded in various contexts, 1 raw in footer
 # The footer is exploitable
-Xssmaze.push("multipleoutput-level6", "/multipleoutput/level6/?query=a", "four outputs: 3 encoded + 1 raw footer")
+Xssmaze.push("multipleoutput-level6", "/multipleoutput/level6/?query=a", "four outputs: 3 encoded + 1 raw footer",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/multipleoutput/level6/" do |env|
   query = env.params.query["query"]
   encoded = HTML.escape(query)

--- a/src/mazes/numeric_context_xss.cr
+++ b/src/mazes/numeric_context_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflected as raw JS value in script (no quotes around it)
-Xssmaze.push("numericcontext-level1", "/numericcontext/level1/?query=1", "numeric context in script var assignment")
+Xssmaze.push("numericcontext-level1", "/numericcontext/level1/?query=1", "numeric context in script var assignment",
+  vuln: "reflected-js", delivery: ["query"], note: "unquoted JS expression position, so a bare statement runs without any breakout")
 maze_get "/numericcontext/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ maze_get "/numericcontext/level1/" do |env|
 end
 
 # Level 2: Reflected in style z-index attribute value (double-quoted)
-Xssmaze.push("numericcontext-level2", "/numericcontext/level2/?query=1", "numeric context in style z-index attribute")
+Xssmaze.push("numericcontext-level2", "/numericcontext/level2/?query=1", "numeric context in style z-index attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "CSS cannot execute script in a modern browser; break out of the double-quoted style attribute")
 maze_get "/numericcontext/level2/" do |env|
   query = env.params.query["query"]
 
@@ -22,7 +24,8 @@ maze_get "/numericcontext/level2/" do |env|
 end
 
 # Level 3: Reflected in input max attribute value (double-quoted)
-Xssmaze.push("numericcontext-level3", "/numericcontext/level3/?query=100", "numeric context in input range max attribute")
+Xssmaze.push("numericcontext-level3", "/numericcontext/level3/?query=100", "numeric context in input range max attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/numericcontext/level3/" do |env|
   query = env.params.query["query"]
 
@@ -33,7 +36,8 @@ maze_get "/numericcontext/level3/" do |env|
 end
 
 # Level 4: Reflected in table border attribute value (double-quoted)
-Xssmaze.push("numericcontext-level4", "/numericcontext/level4/?query=1", "numeric context in table border attribute")
+Xssmaze.push("numericcontext-level4", "/numericcontext/level4/?query=1", "numeric context in table border attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/numericcontext/level4/" do |env|
   query = env.params.query["query"]
 
@@ -44,7 +48,8 @@ maze_get "/numericcontext/level4/" do |env|
 end
 
 # Level 5: Reflected in img width attribute value (double-quoted)
-Xssmaze.push("numericcontext-level5", "/numericcontext/level5/?query=200", "numeric context in img width attribute")
+Xssmaze.push("numericcontext-level5", "/numericcontext/level5/?query=200", "numeric context in img width attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/numericcontext/level5/" do |env|
   query = env.params.query["query"]
 
@@ -55,7 +60,8 @@ maze_get "/numericcontext/level5/" do |env|
 end
 
 # Level 6: Reflected as raw JS value in setTimeout delay (no quotes)
-Xssmaze.push("numericcontext-level6", "/numericcontext/level6/?query=1000", "numeric context in setTimeout delay")
+Xssmaze.push("numericcontext-level6", "/numericcontext/level6/?query=1000", "numeric context in setTimeout delay",
+  vuln: "reflected-js", delivery: ["query"], note: "the delay argument is an unquoted JS expression position, so the injection runs no matter what setTimeout does with the value")
 maze_get "/numericcontext/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/param_pollution_xss.cr
+++ b/src/mazes/param_pollution_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: First param value used for display, second for filter check
 # HPP: duplicate param names cause different server behavior
-Xssmaze.push("hpp-level1", "/hpp/level1/?query=safe&query=a", "HTTP parameter pollution (first wins display)")
+Xssmaze.push("hpp-level1", "/hpp/level1/?query=safe&query=a", "HTTP parameter pollution (first wins display)",
+  vuln: "reflected-html", delivery: ["query"], note: "the first query value is what gets displayed but the last one is what the angle-bracket check inspects; send the payload first and a clean value second")
 maze_get "/hpp/level1/" do |env|
   values = env.params.query.fetch_all("query")
   # Server uses first value for display but checks last for filtering
@@ -15,7 +16,8 @@ maze_get "/hpp/level1/" do |env|
 end
 
 # Level 2: Param splitting - query and q both reflected, but only query is filtered
-Xssmaze.push("hpp-level2", "/hpp/level2/?query=a&q=b", "param split: query filtered, q unfiltered")
+Xssmaze.push("hpp-level2", "/hpp/level2/?query=a&q=b", "param split: query filtered, q unfiltered", "GET", ["query", "q"],
+  vuln: "reflected-html", delivery: ["query"], note: "the injectable parameter is q; query has its angle brackets stripped")
 maze_get "/hpp/level2/" do |env|
   query = Filters.strip_angles(env.params.query.fetch("query", "a"))
   q = env.params.query.fetch("q", "b")
@@ -24,7 +26,8 @@ maze_get "/hpp/level2/" do |env|
 end
 
 # Level 3: Array parameter injection
-Xssmaze.push("hpp-level3", "/hpp/level3/?items[]=a&items[]=b", "array parameter injection")
+Xssmaze.push("hpp-level3", "/hpp/level3/?items[]=a&items[]=b", "array parameter injection", "GET", ["items[]"],
+  vuln: "reflected-html", delivery: ["query"], note: "the parameter name is the literal items[], and every repeat of it is reflected into its own list item")
 maze_get "/hpp/level3/" do |env|
   items = env.params.query.fetch_all("items[]")
 
@@ -32,7 +35,8 @@ maze_get "/hpp/level3/" do |env|
 end
 
 # Level 4: Param with dot notation (config.theme)
-Xssmaze.push("hpp-level4", "/hpp/level4/?config.theme=blue", "dot-notation parameter reflection")
+Xssmaze.push("hpp-level4", "/hpp/level4/?config.theme=blue", "dot-notation parameter reflection", "GET", ["config.theme"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the parameter name is the literal config.theme; the value lands in the double-quoted style attribute of <body>")
 maze_get "/hpp/level4/" do |env|
   theme = env.params.query.fetch("config.theme", "default")
 

--- a/src/mazes/path_based_xss.cr
+++ b/src/mazes/path_based_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query reflected in page breadcrumb-style paragraph
-Xssmaze.push("pathxss-level1", "/pathxss/level1/?query=a", "query reflected in body paragraph")
+Xssmaze.push("pathxss-level1", "/pathxss/level1/?query=a", "query reflected in body paragraph",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/pathxss/level1/" do |env|
   query = env.params.query["query"]
 
@@ -8,7 +9,8 @@ maze_get "/pathxss/level1/" do |env|
 end
 
 # Level 2: Query reflected in breadcrumb navigation
-Xssmaze.push("pathxss-level2", "/pathxss/level2/?query=a", "query reflected in breadcrumb navigation")
+Xssmaze.push("pathxss-level2", "/pathxss/level2/?query=a", "query reflected in breadcrumb navigation",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/pathxss/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ maze_get "/pathxss/level2/" do |env|
 end
 
 # Level 3: Query reflected in <title> tag - break out with </title>
-Xssmaze.push("pathxss-level3", "/pathxss/level3/?query=a", "query reflected in title tag")
+Xssmaze.push("pathxss-level3", "/pathxss/level3/?query=a", "query reflected in title tag",
+  vuln: "reflected-html", delivery: ["query"], note: "RCDATA inside <title>; close the tag before injecting markup")
 maze_get "/pathxss/level3/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +30,8 @@ maze_get "/pathxss/level3/" do |env|
 end
 
 # Level 4: Query reflected in canonical link href - break out with "
-Xssmaze.push("pathxss-level4", "/pathxss/level4/?query=a", "query reflected in canonical link href attribute")
+Xssmaze.push("pathxss-level4", "/pathxss/level4/?query=a", "query reflected in canonical link href attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/pathxss/level4/" do |env|
   query = env.params.query["query"]
 
@@ -38,7 +42,8 @@ maze_get "/pathxss/level4/" do |env|
 end
 
 # Level 5: Query reflected in body AND in JS variable
-Xssmaze.push("pathxss-level5", "/pathxss/level5/?query=a", "query reflected in body and JS variable")
+Xssmaze.push("pathxss-level5", "/pathxss/level5/?query=a", "query reflected in body and JS variable",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected raw twice: once as body text and once inside a double-quoted JS string")
 maze_get "/pathxss/level5/" do |env|
   query = env.params.query["query"]
 
@@ -49,7 +54,8 @@ maze_get "/pathxss/level5/" do |env|
 end
 
 # Level 6: Query reflected raw in <h1>
-Xssmaze.push("pathxss-level6", "/pathxss/level6/?query=a", "query reflected raw in h1 tag")
+Xssmaze.push("pathxss-level6", "/pathxss/level6/?query=a", "query reflected raw in h1 tag",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/pathxss/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/popover_xss.cr
+++ b/src/mazes/popover_xss.cr
@@ -1,18 +1,21 @@
-Xssmaze.push("popover-level1", "/popover/level1/?query=a", "popover content raw reflection (innerHTML of popover element)")
+Xssmaze.push("popover-level1", "/popover/level1/?query=a", "popover content raw reflection (innerHTML of popover element)",
+  vuln: "reflected-html", delivery: ["query"], note: "a closed popover is still parsed, so the injected markup runs without the popover ever being opened")
 maze_get "/popover/level1/" do |env|
   query = env.params.query["query"]
   "<button popovertarget='p'>open</button>
    <div id='p' popover>#{query}</div>"
 end
 
-Xssmaze.push("popover-level2", "/popover/level2/?query=a", "auto-popover with reflected anchor name (attribute breakout)")
+Xssmaze.push("popover-level2", "/popover/level2/?query=a", "auto-popover with reflected anchor name (attribute breakout)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are encoded, so break out of one of the two single-quoted attributes; the button copy accepts autofocus plus onfocus, which needs no interaction")
 maze_get "/popover/level2/" do |env|
   query = env.params.query["query"].gsub("<", "&lt;").gsub(">", "&gt;")
   "<div popover='auto' id='#{query}' style='anchor-name:--a'>x</div>
    <button popovertarget='#{query}'>open</button>"
 end
 
-Xssmaze.push("popover-level3", "/popover/level3/?query=a", "popover triggered via showPopover() with innerHTML sink")
+Xssmaze.push("popover-level3", "/popover/level3/?query=a", "popover triggered via showPopover() with innerHTML sink",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "query.to_json blocks a JS-string breakout, but the value still reaches innerHTML as raw HTML")
 maze_get "/popover/level3/" do |env|
   query = env.params.query["query"]
   "<div id='p' popover></div>

--- a/src/mazes/realworld_encoding_xss.cr
+++ b/src/mazes/realworld_encoding_xss.cr
@@ -3,7 +3,8 @@ require "base64"
 # Level 1: Triple URL decode
 # Server checks after first decode, but applies three total decodes before reflecting
 # Requires triple URL-encoded payload (e.g., %25253Cscript%25253E...)
-Xssmaze.push("realworld-encoding-level1", "/realworld-encoding/level1/?query=a", "triple URL decode")
+Xssmaze.push("realworld-encoding-level1", "/realworld-encoding/level1/?query=a", "triple URL decode",
+  vuln: "reflected-html", delivery: ["query"], note: "the framework decodes once before the handler's own three decodes, and an angle-bracket check runs between them, so the payload has to be percent-encoded four times on the wire, not three")
 maze_get "/realworld-encoding/level1/" do |env|
   data = URI.decode(env.params.query["query"])
   if data.includes?("<") || data.includes?(">")
@@ -23,7 +24,8 @@ end
 # Level 2: Unicode normalization (NFKC)
 # Fullwidth characters like U+FF1C (＜) normalize to < (U+003C)
 # Server blocks literal < and > but normalizes Unicode before reflecting
-Xssmaze.push("realworld-encoding-level2", "/realworld-encoding/level2/?query=a", "Unicode NFKC normalization bypass")
+Xssmaze.push("realworld-encoding-level2", "/realworld-encoding/level2/?query=a", "Unicode NFKC normalization bypass",
+  vuln: "reflected-html", delivery: ["query"], note: "literal angle brackets are rejected, but the value is NFKC-normalized afterwards, so fullwidth forms such as U+FF1C become <")
 maze_get "/realworld-encoding/level2/" do |env|
   query = env.params.query["query"]
   if query.includes?("<") || query.includes?(">")
@@ -41,7 +43,8 @@ end
 # Server decodes HTML entities once, then reflects the result in HTML context
 # The browser will decode the remaining entities, so nested entities work
 # e.g., &amp;lt; -> &lt; (server decode) -> < (browser decode)
-Xssmaze.push("realworld-encoding-level3", "/realworld-encoding/level3/?query=a", "HTML entity double decode")
+Xssmaze.push("realworld-encoding-level3", "/realworld-encoding/level3/?query=a", "HTML entity double decode",
+  vuln: "reflected-html", delivery: ["query"], note: "literal angle brackets are rejected, but the chained entity decodes turn &lt; into a real < before reflection")
 maze_get "/realworld-encoding/level3/" do |env|
   query = env.params.query["query"]
   if query.includes?("<") || query.includes?(">")
@@ -70,7 +73,8 @@ end
 # Level 4: Mixed encoding chain (Base64 + URL)
 # Server base64-decodes, then URL-decodes the result before reflecting
 # To exploit: URL-encode your payload, then base64-encode that result
-Xssmaze.push("realworld-encoding-level4", "/realworld-encoding/level4/?query=a", "base64 then URL decode chain")
+Xssmaze.push("realworld-encoding-level4", "/realworld-encoding/level4/?query=a", "base64 then URL decode chain",
+  vuln: "reflected-html", delivery: ["query"], note: "the parameter must be base64 of a URL-encoded payload; anything that fails to decode returns a fixed error string instead")
 maze_get "/realworld-encoding/level4/" do |env|
   data = Base64.decode_string(env.params.query["query"])
   decoded = URI.decode(data)
@@ -82,7 +86,8 @@ end
 # Level 5: CSS style attribute injection
 # Input reflected inside a style attribute value
 # Can break out with "> or use expression()/url() for older browsers
-Xssmaze.push("realworld-encoding-level5", "/realworld-encoding/level5/?query=a", "CSS style attribute injection")
+Xssmaze.push("realworld-encoding-level5", "/realworld-encoding/level5/?query=a", "CSS style attribute injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "expression() and url(javascript:) are long gone; break out of the double-quoted style attribute")
 maze_get "/realworld-encoding/level5/" do |env|
   query = env.params.query["query"]
 
@@ -95,7 +100,8 @@ end
 # Level 6: CSS @import / style body injection
 # Input reflected inside <style> block in a property value
 # Can break out with </style> to inject HTML, or use url(javascript:) in some contexts
-Xssmaze.push("realworld-encoding-level6", "/realworld-encoding/level6/?query=a", "CSS style tag body injection")
+Xssmaze.push("realworld-encoding-level6", "/realworld-encoding/level6/?query=a", "CSS style tag body injection",
+  vuln: "reflected-html", delivery: ["query"], note: "CSS does not execute; close the </style> block and inject markup")
 maze_get "/realworld-encoding/level6/" do |env|
   query = env.params.query["query"]
 
@@ -112,7 +118,8 @@ end
 # Level 7: SVG + URL encoding combo
 # Input is URL-decoded once, then placed inside an SVG element
 # Requires URL-encoded SVG XSS payload (e.g., onload handler)
-Xssmaze.push("realworld-encoding-level7", "/realworld-encoding/level7/?query=a", "SVG with URL decode combo")
+Xssmaze.push("realworld-encoding-level7", "/realworld-encoding/level7/?query=a", "SVG with URL decode combo",
+  vuln: "reflected-html", delivery: ["query"], note: "literal angle brackets are rejected before the handler's single decode, so percent-encode them twice on the wire; the value lands in SVG foreign content, so close </text></svg> before injecting HTML")
 maze_get "/realworld-encoding/level7/" do |env|
   query = env.params.query["query"]
   if query.includes?("<") || query.includes?(">")
@@ -132,7 +139,8 @@ end
 # Input reflected inside a JSON string within a <script> tag
 # Server escapes quotes and backslashes but does NOT sanitize </script>
 # Payload: </script><script>alert(1)</script>
-Xssmaze.push("realworld-encoding-level8", "/realworld-encoding/level8/?query=a", "JSON string with script tag breakout")
+Xssmaze.push("realworld-encoding-level8", "/realworld-encoding/level8/?query=a", "JSON string with script tag breakout",
+  vuln: "reflected-js", delivery: ["query"], note: "quotes and backslashes are escaped and the DOM sink is textContent, so the only way out is closing the <script> block")
 maze_get "/realworld-encoding/level8/" do |env|
   query = env.params.query["query"]
   # Escape quotes and backslashes (typical JSON string escaping)

--- a/src/mazes/recursive_filter_xss.cr
+++ b/src/mazes/recursive_filter_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Strip <script non-recursively (single pass)
-Xssmaze.push("recfilt-level1", "/recfilt/level1/?query=a", "strip <script non-recursively (single pass)")
+Xssmaze.push("recfilt-level1", "/recfilt/level1/?query=a", "strip <script non-recursively (single pass)",
+  vuln: "reflected-html", delivery: ["query"], note: "only the literal <script prefix is stripped, in a single pass; every other tag is untouched")
 maze_get "/recfilt/level1/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/<script/i, "")
@@ -8,7 +9,8 @@ maze_get "/recfilt/level1/" do |env|
 end
 
 # Level 2: Strip on* event handlers non-recursively
-Xssmaze.push("recfilt-level2", "/recfilt/level2/?query=a", "strip on* event handlers non-recursively")
+Xssmaze.push("recfilt-level2", "/recfilt/level2/?query=a", "strip on* event handlers non-recursively",
+  vuln: "reflected-html", delivery: ["query"], note: "event-handler attributes are stripped, but tags are not")
 maze_get "/recfilt/level2/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/\bon\w+\s*=/i, "")
@@ -17,7 +19,8 @@ maze_get "/recfilt/level2/" do |env|
 end
 
 # Level 3: Replace < with empty but only first occurrence
-Xssmaze.push("recfilt-level3", "/recfilt/level3/?query=a", "replace first < only")
+Xssmaze.push("recfilt-level3", "/recfilt/level3/?query=a", "replace first < only",
+  vuln: "reflected-html", delivery: ["query"], note: "only the first < is removed; double it")
 maze_get "/recfilt/level3/" do |env|
   query = env.params.query["query"]
   filtered = query.sub("<", "")
@@ -26,7 +29,8 @@ maze_get "/recfilt/level3/" do |env|
 end
 
 # Level 4: Strip javascript: protocol non-recursively, reflect in href
-Xssmaze.push("recfilt-level4", "/recfilt/level4/?query=a", "strip javascript: non-recursively in href context")
+Xssmaze.push("recfilt-level4", "/recfilt/level4/?query=a", "strip javascript: non-recursively in href context",
+  vuln: "reflected-attr", delivery: ["query"], note: "javascript: is stripped in a single pass, so javajavascript:script: survives it; the double-quoted href can also just be broken out of")
 maze_get "/recfilt/level4/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/javascript:/i, "")
@@ -35,7 +39,8 @@ maze_get "/recfilt/level4/" do |env|
 end
 
 # Level 5: Double-escape quotes but reflect in JS string (exploitable via </script>)
-Xssmaze.push("recfilt-level5", "/recfilt/level5/?query=a", "double-escape quotes in JS string context")
+Xssmaze.push("recfilt-level5", "/recfilt/level5/?query=a", "double-escape quotes in JS string context",
+  vuln: "reflected-js", delivery: ["query"], note: "the backslash is not escaped, so a leading backslash neutralises the quote escape; closing the <script> block also works")
 maze_get "/recfilt/level5/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("\"", "\\\"")
@@ -46,7 +51,8 @@ maze_get "/recfilt/level5/" do |env|
 end
 
 # Level 6: Strip parentheses non-recursively (bypass with backtick templates)
-Xssmaze.push("recfilt-level6", "/recfilt/level6/?query=a", "strip parentheses non-recursively")
+Xssmaze.push("recfilt-level6", "/recfilt/level6/?query=a", "strip parentheses non-recursively",
+  vuln: "reflected-html", delivery: ["query"], note: "parentheses are stripped from the input, but an entity-encoded paren inside an injected attribute decodes after the filter, and tagged-template syntax needs none at all")
 maze_get "/recfilt/level6/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/[()]/, "")

--- a/src/mazes/redirect.cr
+++ b/src/mazes/redirect.cr
@@ -8,24 +8,28 @@
 # split response, so without it a CRLF payload was a 500, not a lesson. The
 # `javascript:` sink these levels exist to teach is untouched.
 
-Xssmaze.push("redirect-level1", "/redirect/level1/?query=/", "query param")
+Xssmaze.push("redirect-level1", "/redirect/level1/?query=/", "query param",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "open redirect, not XSS: the value only reaches a Location header on an empty 302, and browsers refuse to follow javascript: or top-level data: from a redirect")
 maze_get "/redirect/level1/" do |env|
   env.redirect Xssmaze.header_value(env.params.query.fetch("query", "/"))
 end
 
-Xssmaze.push("redirect-level2", "/redirect/level2/?query=/", "query param, strips 'javascript'")
+Xssmaze.push("redirect-level2", "/redirect/level2/?query=/", "query param, strips 'javascript'",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "as level1: a single non-recursive javascript strip that javajavascriptscript: walks through, but a Location header still cannot execute anything")
 maze_get "/redirect/level2/" do |env|
   query = env.params.query.fetch("query", "/").gsub("javascript", "")
   env.redirect Xssmaze.header_value(query)
 end
 
-Xssmaze.push("redirect-level3", "/redirect/level3/?query=/", "query param, lowercased then strips 'javascript'")
+Xssmaze.push("redirect-level3", "/redirect/level3/?query=/", "query param, lowercased then strips 'javascript'",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "as level2 with the value lowercased first, which closes the mixed-case bypass; still a redirect sink with no script execution")
 maze_get "/redirect/level3/" do |env|
   query = env.params.query.fetch("query", "/").downcase.gsub("javascript", "")
   env.redirect Xssmaze.header_value(query)
 end
 
-Xssmaze.push("redirect-level4", "/redirect/level4/?query=/", "query param, two lowercase+strip passes")
+Xssmaze.push("redirect-level4", "/redirect/level4/?query=/", "query param, two lowercase+strip passes",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "as level3 with a second lowercase-and-strip pass, which closes the nesting bypass; still a redirect sink with no script execution")
 maze_get "/redirect/level4/" do |env|
   query = env.params.query.fetch("query", "/")
     .downcase.gsub("javascript", "")

--- a/src/mazes/response_header_xss.cr
+++ b/src/mazes/response_header_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: X-Content-Type-Options: nosniff with text/html content type
 # Standard XSS works - nosniff just prevents MIME type sniffing
-Xssmaze.push("respheader-level1", "/respheader/level1/?query=a", "nosniff header with text/html, raw reflection")
+Xssmaze.push("respheader-level1", "/respheader/level1/?query=a", "nosniff header with text/html, raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "nosniff is not a control here: the response really is text/html, so the reflection executes")
 maze_get "/respheader/level1/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -14,7 +15,8 @@ end
 
 # Level 2: X-XSS-Protection: 0 - XSS auditor explicitly disabled
 # Standard injection works
-Xssmaze.push("respheader-level2", "/respheader/level2/?query=a", "X-XSS-Protection disabled, raw reflection")
+Xssmaze.push("respheader-level2", "/respheader/level2/?query=a", "X-XSS-Protection disabled, raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "X-XSS-Protection is dead in every current browser, so the header changes nothing either way")
 maze_get "/respheader/level2/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -28,7 +30,8 @@ end
 
 # Level 3: Cache-Control headers present but query still reflected raw
 # Caching headers have no effect on XSS
-Xssmaze.push("respheader-level3", "/respheader/level3/?query=a", "cache-control headers with raw reflection")
+Xssmaze.push("respheader-level3", "/respheader/level3/?query=a", "cache-control headers with raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/respheader/level3/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -44,7 +47,8 @@ end
 
 # Level 4: Query reflected in Set-Cookie value AND body
 # Body injection works regardless of cookie setting
-Xssmaze.push("respheader-level4", "/respheader/level4/?query=a", "query in Set-Cookie and body reflection")
+Xssmaze.push("respheader-level4", "/respheader/level4/?query=a", "query in Set-Cookie and body reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "the two Set-Cookie copies drop the bytes a cookie value cannot carry; the body reflection is the raw one")
 maze_get "/respheader/level4/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -61,7 +65,8 @@ end
 
 # Level 5: CORS header Access-Control-Allow-Origin: * with raw reflection
 # CORS does not prevent XSS in the page itself
-Xssmaze.push("respheader-level5", "/respheader/level5/?query=a", "CORS allow-all with raw reflection")
+Xssmaze.push("respheader-level5", "/respheader/level5/?query=a", "CORS allow-all with raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/respheader/level5/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"
@@ -77,7 +82,8 @@ end
 
 # Level 6: All security headers EXCEPT CSP, query reflected raw
 # Without CSP, inline scripts still execute
-Xssmaze.push("respheader-level6", "/respheader/level6/?query=a", "all security headers except CSP, raw reflection")
+Xssmaze.push("respheader-level6", "/respheader/level6/?query=a", "all security headers except CSP, raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "every security header here is present except the one that would matter; with no CSP the inline reflection still runs")
 maze_get "/respheader/level6/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html"

--- a/src/mazes/seo_context_xss.cr
+++ b/src/mazes/seo_context_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Reflection in og:title meta tag content attribute
 # Bypass: break out of content attribute with " then inject new tag
 # e.g. "><script>alert(1)</script>
-Xssmaze.push("seoctx-level1", "/seoctx/level1/?query=a", "reflection in og:title meta content attribute")
+Xssmaze.push("seoctx-level1", "/seoctx/level1/?query=a", "reflection in og:title meta content attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ end
 # Level 2: Reflection in keywords meta tag content attribute
 # Bypass: break out of content attribute with " then inject new tag
 # e.g. "><script>alert(1)</script>
-Xssmaze.push("seoctx-level2", "/seoctx/level2/?query=a", "reflection in keywords meta content attribute")
+Xssmaze.push("seoctx-level2", "/seoctx/level2/?query=a", "reflection in keywords meta content attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ end
 # Level 3: Reflection in og:description meta tag content attribute
 # Bypass: break out of content attribute with " then inject new tag
 # e.g. "><script>alert(1)</script>
-Xssmaze.push("seoctx-level3", "/seoctx/level3/?query=a", "reflection in og:description meta content attribute")
+Xssmaze.push("seoctx-level3", "/seoctx/level3/?query=a", "reflection in og:description meta content attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level3/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +34,8 @@ end
 # Level 4: Reflection in og:url meta tag content attribute
 # Bypass: break out of content attribute with " then inject new tag
 # e.g. "><script>alert(1)</script>
-Xssmaze.push("seoctx-level4", "/seoctx/level4/?query=a", "reflection in og:url meta content attribute")
+Xssmaze.push("seoctx-level4", "/seoctx/level4/?query=a", "reflection in og:url meta content attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -41,7 +45,8 @@ end
 # Level 5: Reflection in canonical link href attribute
 # Bypass: break out of href attribute with " then inject new tag
 # e.g. "><script>alert(1)</script>
-Xssmaze.push("seoctx-level5", "/seoctx/level5/?query=a", "reflection in canonical link href attribute")
+Xssmaze.push("seoctx-level5", "/seoctx/level5/?query=a", "reflection in canonical link href attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -51,7 +56,8 @@ end
 # Level 6: Dual reflection - in meta author content AND in body span
 # Bypass: either context is exploitable; body span is easiest with raw HTML injection
 # e.g. <script>alert(1)</script>
-Xssmaze.push("seoctx-level6", "/seoctx/level6/?query=a", "dual reflection in meta author and body span")
+Xssmaze.push("seoctx-level6", "/seoctx/level6/?query=a", "dual reflection in meta author and body span",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into the meta content attribute and again as span text; the span copy takes markup directly")
 maze_get "/seoctx/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/special_tag_xss.cr
+++ b/src/mazes/special_tag_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflection inside <option> tag value
-Xssmaze.push("specialtag-level1", "/specialtag/level1/?query=a", "reflection in option value attribute")
+Xssmaze.push("specialtag-level1", "/specialtag/level1/?query=a", "reflection in option value attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/specialtag/level1/" do |env|
   query = env.params.query["query"]
 
@@ -7,7 +8,8 @@ maze_get "/specialtag/level1/" do |env|
 end
 
 # Level 2: Reflection inside <meta> tag content
-Xssmaze.push("specialtag-level2", "/specialtag/level2/?query=a", "reflection in meta tag content")
+Xssmaze.push("specialtag-level2", "/specialtag/level2/?query=a", "reflection in meta tag content",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/specialtag/level2/" do |env|
   query = env.params.query["query"]
 
@@ -15,7 +17,8 @@ maze_get "/specialtag/level2/" do |env|
 end
 
 # Level 3: Reflection inside <button> with value attribute
-Xssmaze.push("specialtag-level3", "/specialtag/level3/?query=a", "button value attribute (formaction possible)")
+Xssmaze.push("specialtag-level3", "/specialtag/level3/?query=a", "button value attribute (formaction possible)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/specialtag/level3/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +26,8 @@ maze_get "/specialtag/level3/" do |env|
 end
 
 # Level 4: Reflection in <base> tag href
-Xssmaze.push("specialtag-level4", "/specialtag/level4/?query=a", "base tag href injection")
+Xssmaze.push("specialtag-level4", "/specialtag/level4/?query=a", "base tag href injection",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/specialtag/level4/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +35,8 @@ maze_get "/specialtag/level4/" do |env|
 end
 
 # Level 5: Input in <img> alt attribute (< > stripped, attribute breakout possible)
-Xssmaze.push("specialtag-level5", "/specialtag/level5/?query=a", "img alt attribute (angle stripped)")
+Xssmaze.push("specialtag-level5", "/specialtag/level5/?query=a", "img alt attribute (angle stripped)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped, so break out of the quote and add a handler to the image itself; /logo.png does not exist, so an injected onerror fires on its own")
 maze_get "/specialtag/level5/" do |env|
   query = Filters.strip_angles(env.params.query["query"])
 
@@ -39,7 +44,8 @@ maze_get "/specialtag/level5/" do |env|
 end
 
 # Level 6: Reflection in srcdoc attribute of iframe
-Xssmaze.push("specialtag-level6", "/specialtag/level6/?query=a", "iframe srcdoc attribute injection")
+Xssmaze.push("specialtag-level6", "/specialtag/level6/?query=a", "iframe srcdoc attribute injection",
+  vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "the srcdoc attribute is double-quoted, so quote the injected markup with single quotes or entities")
 maze_get "/specialtag/level6/" do |env|
   query = env.params.query["query"]
 
@@ -47,7 +53,8 @@ maze_get "/specialtag/level6/" do |env|
 end
 
 # Level 7: Reflection in <object> data attribute
-Xssmaze.push("specialtag-level7", "/specialtag/level7/?query=a", "object data attribute injection")
+Xssmaze.push("specialtag-level7", "/specialtag/level7/?query=a", "object data attribute injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "an object data URL is not a script sink on its own; break out of the double-quoted attribute")
 maze_get "/specialtag/level7/" do |env|
   query = env.params.query["query"]
 
@@ -55,7 +62,8 @@ maze_get "/specialtag/level7/" do |env|
 end
 
 # Level 8: Reflection in unquoted img src (space-terminated)
-Xssmaze.push("specialtag-level8", "/specialtag/level8/?query=a", "unquoted src attribute injection")
+Xssmaze.push("specialtag-level8", "/specialtag/level8/?query=a", "unquoted src attribute injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "the src attribute is unquoted, so a space is enough to start a new attribute")
 maze_get "/specialtag/level8/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/svg_context_xss.cr
+++ b/src/mazes/svg_context_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Full SVG document with query reflected in <text> element
 # Bypass: inject SVG event handler, e.g. </text><svg onload=alert(1)>
-Xssmaze.push("svgctx-level1", "/svgctx/level1/?query=a", "SVG text element injection (break out and inject onload)")
+Xssmaze.push("svgctx-level1", "/svgctx/level1/?query=a", "SVG text element injection (break out and inject onload)",
+  vuln: "reflected-html", delivery: ["query"], note: "the reflection sits in SVG foreign content; close </text> before injecting")
 maze_get "/svgctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -15,7 +16,8 @@ end
 
 # Level 2: SVG <desc> element with query reflected
 # Bypass: </desc><svg onload=alert(1)>
-Xssmaze.push("svgctx-level2", "/svgctx/level2/?query=a", "SVG desc element injection (break out of desc)")
+Xssmaze.push("svgctx-level2", "/svgctx/level2/?query=a", "SVG desc element injection (break out of desc)",
+  vuln: "reflected-html", delivery: ["query"], note: "SVG <desc> holds parsed content; close </desc> before injecting")
 maze_get "/svgctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -30,7 +32,8 @@ end
 
 # Level 3: SVG <title> element with query reflected
 # Bypass: </title><svg onload=alert(1)>
-Xssmaze.push("svgctx-level3", "/svgctx/level3/?query=a", "SVG title element injection (break out of title)")
+Xssmaze.push("svgctx-level3", "/svgctx/level3/?query=a", "SVG title element injection (break out of title)",
+  vuln: "reflected-html", delivery: ["query"], note: "this is the SVG <title>, not the document title; close </title> before injecting")
 maze_get "/svgctx/level3/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +48,8 @@ end
 
 # Level 4: SVG <a> with query in xlink:href attribute
 # Bypass: javascript:alert(1)
-Xssmaze.push("svgctx-level4", "/svgctx/level4/?query=a", "SVG xlink:href attribute injection (javascript: protocol)")
+Xssmaze.push("svgctx-level4", "/svgctx/level4/?query=a", "SVG xlink:href attribute injection (javascript: protocol)",
+  vuln: "reflected-attr", delivery: ["query"], note: "an SVG anchor takes a javascript: URL, but that needs a click; a quote breakout does not")
 maze_get "/svgctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -61,7 +65,8 @@ end
 
 # Level 5: SVG <foreignObject> with query reflected in HTML inside it
 # Bypass: standard HTML injection, e.g. <img src=x onerror=alert(1)>
-Xssmaze.push("svgctx-level5", "/svgctx/level5/?query=a", "SVG foreignObject HTML injection")
+Xssmaze.push("svgctx-level5", "/svgctx/level5/?query=a", "SVG foreignObject HTML injection",
+  vuln: "reflected-html", delivery: ["query"], note: "inside foreignObject the content is ordinary XHTML, so a plain HTML payload works with no SVG-specific tricks")
 maze_get "/svgctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -79,7 +84,8 @@ end
 
 # Level 6: SVG <animate> with query in values attribute
 # Bypass: break out of attribute, e.g. "><svg onload=alert(1)>
-Xssmaze.push("svgctx-level6", "/svgctx/level6/?query=a", "SVG animate values attribute injection (break out of attribute)")
+Xssmaze.push("svgctx-level6", "/svgctx/level6/?query=a", "SVG animate values attribute injection (break out of attribute)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/svgctx/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/template_injection.cr
+++ b/src/mazes/template_injection.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("template-injection-level1", "/template/level1/?query=a", "Server-side template injection (basic)")
+Xssmaze.push("template-injection-level1", "/template/level1/?query=a", "Server-side template injection (basic)",
+  vuln: "reflected-html", delivery: ["query"], note: "no template engine runs: the placeholder is filled by a plain string substitution and the result reflected raw, so this is an ordinary HTML-context reflection")
 maze_get "/template/level1/" do |env|
   query = env.params.query["query"]
   template = "Hello {{user_input}}"
@@ -10,7 +11,8 @@ maze_get "/template/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("template-injection-level2", "/template/level2/?query=a", "Client-side template injection (Handlebars style)")
+Xssmaze.push("template-injection-level2", "/template/level2/?query=a", "Client-side template injection (Handlebars style)",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "no Handlebars runs; the value is server-inlined into a JS string and reaches innerHTML through a plain string replace")
 maze_get "/template/level2/" do |env|
   query = env.params.query["query"]
 
@@ -27,7 +29,8 @@ maze_get "/template/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("template-injection-level3", "/template/level3/?query=a", "Template injection with expression evaluation")
+Xssmaze.push("template-injection-level3", "/template/level3/?query=a", "Template injection with expression evaluation",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["eval", "innerHTML"], delivery: ["query"], note: "the value is server-inlined into a JS string and then concatenated into an eval; breaking out of the outer string literal works too")
 maze_get "/template/level3/" do |env|
   query = env.params.query["query"]
 
@@ -47,7 +50,8 @@ maze_get "/template/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("template-injection-level4", "/template/level4/?query=a", "Template injection with conditional rendering")
+Xssmaze.push("template-injection-level4", "/template/level4/?query=a", "Template injection with conditional rendering",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the ternary is decoration; the server-inlined string is concatenated straight into innerHTML")
 maze_get "/template/level4/" do |env|
   query = env.params.query["query"]
 
@@ -62,7 +66,8 @@ maze_get "/template/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("template-injection-level5", "/template/level5/?query=a", "Template injection with loop rendering")
+Xssmaze.push("template-injection-level5", "/template/level5/?query=a", "Template injection with loop rendering",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined as the single element of a JS array that is concatenated into innerHTML")
 maze_get "/template/level5/" do |env|
   query = env.params.query["query"]
 
@@ -80,7 +85,8 @@ maze_get "/template/level5/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("template-injection-level6", "/template/level6/?query=a", "Template injection with sanitization bypass")
+Xssmaze.push("template-injection-level6", "/template/level6/?query=a", "Template injection with sanitization bypass",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "script tags are entity-encoded before the value is inlined into the JS string, but every other tag reaches innerHTML intact")
 maze_get "/template/level6/" do |env|
   query = env.params.query["query"].gsub("<script", "&lt;script").gsub("</script>", "&lt;/script&gt;")
 

--- a/src/mazes/unicode_xss.cr
+++ b/src/mazes/unicode_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Fullwidth character normalization - converts fullwidth < > to ASCII before reflection
 # The filter converts fullwidth chars to ASCII first, then reflects. Regular < > still work.
 # Exploit: query=<script>alert(1)</script> (regular ASCII chars pass through)
-Xssmaze.push("unicode-level1", "/unicode/level1/?query=a", "fullwidth normalization (regular ASCII angles still work)")
+Xssmaze.push("unicode-level1", "/unicode/level1/?query=a", "fullwidth normalization (regular ASCII angles still work)",
+  vuln: "reflected-html", delivery: ["query"], note: "nothing is filtered here; the fullwidth normalization only adds a second way in beside plain ASCII angles")
 maze_get "/unicode/level1/" do |env|
   query = env.params.query["query"]
   # Normalize fullwidth to ASCII
@@ -15,7 +16,8 @@ end
 
 # Level 2: Strip ASCII < > but allow unicode fullwidth, then normalize to ASCII before output
 # Exploit: query=%EF%BC%9Cscript%EF%BC%9Ealert(1)%EF%BC%9C/script%EF%BC%9E (fullwidth angles bypass strip, then become real)
-Xssmaze.push("unicode-level2", "/unicode/level2/?query=a", "strip ASCII angles then normalize fullwidth (order-of-ops bypass)")
+Xssmaze.push("unicode-level2", "/unicode/level2/?query=a", "strip ASCII angles then normalize fullwidth (order-of-ops bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "ASCII angle brackets are stripped before the fullwidth normalization runs, so send U+FF1C and U+FF1E instead")
 maze_get "/unicode/level2/" do |env|
   query = env.params.query["query"]
   # Step 1: Strip ASCII angle brackets
@@ -31,7 +33,8 @@ end
 
 # Level 3: Reflection with null bytes stripped
 # Exploit: query=<script>alert(1)</script> (null bytes are stripped but all other chars pass through)
-Xssmaze.push("unicode-level3", "/unicode/level3/?query=a", "null byte stripping only (all other chars reflected)")
+Xssmaze.push("unicode-level3", "/unicode/level3/?query=a", "null byte stripping only (all other chars reflected)",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/unicode/level3/" do |env|
   query = env.params.query["query"]
   query = query.gsub("\0", "")
@@ -44,7 +47,8 @@ end
 
 # Level 4: UTF-7 encoding hint via Content-Type charset
 # Exploit: query=+ADw-script+AD4-alert(1)+ADw-/script+AD4- (UTF-7 encoded XSS)
-Xssmaze.push("unicode-level4", "/unicode/level4/?query=a", "UTF-7 charset with raw reflection")
+Xssmaze.push("unicode-level4", "/unicode/level4/?query=a", "UTF-7 charset with raw reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "no modern browser decodes UTF-7, but the reflection is raw, so a plain payload works regardless of the declared charset")
 maze_get "/unicode/level4/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/html; charset=utf-7"
@@ -57,7 +61,8 @@ end
 
 # Level 5: Right-to-left override character injection in attribute
 # Exploit: query=" onfocus=alert(1) autofocus=" (standard attribute breakout)
-Xssmaze.push("unicode-level5", "/unicode/level5/?query=a", "reflection in attribute (RLO/bidi chars allowed)")
+Xssmaze.push("unicode-level5", "/unicode/level5/?query=a", "reflection in attribute (RLO/bidi chars allowed)",
+  vuln: "reflected-attr", delivery: ["query"], note: "the bidi angle is a red herring: nothing is filtered, so this is a plain double-quoted attribute breakout")
 maze_get "/unicode/level5/" do |env|
   query = env.params.query["query"]
 
@@ -69,7 +74,8 @@ end
 
 # Level 6: Reflection with backslash stripping only - strips \ but allows < > " '
 # Exploit: query=<img src=x onerror=alert(1)> (angle brackets and quotes are not filtered)
-Xssmaze.push("unicode-level6", "/unicode/level6/?query=a", "backslash stripping only (angles and quotes allowed)")
+Xssmaze.push("unicode-level6", "/unicode/level6/?query=a", "backslash stripping only (angles and quotes allowed)",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/unicode/level6/" do |env|
   query = env.params.query["query"]
   query = query.gsub("\\", "")

--- a/src/mazes/wrapper_context_xss.cr
+++ b/src/mazes/wrapper_context_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query wrapped in <b> and <i> tags - standard injection
-Xssmaze.push("wrappercontext-level1", "/wrappercontext/level1/?query=a", "reflection wrapped in bold+italic tags")
+Xssmaze.push("wrappercontext-level1", "/wrappercontext/level1/?query=a", "reflection wrapped in bold+italic tags",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level1/" do |env|
   query = env.params.query["query"]
 
@@ -7,7 +8,8 @@ maze_get "/wrappercontext/level1/" do |env|
 end
 
 # Level 2: Query wrapped in <span style="color:red"> - standard injection
-Xssmaze.push("wrappercontext-level2", "/wrappercontext/level2/?query=a", "reflection wrapped in styled span")
+Xssmaze.push("wrappercontext-level2", "/wrappercontext/level2/?query=a", "reflection wrapped in styled span",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level2/" do |env|
   query = env.params.query["query"]
 
@@ -15,7 +17,8 @@ maze_get "/wrappercontext/level2/" do |env|
 end
 
 # Level 3: Query wrapped in <a href="#"> - inject tags within link text
-Xssmaze.push("wrappercontext-level3", "/wrappercontext/level3/?query=a", "reflection wrapped in anchor tag text")
+Xssmaze.push("wrappercontext-level3", "/wrappercontext/level3/?query=a", "reflection wrapped in anchor tag text",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level3/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +26,8 @@ maze_get "/wrappercontext/level3/" do |env|
 end
 
 # Level 4: Query wrapped in <small><em> - standard injection
-Xssmaze.push("wrappercontext-level4", "/wrappercontext/level4/?query=a", "reflection wrapped in small+em tags")
+Xssmaze.push("wrappercontext-level4", "/wrappercontext/level4/?query=a", "reflection wrapped in small+em tags",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level4/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +35,8 @@ maze_get "/wrappercontext/level4/" do |env|
 end
 
 # Level 5: Query wrapped in <mark> - standard injection
-Xssmaze.push("wrappercontext-level5", "/wrappercontext/level5/?query=a", "reflection wrapped in mark tag")
+Xssmaze.push("wrappercontext-level5", "/wrappercontext/level5/?query=a", "reflection wrapped in mark tag",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level5/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +44,8 @@ maze_get "/wrappercontext/level5/" do |env|
 end
 
 # Level 6: Query wrapped in <abbr title="abbreviation"> - standard injection
-Xssmaze.push("wrappercontext-level6", "/wrappercontext/level6/?query=a", "reflection wrapped in abbr tag")
+Xssmaze.push("wrappercontext-level6", "/wrappercontext/level6/?query=a", "reflection wrapped in abbr tag",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level6/" do |env|
   query = env.params.query["query"]
 


### PR DESCRIPTION
## What changed

All **210** `Xssmaze.push(...)` calls across my 36 files (slice T2) were `vuln: "unclassified"` /
`reach: "unknown"`. Each now carries `vuln`, `delivery`, and — for client-side flows — `sources`
and `sinks`. `reach` is left to derive itself from `delivery`; it is never set by hand.

Metadata-only diff: no handler body, filter, or byte of HTML was touched.

**Classification follows the injection-context rule in `src/maze.cr`**, not the maze name — several
names are actively misleading. `pathxss-*` reads no path segment, `template-injection-*` runs no
template engine, `fwoutput-level4`'s `th:text` has no Thymeleaf behind it, and `hidden-reflection-*`
is a set of ordinary server-side reflections. Where a name would mislead a reader, the `note:` says so.

The `dom` vs `reflected-js` split follows the rule's carve-out and the existing corpus
(`websocket_xss.cr`, `slot_xss.cr`, `csti_xss.cr`): a value inlined raw into a JS string is
`reflected-js`, *unless* a live client-side sink executes it without any breakout — then it is `dom`
with `sources: ["server-reflected"]`. So `encmix-level3` (quotes escaped, but the value still lands
in `innerHTML`) is `dom`, while `realworld-encoding-level8` (quotes escaped, sink is `textContent`)
is `reflected-js`.

147 of the 210 carry a `note:`; 63 are left `nil` because there was nothing non-obvious to say.

### Vocabulary

No new `vuln` class. Two new `sources`/`sinks` names were needed: **none** — every value reuses a
name already in `/stats` (`server-reflected`, `innerHTML`, `eval`, `srcdoc`, `trustedtypes.createHTML`).

## `exploitable: false` — please review these individually

Eight endpoints. Each changes a benchmark's denominator, so each is listed with its reason. All eight
were verified against real Chrome (see the beacon table below); none is a "could not classify".

| endpoint | catalog URL | why it cannot execute |
| --- | --- | --- |
| `bugbounty-level10` | `/bugbounty/level10/?msg=hi` | The body is HTML but the response is served as `application/json`. No modern browser sniffs that into a document. The handler's own comment banks on "legacy sniffers"; there are none left. |
| `encmix-level2` | `/encmix/level2/?query=a` | Both angle brackets are entity-encoded before reflection. `solutions/encmix.md` claims `&#x3c;script&#x3e;` passes through and "browser decodes" it — but an entity in a text node decodes to a *character*, never to markup, so it renders as visible text. |
| `encoding-bypass-level6` | `/encoding-bypass/level6/?query=a` | The level advertises a double-encoding bypass, but `strip_angles` runs **after** the decode, so no `<` or `>` can reach the body context at all. |
| `metarefresh-level2` | `/metarefresh/level2/?url=a` | Both quote characters are stripped, so the single-quoted `content` attribute cannot be broken out of; and browsers refuse both `javascript:` and top-level `data:` navigation from a meta refresh. `solutions/metarefresh.md` proposes exactly the `data:text/html` payload that is blocked. Only an open redirect remains. |
| `redirect-level1` | `/redirect/level1/?query=/` | Open redirect, not XSS — a different bug class, handled the way `xsleak.cr` handles its oracles. The value reaches a `Location` header on an empty 302 and nothing else; browsers will not follow `javascript:` or `data:` from a redirect. |
| `redirect-level2` | `/redirect/level2/?query=/` | As level1. The non-recursive `javascript` strip is walkable (`javajavascriptscript:`), but a `Location` header still cannot execute anything. |
| `redirect-level3` | `/redirect/level3/?query=/` | As level2 with a lowercase pass first, closing the mixed-case bypass. Still a redirect sink. |
| `redirect-level4` | `/redirect/level4/?query=/` | As level3 with a second lowercase-and-strip pass, closing the nesting bypass. Still a redirect sink. |

**The four `redirect-*` levels are the call most worth a second opinion.** They are genuinely
vulnerable — as open redirects — and the file's own comment says the `javascript:` sink is "the
lesson". I marked them `non-xss-control` because `src/maze.cr` reserves that value for endpoints that
are "a different bug class entirely", and because no current browser executes a `javascript:` or
`data:` `Location`. If the project would rather keep them scoreable as XSS, that is a one-word change
in four places — but the catalog would then be telling scanners something that is not true.

## Second defect: `params:` that did not match the URL

Ten endpoints advertised parameters their handler never reads. Verified against the handler, not just
the URL string.

| endpoint | catalog URL | before | after |
| --- | --- | --- | --- |
| `bugbounty-level2` | `/bugbounty/level2/?error=invalid_request&error_description=bad+input` | `["error_description"]` | `["error", "error_description"]` |
| `callback-level1` | `/callback/level1/?callback=myFunc` | `["query"]` (default) | `["callback"]` |
| `callback-level2` | `/callback/level2/?callback=myFunc` | `["query"]` (default) | `["callback"]` |
| `callback-level3` | `/callback/level3/?fn=render` | `["query"]` (default) | `["fn"]` |
| `callback-level4` | `/callback/level4/?handler=onData` | `["query"]` (default) | `["handler"]` |
| `ctype-level4` | `/ctype/level4/?callback=func` | `["query"]` (default) | `["callback"]` |
| `hpp-level2` | `/hpp/level2/?query=a&q=b` | `["query"]` (default) | `["query", "q"]` |
| `hpp-level3` | `/hpp/level3/?items[]=a&items[]=b` | `["query"]` (default) | `["items[]"]` |
| `hpp-level4` | `/hpp/level4/?config.theme=blue` | `["query"]` (default) | `["config.theme"]` |
| `multicontext-level6` | `/multicontext/level6/?q1=a&q2=b` | `["query"]` (default) | `["q1", "q2"]` |

Before this, `/map/json` told a scanner to fuzz `query` on seven endpoints that never read it.

## Verification

### `/stats`, before and after

`shards build` at `origin/main` (27e59ac) and at this branch, each served and queried:

```
class                    before    after    delta
csti                          5        5       +0
dom                         177      190      +13
non-xss-control              13       21       +8
prototype-pollution           6        6       +0
reflected-attr              144      207      +63
reflected-html              240      344     +104
reflected-js                 49       71      +22
stored                       10       10       +0
unclassified                420      210     -210

reach unknown               420      210     -210
reach server                620      830     +210
reach client                 24       24       +0

classes outside VULN_CLASSES: none
unclassified dropped by: 210
controls: 13 -> 21 (+8)
total unchanged: True
```

`unclassified` drops by exactly 210 — my slice size, no more and no less. All 210 are `reach: server`,
which is correct: every endpoint in this slice takes its payload from the query string or a request
header. `client` is untouched, so nothing here wrongly claims to be browser-only, and nothing
browser-only was wrongly given a server channel.

### End-to-end payload spot-checks

Driven through real headless Chrome (Google Chrome 141, `--headless=new`) against the running lab,
with execution observed via this repo's own `/beacon` oracle (#44) rather than `alert()` — the beacon
records a fire only if the injected markup or JS actually ran. `FIRE` = must execute, `QUIET` = the
`exploitable: false` claims, which must not.

```
TOKEN EXPECT RESULT     ENDPOINT                     VERDICT
t01   FIRE   fired=True /booleanattr/level1/         PASS
t02   FIRE   fired=True /ctype/level3/               PASS
t03   FIRE   fired=True /customtag/level5/           PASS
t04   FIRE   fired=True /encmix/level3/              PASS
t05   FIRE   fired=True /hidden-reflection/level4/   PASS
t06b  FIRE   fired=True /injs/level6/                PASS
t07   FIRE   fired=True /realworld-encoding/level1/  PASS
t08   FIRE   fired=True /svgctx/level1/              PASS
t09   FIRE   fired=True /template/level6/            PASS
t10b  FIRE   fired=True /jsescape/level2/            PASS
t11   FIRE   fired=True /popover/level1/             PASS
t12   FIRE   fired=True /specialtag/level5/          PASS
t13   FIRE   fired=True /callback/level3/            PASS
t14   FIRE   fired=True /multicontext/level2/        PASS
t15   FIRE   fired=True /hpp/level3/                 PASS
t80   QUIET  fired=False /encmix/level2/             PASS
t81   QUIET  fired=False /metarefresh/level2/        PASS
t82   QUIET  fired=False /bugbounty/level10/         PASS
t83   QUIET  fired=False /redirect/level1/           PASS
t84   QUIET  fired=False /encoding-bypass/level6/    PASS
t85   QUIET  fired=False /customtag/level5/          PASS
```

21/21. What each one proves about the metadata it checks:

- **t01** `?query="><img src=/beacon/t01>` — `reflected-attr`, double-quoted boolean attribute breakout.
- **t02** `?query=><img src=/beacon/t02>` — confirms the `note:` on `ctype-level3`: the HTML parser
  treats `<![CDATA[` as a bogus comment that ends at the first `>`.
- **t03 / t85** the same endpoint, twice, and this pair is the point: `<img src=/beacon/t85>` alone
  does **not** fire (`<template>` content is inert), while `</template><img src=/beacon/t03>` does.
  That is exactly what the `note:` on `customtag-level5` tells a scanner.
- **t04** `?query=<img src=/beacon/t04>` — `encmix-level3` is `dom`, not `reflected-js`: quotes and
  backslashes are escaped so the JS string holds, yet the raw value still reaches `innerHTML`.
  (`solutions/encmix.md` recommends a `\uXXXX` payload, which cannot work — the backslash is escaped
  first. The plain-markup path does.)
- **t05** `?query=</script><img src=/beacon/t05>` — `hidden-reflection-level4` is `reflected-html`,
  not `reflected-js`: the block is `type="application/json"` and never executes.
- **t06b** `?query=%0Anew Image().src='/beacon/t06b';//` — `reflected-js`, newline ends the `//` comment.
- **t07** — `realworld-encoding-level1` needs **four** wire-level percent encodes, not the three the
  level's own comment claims, because the framework decodes once before the handler's three. Three
  encodes return `Detect Special Character`; four execute.
- **t08** `?query=</text><img src=/beacon/t08>` — `svgctx-level1`, SVG foreign content.
- **t09** `?query=<img src=/beacon/t09>` — `template-injection-level6` is `dom`: `<script` is
  entity-encoded, every other tag reaches `innerHTML` intact.
- **t10b** `` ?query=\';new Image().src=`/beacon/t10b`;// `` — confirms the `note:` on `jsescape-level2`:
  the backslash is *not* escaped, so a leading backslash neutralises the quote escape and closes the string.
- **t11** — `popover-level1`: a *closed* popover is still parsed, so the payload runs without the
  popover ever being opened.
- **t12** `?query=" onerror="new Image().src='/beacon/t12'` — `specialtag-level5` with angle brackets
  stripped; `/logo.png` 404s, so the injected `onerror` fires unassisted.
- **t13 / t15** — the `params:` fixes, proven by exploiting the *renamed* parameter: `fn` on
  `callback-level3` and the literal `items[]` on `hpp-level3`. Both were advertised as `query`.
- **t14** `?query=</title><img src=/beacon/t14>` — `multicontext-level2`'s inline comment calls the
  `<title>` copy "safe". It is RCDATA, and it executes.

Two additional checks that a beacon cannot express:

**`bugbounty-level7` — `delivery: ["header"]`.** Chrome cannot be made to send `X-Forwarded-Host` on a
navigation, so this one is verified at the byte level:

```
$ curl -s -H 'X-Forwarded-Host: x" onload="new Image().src=/beacon/hdr" x="' \
    localhost:3921/bugbounty/level7/
<!doctype html><html><head>
  <base href="https://x" onload="new Image().src=/beacon/hdr" x="/">
```

The header lands raw inside the double-quoted `<base href>` — confirming both `reflected-attr` and
`delivery: ["header"]` (and so `reach: server`, since `header` is in `SERVER_CHANNELS`).

**`hidden-xss-level2` — the "type override" that isn't.** `solutions/hidden.md` says to override
`type=hidden` with a second `type=text`. The HTML parser drops duplicate attributes, so it cannot work.
Chrome's parsed DOM for `?query=" type=text autofocus onfocus=NOPE x="`:

```
<input type="hidden" value="" autofocus="" onfocus="NOPE" x="">
```

`type` is still `hidden`; the injected `type=text` is gone, and `onfocus` can never fire on a hidden
input. The `note:` on `hidden-xss-level2` and `-level3` records this and points at the real remaining
vector (an injected `accesskey` plus a handler, Firefox only, needs an Alt+Shift keypress), so the
endpoints stay `exploitable: true` with the constraint written down rather than being silently
over-credited.

### Gates

```
$ crystal spec
193 examples, 0 failures, 0 errors, 0 pending

$ ./lib/ameba/bin/ameba
206 inspected, 0 failures

$ crystal tool format --check
(clean)
```

`crystal spec` is green including the answer-key parity specs added by #46.

## For the reviewer

1. **The four `redirect-*` levels** marked `non-xss-control` — the one judgement call I would most
   like a second opinion on. Reasoning is in the table above.
2. **Where the shipped `solutions/*.md` are wrong.** Five payloads in the answer key do not execute in
   a current browser: `encmix-level2` (entities are not markup), `encmix-level3` (`\uXXXX` cannot
   survive the backslash escape — though the level *is* exploitable another way),
   `metarefresh-level2` (`data:` top-level navigation), `hidden-reflection-level2` (`javascript:` in a
   meta refresh), and the `type=text` override in `hidden.md` used by `hidden-reflection-level1`,
   `hidden-xss-level2` and `-level3`. My `note:` fields record the working path instead. I did **not**
   edit `solutions/` — it is outside my file list, and #46 now builds an answer key from it, so
   someone should decide whether those files get corrected to match.
3. `advanced-xss-level3` is described as a Service Worker level but never registers a service worker;
   the reflection is a plain synchronous `innerHTML`. Classified on what it does, noted accordingly.

No files outside my slice were touched.
