### PR TITLE
docs: record the triage, answer key, beacon and scorecard; fix sink-level8 params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,25 @@ When adding new vulnerability scenarios, follow these patterns:
    curl "http://localhost:3000/your/endpoint?query=<script>alert(1)</script>"
    ```
 
+### Lab infrastructure (not mazes)
+
+Three route groups are instrumentation and deliberately never call `Xssmaze.push` — adding
+them to the catalog would pollute `/map/json`, `/stats` and every benchmark denominator:
+
+- `src/store.cr`: `Xssmaze::Store` holds the stored mazes' state in bounded named collections
+  and serves `/reset`. A new stateful maze should register its collection here rather than
+  keeping a file-local Hash, or it will grow without limit and leak payloads between runs.
+- `src/mazes/beacon.cr`: `/beacon/<token>` + `/beacon/log`, the execution oracle. Use it when
+  a change turns on whether something actually runs; drive it from headless Chrome and always
+  run a known-exploitable endpoint through the same harness first, so a "did not fire" result
+  is evidence rather than a broken test.
+- `src/solutions.cr`: the answer key, embedded from `solutions/` at compile time. Adding a
+  maze without a matching `### <name>` entry in `solutions/<category>.md` fails
+  `spec/solutions_spec.cr`.
+
+`spec/smoke_spec.cr` walks the whole catalog and fails on any 5xx, so a maze that crashes on
+its own payload cannot ship.
+
 ### Crystal Language Patterns
 - Use `env.params.query["parameter"]` to access GET parameters
 - Use `env.params.body["parameter"]` for POST parameters  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,12 @@
 - **Stored mazes are bounded and resettable.** State grew without limit and never cleared, so
   a second scanner run read the first run's payloads back out as its own finding. Collections
   keep their most recent entries and `/reset` clears them between runs (#42)
-- Fixed 26 endpoints whose `params:` named a parameter their handler never reads, which had
-  been pointing scanners at the wrong field
+- Fixed the `params:` lists that named a parameter the handler never reads, which had been
+  telling a scanner reading `/map/json` to fuzz the wrong field — `rsplit-level4` advertised
+  `query` while its sink is `pref`, `sink-level8` advertised `query` while only `callback` is
+  read. 26 endpoints declared a parameter their own catalog URL contradicted; that is now 0
+  (the 3 still flagged by that check are `multipart-*`, where `params` correctly names a
+  header or body field and only the vestigial `?query=a` in the URL differs)
 
 ## v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased
+
+- **Every endpoint is classified.** `unclassified` went 838 -> 0 and `reach: "unknown"` with
+  it, so `/map/json?reach=server` now returns the 1040 endpoints a request-only scanner can
+  actually reach instead of the 206 it used to admit to. 28 endpoints are marked
+  `exploitable: false` after review — CSP levels whose policy blocks the page's own inline
+  script, open redirects, `application/json` bodies no browser sniffs — each verified in
+  headless Chrome rather than argued from the served HTML (#47, #48, #49, #50)
+- **Answer key served.** `solutions/` was 1049 ground-truth payloads that nothing referenced
+  and `.dockerignore` excluded; it is now embedded at compile time and served as
+  `/solutions.json`, `/solutions/<category>` and `/map/json?with=solutions`. A spec asserts
+  catalog parity in both directions so it cannot drift again (#46)
+- **Execution oracle.** `/beacon/<token>` records that a payload *ran* and `/beacon/log`
+  reports it with the `Referer` that fired it, so a benchmark can tell execution from
+  reflection and score the DOM flows whose payload never reaches the server response (#44)
+- **Scorecard measures the right thing.** `scripts/benchmark.py` scored controls and
+  client-only endpoints as misses and had no false-positive metric at all; it now reports
+  TP/FN/FP with precision, recall and F1, excludes `exploitable: false` from the denominator
+  and counts a detection there as a false positive, and picks its population with `--reach`.
+  A custom scanner now needs an explicit `--detect-regex`/`--detect-json` contract — the old
+  code marked an endpoint detected whenever the tool merely exited 0, so any well-behaved
+  scanner scored 100% (#45)
+- **Cookie reflections stopped 500ing.** `respheader-level4`, `rsplit-level4` and
+  `realworld-input-level6` raised `IO::Error` on the exact payloads they exist to reflect,
+  because `HTTP::Cookie` rejects the bytes RFC 6265 forbids — `rsplit-level4` is a response
+  splitting level that died on the splitting characters. New `Xssmaze.cookie_value` keeps the
+  reflection and drops the crash, and a smoke spec now walks the whole catalog so a 5xx
+  cannot ship again (#43)
+- **Stored mazes are bounded and resettable.** State grew without limit and never cleared, so
+  a second scanner run read the first run's payloads back out as its own finding. Collections
+  keep their most recent entries and `/reset` clears them between runs (#42)
+- Fixed 26 endpoints whose `params:` named a parameter their handler never reads, which had
+  been pointing scanners at the wrong field
+
 ## v0.4.0
 
 - Kemal 1.13.0, Crystal floor `>= 1.12.0`. Kemal now rejects a WebSocket without an `Origin`, so `/domsource/level7/echo` 403'd wscat, fuzzers and raw curl upgrades — `Server.start!` opts back into allow-all, pinned by a spec (#41)

--- a/README.md
+++ b/README.md
@@ -64,11 +64,17 @@ Colour is dropped automatically when the output is not a terminal, and
 | `/health` | liveness probe (`/healthz` alias) |
 | `/version` | version + counts |
 | `/random` | 302 to a random maze |
+| `/solutions.json` | the answer key: expected payload + injection context per maze |
+| `/solutions/<category>` | that category's exploit guide as markdown |
+| `/beacon/<token>` | execution oracle — a 1x1 GIF that records that a payload *ran* |
+| `/beacon/log` | what fired, how often, and from which maze page |
+| `/reset` | stored-maze state: `GET` reports sizes, `POST` clears |
 
 ```bash
 curl "http://localhost:3000/map/json?vuln=dom"           # only DOM flows
 curl "http://localhost:3000/map/json?reach=server"       # payload fits in an HTTP request
 curl "http://localhost:3000/map/json?exploitable=false"  # deliberate true negatives
+curl "http://localhost:3000/map/json?with=solutions"     # fold the answer key in
 ```
 
 The index page (`/`) has a client-side filter and links to every map above. Map responses
@@ -120,6 +126,55 @@ Two things this exists to stop a benchmark getting wrong:
 Untriaged endpoints are `"unclassified"` with `reach: "unknown"`, deliberately distinct
 from "reviewed and found safe".
 
+## Answer key
+
+Every maze ships its expected payload and injection context, so a harness can score what a
+scanner *should* have found instead of guessing from the served HTML. The key is embedded in
+the binary at compile time — the Docker image carries it too — and a spec asserts both
+directions of parity with the catalog, so it cannot silently drift.
+
+```bash
+curl "http://localhost:3000/solutions.json"                    # every maze, keyed by name
+curl "http://localhost:3000/solutions/basic"                   # one category, as markdown
+curl "http://localhost:3000/map/json?with=solutions&type=dom"  # composes with every filter
+```
+
+```json
+"basic-level1": {
+  "payload": "<script>alert(1)</script>",
+  "context": "raw reflection, no filter",
+  "url": "/basic/level1/?query=%3Cscript%3Ealert(1)%3C/script%3E"
+}
+```
+
+## Proving execution
+
+Reflection is not execution. String-matching the response scores a harmlessly-escaped echo as
+a hit, and it is blind to the DOM flows where the payload never reaches the server response at
+all. The beacon closes that gap: a payload has to actually run to reach it.
+
+```bash
+curl "http://localhost:3000/basic/level1/?query=<img src=/beacon/run1 onerror=fetch('/beacon/run1')>"
+curl "http://localhost:3000/beacon/log?token=run1"
+```
+
+The recorded `Referer` names the maze page that executed, so one token can cover a whole sweep
+and every hit still attributes to the endpoint that produced it. `DELETE /beacon/log` clears it
+between runs. The beacon is instrumentation, not a maze — it never appears in `/map/json`,
+`/stats` or a benchmark denominator.
+
+## Isolating runs
+
+The stored mazes remember what a scanner posted. Left alone that means a second run reads the
+first run's payloads back out and reports them as its own finding. Each collection keeps only
+its most recent entries, and `/reset` clears them between runs:
+
+```bash
+curl "http://localhost:3000/reset"                        # sizes, read-only
+curl -X POST "http://localhost:3000/reset"                # clear everything
+curl -X POST "http://localhost:3000/reset?scope=stored/level1"
+```
+
 ## Security header overrides
 
 To calibrate scanners against different defensive configurations, any endpoint accepts
@@ -163,17 +218,29 @@ handlers, timing, and `iframe.contentWindow.length`.
 
 ## Benchmarking scanners
 
-`scripts/benchmark.py` pulls every endpoint from `/map/json`, runs a scanner against
-them, and prints a detection scorecard.
+`scripts/benchmark.py` pulls every endpoint from `/map/json`, runs a scanner against them,
+and scores it against the lab's own metadata — TP / FN / FP with precision, recall and F1.
 
 ```bash
 ./bin/xssmaze -b 0.0.0.0          # terminal 1
 cd scripts && ./benchmark.sh http://localhost:3000   # terminal 2
 ```
 
-Nuclei is supported out of the box; any other tool can be wired in with
-`--custom-scanner "mytool {URL}"`. See [scripts/README.md](scripts/README.md) for
-options, report formats, and how to add a scanner permanently.
+The denominator is deliberate. `exploitable: false` endpoints leave it entirely and a
+detection on one is a **false positive**, never a miss. `--reach` picks the scored
+population — `server` (default: what a request-only scanner can actually reach), `client`,
+or `all` — and the populations are never merged into one unlabelled number.
+
+Nuclei is supported out of the box. Any other tool needs an explicit detection contract,
+because exit code alone never marks a detection:
+
+```bash
+./benchmark.sh http://localhost:3000 \
+  --custom-scanner "mytool {URL}" --detect-regex 'VULNERABLE'
+```
+
+See [scripts/README.md](scripts/README.md) for the scoring model, both invocation modes,
+report formats, and a CI regression gate.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,14 @@ Two things this exists to stop a benchmark getting wrong:
 - **`exploitable: false`** endpoints are not bugs. The whole `xsleak` category is
   cross-site *leaks*, not XSS — a scanner that reports nothing there is correct.
 
-Untriaged endpoints are `"unclassified"` with `reach: "unknown"`, deliberately distinct
-from "reviewed and found safe".
+Every endpoint in the catalog is classified — `unclassified` / `reach: "unknown"` remain in
+the schema for anything added later, deliberately distinct from "reviewed and found safe",
+but nothing currently carries them.
+
+Where the question was whether a payload actually *executes* — CSP levels whose policy turns
+out to block the page's own inline script, an entity inside an attribute name, a `Location`
+header — the call was settled in a real browser against the `/beacon` oracle, not argued from
+the served HTML.
 
 ## Answer key
 

--- a/src/mazes/sink_xss.cr
+++ b/src/mazes/sink_xss.cr
@@ -74,7 +74,8 @@ end
 
 # Level 8: JSON response with Content-Type text/html (JSONP-like)
 Xssmaze.push("sink-level8", "/sink/level8/?callback=render", "JSONP-like with text/html content-type",
-  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; JSONP-shaped body served as text/html. The injectable parameter is `callback`, not `query`")
+  params: ["callback"],
+  vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; JSONP-shaped body served as text/html")
 maze_get "/sink/level8/" do |env|
   callback = env.params.query.fetch("callback", "callback")
   env.response.content_type = "text/html"


### PR DESCRIPTION
Consolidates the documentation for everything merged in #42–#50, which the parallel work
deliberately left alone so five branches would not all collide in the same three files.

## README

- Endpoint map gains `/solutions.json`, `/solutions/<category>`, `/beacon/<token>`,
  `/beacon/log` and `/reset`.
- New **Answer key**, **Proving execution** and **Isolating runs** sections.
- **Vulnerability metadata**: the "untriaged endpoints are unclassified" paragraph is no
  longer true — coverage is complete — so it now says the values remain in the schema for
  anything added later, and records that the execution calls were settled in a real browser.
- **Benchmarking scanners** was documenting an interface that no longer exists: it still
  said any tool could be wired in with `--custom-scanner "mytool {URL}"`, but a custom
  scanner now requires an explicit `--detect-regex`/`--detect-json` contract because exit
  code alone no longer marks a detection. Rewritten, with the scoring model stated.

## AGENTS.md

New "Lab infrastructure (not mazes)" section covering `src/store.cr`, `src/mazes/beacon.cr`
and `src/solutions.cr` — the three route groups that deliberately never call `Xssmaze.push`,
and why. Future contributors adding a stateful maze need to know to register with
`Xssmaze::Store` rather than keeping a file-local Hash.

## CHANGELOG

An `## Unreleased` entry for the whole batch.

## One code fix

`sink-level8` carried `note: "The injectable parameter is \`callback\`, not \`query\`"` but
never set `params:`, so it kept the `["query"]` default and `/map/json` still pointed a
scanner at a field the handler never reads. A tool reads the field, not the prose. Fixed,
and the note trimmed to stop repeating what the field now says.

## Verification

```
$ crystal spec            193 examples, 0 failures
$ crystal tool format --check   clean
```

Against a running build, every endpoint documented in the README returns 200, and the
`params`-vs-URL drift check goes 26 → 0 real cases (the 3 still flagged are `multipart-*`,
where `params` correctly names a header or body field and only the vestigial `?query=a` in
the catalog URL differs — left alone rather than churned).

Numbers in the CHANGELOG were re-measured against this branch: `unclassified` 0,
`reach` server 1040 / client 24, controls 28, total 1064.