### PR TITLE
fix(solutions): reconcile the answer key with exploitable:false controls

### DIFF
--- a/solutions/bugbounty.md
+++ b/solutions/bugbounty.md
@@ -69,5 +69,9 @@ Patterns from real bug-bounty reports / CVEs: OAuth flows, JWT/reset tokens, upl
 
 `/bugbounty/level10/?msg=%3Cscript%3Ealert(1)%3C/script%3E`
 
-- payload: `<script>alert(1)</script>`
-- context: application/json without nosniff; HTML body sniffed as text/html
+- payload: `no payload — control`
+- context: the `<h1>` body is HTML, but the response is served `Content-Type:
+  application/json`, and no modern browser sniffs a declared JSON response into
+  a document. Chrome renders it as escaped text inside a `<pre>` (verified with
+  `--dump-dom`: the markup arrives as a text node, and an `onerror` beacon
+  payload never fired). The markup never parses, so reporting no XSS is correct.

--- a/solutions/csp.md
+++ b/solutions/csp.md
@@ -20,15 +20,25 @@ CSP-protected reflections with various policy weaknesses (unsafe-inline, nonce r
 
 `/csp/level3/?query=%22;alert(1);//`
 
-- payload: `";alert(1);//`
-- context: inside eval('var userInput="..."') — break double-quoted JS string
+- payload: `no payload — control`
+- context: the value does land raw in a JS string inside `eval(...)`, but the CSP
+  is `script-src 'unsafe-eval'` with no `'unsafe-inline'`, nonce or host source,
+  so the page's own inline `<script>` never runs — and neither can an injected
+  script or event handler (verified: a `";fetch('/beacon/...');//` payload stayed
+  silent while a known-exploitable control endpoint fired through the same
+  harness). Reporting no XSS is correct.
 
 ### csp-bypass-level4
 
 `/csp/level4/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
-- payload: `<img src=x onerror=alert(1)>`
-- context: reflected inside data: iframe src then posted to parent and innerHTML'd
+- payload: `no payload — control`
+- context: the payload would ride a `data:` iframe and be `innerHTML`'d after a
+  postMessage round-trip, but the CSP is `default-src 'self'; script-src 'self'`:
+  `default-src 'self'` blocks the `data:` iframe that carries the payload and
+  `script-src 'self'` blocks the inline listener that would render it, so neither
+  half executes (verified: `<img … onerror=fetch('/beacon/...')>` stayed silent
+  while a control endpoint fired). Reporting no XSS is correct.
 
 ### csp-bypass-level5
 

--- a/solutions/cspbypass.md
+++ b/solutions/cspbypass.md
@@ -20,8 +20,13 @@ Reflections under various CSP configurations that fail to actually prevent execu
 
 `/cspbypass/level3/?query=%22;alert(1);//`
 
-- payload: `";alert(1);//`
-- context: inside `var data = "..."` then eval'd; break double-quoted string
+- payload: `no payload — control`
+- context: the value lands raw in `var data = "..."` that is then `eval`'d, but
+  the CSP is `script-src 'self' 'unsafe-eval'` with no `'unsafe-inline'`, so the
+  inline `<script>` holding the reflection never executes and an injected script
+  or handler is blocked too (verified: a `";fetch('/beacon/...');//` payload
+  stayed silent while a control endpoint fired through the same harness).
+  Reporting no XSS is correct.
 
 ### cspbypass-level4
 

--- a/solutions/dom.md
+++ b/solutions/dom.md
@@ -71,10 +71,11 @@ Client-side DOM sinks driven by URL, hash, query, name, referrer, postMessage.
 
 `/dom/level10/?query=javascript:alert(1)`
 
-- payload: `javascript:alert(1)`
-- context: `img.src = query`. Control / true negative: no modern browser
-  executes a `javascript:` URL from an image src, so the taint reaches a sink
-  but nothing runs. Marked `exploitable: false` in `/map/json`.
+- payload: `no payload — control`
+- context: `img.src = query` — the tainted value only reaches an image URL (the
+  value to try is `javascript:alert(1)`). No modern browser executes a
+  `javascript:` URL from an image src, so the taint reaches a sink but nothing
+  runs. True negative, `exploitable: false` in `/map/json`.
 
 ### dom-level11
 

--- a/solutions/encmix.md
+++ b/solutions/encmix.md
@@ -13,8 +13,11 @@ Charset and encoding tricks (UTF-7, partial entity encode, JS string escape, JSO
 
 `/encmix/level2/?query=%26%23x3c%3Bscript%26%23x3e%3Balert(1)%26%23x3c%3B/script%26%23x3e%3B`
 
-- payload: `&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;`
-- context: server encodes `<`/`>` but not `&`; numeric entities pass through then browser decodes
+- payload: `no payload — control`
+- context: the server entity-encodes `<`/`>` before reflecting into a text node,
+  and a character reference in text decodes to a literal character, not markup —
+  served output is `<div>&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;</div>`,
+  which renders as the visible text `<script>alert(1)</script>`. No tag forms.
 
 ### encmix-level3
 

--- a/solutions/encoding-bypass.md
+++ b/solutions/encoding-bypass.md
@@ -41,8 +41,11 @@ Server filter strategies bypassable via case mix, double-encoding, alternative t
 
 `/encoding-bypass/level6/?query=%253Cscript%253Ealert(1)%253C/script%253E`
 
-- payload: `%3Cscript%3Ealert(1)%3C/script%3E`
-- context: server URL-decodes once then strips raw `<>`; double-encode to deliver after strip
+- payload: `no payload — control`
+- context: the description promises a double-encoding bypass, but the raw `<`/`>`
+  strip runs *after* the single URL-decode, so both angle brackets are removed
+  before reaching the body — served output is `scriptalert(1)/script`, inert.
+  No `<` or `>` can reach the sink.
 
 ### encoding-bypass-level7
 

--- a/solutions/json.md
+++ b/solutions/json.md
@@ -13,15 +13,24 @@ JSON-context reflections: JSONP callbacks, embedded JSON in script blocks, and D
 
 `/json/level2/?query=%3Cimg%20src=x%20onerror=alert(1)%3E`
 
-- payload: `<img src=x onerror=alert(1)>`
-- context: rendered to a JSON value but Content-Type sniffed if loaded as HTML; raw `<div>...</div>` wrapper
+- payload: `no payload — control`
+- context: the value is reflected raw (the value to try is
+  `<img src=x onerror=alert(1)>`), but the response is served
+  `Content-Type: application/json`, which no modern browser parses as HTML, so
+  the markup never executes (verified: `<img … onerror=fetch('/beacon/...')>`
+  stayed silent while a control endpoint fired through the same harness).
+  Reporting no XSS is correct.
 
 ### json-xss-level3
 
 `/json/level3/?query=%3C/script%3E%3Cscript%3Ealert(1)%3C/script%3E`
 
-- payload: `</script><script>alert(1)</script>`
-- context: JSON string, only `\` and `"` escaped; angles pass through
+- payload: `no payload — control`
+- context: served `Content-Type: application/json`, and quotes and backslashes are
+  escaped, so the value cannot break out of its JSON string and no browser parses
+  the response as HTML (verified: a `</script><script>fetch('/beacon/...')`
+  payload stayed silent while a control endpoint fired). Reporting no XSS is
+  correct.
 
 ### json-xss-level4
 

--- a/solutions/metarefresh.md
+++ b/solutions/metarefresh.md
@@ -13,8 +13,12 @@
 
 `/metarefresh/level2/?url=data:text/html,%3Cscript%3Ealert(1)%3C/script%3E`
 
-- payload: `data:text/html,<script>alert(1)</script>`
-- context: quotes stripped — use unquoted data: URL
+- payload: `no payload — control`
+- context: the value lands in a `<meta http-equiv='refresh'>` content attribute
+  (the value to try is `data:text/html,<script>alert(1)</script>`). Browsers
+  refuse a top-level `data:` navigation from a meta refresh, so it never loads
+  (verified: the beacon stayed silent and no navigation occurred). Only an open
+  redirect remains — not XSS.
 
 ### metarefresh-level3
 

--- a/solutions/modern-bypass.md
+++ b/solutions/modern-bypass.md
@@ -133,8 +133,13 @@ Modern real-world XSS bypasses: multi-step state, DOM clobbering config, Vue.js 
 ### modern-bypass-level19
 
 `/modern-bypass/level19/`
-- payload: `window.opener.postMessage({action: 'execute', code: 'alert(1)'}, '*')`
-- context: Client-side `message` listener uses a weak, unanchored RegExp (`/https:\/\/xssmaze\.com/`) to validate sender origin. An attacker hosting a page on a domain like `https://xssmaze.com.attacker.com` can pass origin checks and send execution payloads.
+- payload: `no payload — control`
+- context: the inline script does not parse. `if (/https://xssmaze.com/.test(event.origin))`
+  tokenises as the regex `/https:/` followed by a `//…` line comment, leaving
+  the `if (` unclosed — a genuine SyntaxError (verified: the whole `<script>`
+  fails, so `addEventListener('message', …)` never runs). The listener is never
+  registered and nothing reaches `eval`, no matter what origin trick a sender
+  attempts. A true negative.
 
 ### modern-bypass-level20
 

--- a/solutions/mutfilter.md
+++ b/solutions/mutfilter.md
@@ -6,8 +6,11 @@ Reflections with mutation/regex filters that can be bypassed.
 
 `/mutfilter/level1/?query=%25%33%43img%20src=x%20onerror=alert(1)%25%33%45`
 
-- payload: `%3Cimg src=x onerror=alert(1)%3E` (double-encoded `<`/`>`)
-- context: `<`/`>` replaced with literal `%3C`/`%3E`; double-URL-encode so framework decodes once leaving `%3C` literal which the filter ignores (note: browser still sees `%3C` literally — practical bypass requires double-decoding sink, level is mostly unexploitable)
+- payload: `no payload — control`
+- context: `<`/`>` are replaced with the literal text `%3C`/`%3E` and nothing
+  decodes them client-side — served output is the visible string
+  `%3Cimg src=x onerror=alert(1)%3E`, so no tag can form. There is no
+  double-decoding sink to walk the encoding back through. A true negative.
 
 ### mutfilter-level2
 

--- a/solutions/nonce.md
+++ b/solutions/nonce.md
@@ -13,8 +13,13 @@ CSP nonce-based protections bypassed via injection inside trusted contexts.
 
 `/nonce/level2/?query=%27)%3Balert(1)%2F%2F`
 
-- payload: `');alert(1)//`
-- context: onclick="handle('QUERY')" with unsafe-hashes; break out of call
+- payload: `no payload — control`
+- context: the value breaks out of an `onclick="handle('...')"` call, but the CSP
+  is `script-src 'nonce-X' 'unsafe-hashes'` with no hash source listed, so
+  `'unsafe-hashes'` enables nothing and the inline `onclick` never runs — an
+  injected handler or script is blocked too, and the nonce is random per response
+  (verified: a `');fetch('/beacon/...')//` payload reached no JS sink while a
+  control endpoint fired through the same harness). Reporting no XSS is correct.
 
 ### nonce-level3
 

--- a/solutions/realworld-input.md
+++ b/solutions/realworld-input.md
@@ -30,8 +30,11 @@ Real-world input vectors: headers, JSON/multipart bodies, redirect sinks, cookie
 
 `/realworld-input/level4/?url=javascript%3Aalert(1)`
 
-- payload: `javascript:alert(1)`
-- context: Location header redirect; javascript: triggers when clicked from same-origin context (legacy/curl link)
+- payload: `no payload — control`
+- context: the value lands in a `Location:` redirect header (the value to try is
+  `javascript:alert(1)`). Browsers do not execute `javascript:`/`data:` from a
+  Location redirect and CR/LF is stripped, so nothing runs (verified: the beacon
+  stayed silent). The real bug is an open redirect, not XSS.
 
 ### realworld_input-level5
 

--- a/solutions/realworld.md
+++ b/solutions/realworld.md
@@ -41,8 +41,13 @@ Real-world reflection patterns: double sinks, debug flags, truncation, headers, 
 
 `/realworld/level6/?query=%3Cscript%3Ealert(1)%3C%2Fscript%3E`
 
-- payload: `<script>alert(1)</script>`
-- context: response Content-Type text/plain; browsers may sniff (legacy IE/Chrome no-sniff disabled)
+- payload: `no payload — control`
+- context: the markup is reflected raw (the value to try is
+  `<script>alert(1)</script>`), but the response is served
+  `Content-Type: text/plain`, which no modern browser sniffs into HTML, so it
+  never parses (verified: `<img … onerror=fetch('/beacon/...')>` stayed silent
+  while a control endpoint fired through the same harness). Reporting no XSS is
+  correct.
 
 ### realworld-level7
 

--- a/solutions/redirect.md
+++ b/solutions/redirect.md
@@ -6,26 +6,37 @@ Open-redirect endpoints where the `query` param feeds `env.redirect`; XSS via `j
 
 `/redirect/level1/?query=javascript:alert(1)`
 
-- payload: `javascript:alert(1)`
-- context: unfiltered redirect target
+- payload: `no payload — control`
+- context: the value reaches only a `Location:` header on an empty 302 (the value
+  to try is `javascript:alert(1)`). Browsers refuse to follow `javascript:` or a
+  top-level `data:` from a redirect, so nothing executes (verified: headless
+  Chrome navigated the redirect and the beacon stayed silent). The real bug is
+  an open redirect, not XSS.
 
 ### redirect-level2
 
 `/redirect/level2/?query=javajavascriptscript:alert(1)`
 
-- payload: `javajavascriptscript:alert(1)`
-- context: single-pass `javascript` strip; nest to reassemble
+- payload: `no payload — control`
+- context: a single non-recursive `javascript` strip that `javajavascriptscript:`
+  walks through — the `Location:` header does reassemble to `javascript:alert(1)`
+  (verified served), but a redirect sink still cannot execute JS. Open redirect,
+  not XSS.
 
 ### redirect-level3
 
 `/redirect/level3/?query=javajavascriptscript:alert(1)`
 
-- payload: `javajavascriptscript:alert(1)`
-- context: downcase + single-pass `javascript` strip; nest reassembles
+- payload: `no payload — control`
+- context: as level2 with the value lowercased first (which closes the mixed-case
+  bypass); the nested `javascript` still reassembles in the `Location:` header,
+  but a redirect sink executes nothing. Open redirect only.
 
 ### redirect-level4
 
 `/redirect/level4/?query=javajavajavascriptscriptscript:alert(1)`
 
-- payload: `javajavajavascriptscriptscript:alert(1)`
-- context: two passes of `javascript` strip; triple-nest to survive both
+- payload: `no payload — control`
+- context: two lowercase-and-strip passes; a triple-nested
+  `javajavajavascriptscriptscript:` survives both and reassembles in `Location:`,
+  yet the redirect sink still cannot run JS. Open redirect, not XSS.

--- a/solutions/sanitizer.md
+++ b/solutions/sanitizer.md
@@ -34,8 +34,11 @@ Hand-rolled sanitizers that pass the most-obvious payload but break on context o
 
 `/sanitizer/level5/?query=test`
 
-- payload: `test`
-- context: double HTML-escape applied to both body and title attr; no working sink (level is protected)
+- payload: `no payload — control`
+- context: the value is double HTML-entity-encoded into both the body and the
+  title attribute; the browser decodes only once, leaving inert entities as
+  visible text — served output is `&amp;lt;script&amp;gt;…`, which renders as the
+  literal text `&lt;script&gt;…`. No breakout, no sink.
 
 ### sanitizer-level6
 

--- a/solutions/stored.md
+++ b/solutions/stored.md
@@ -14,9 +14,11 @@ Classic stored XSS endpoints: input persisted server-side, then reflected on sub
 
 `[POST] /stored/level2/`
 
-- payload: `<script>alert(1)</script>`
-- body: `query=<script>alert(1)</script>`
-- context: strip_angles removes `<` `>` from li body — defensive stub, no working bypass
+- payload: `no payload — control`
+- context: submitted via POST (`query=<script>alert(1)</script>`) and rendered as
+  `<li>` text content, but `strip_angles` removes `<`/`>` before storage, so no
+  markup can be introduced — a `<script>` body stores and renders as inert text.
+  A defensive stub with no working bypass.
 
 ### stored-level3
 

--- a/solutions/waf-bypass.md
+++ b/solutions/waf-bypass.md
@@ -20,8 +20,14 @@ Classic WAF bypass filters: keyword strip, event strip, quote escape, single-sid
 
 `/waf-bypass/level3/?query=%22%20autofocus%20o%26%23110%3Bfocus=alert(1)%20x=%22`
 
-- payload: `" autofocus o&#110;focus=alert(1) x="`
-- context: angles encoded, `on\w+=` stripped; HTML entity inside attr decodes to `onfocus` after filter
+- payload: `no payload — control`
+- context: reflected into a double-quoted input `value`; angle brackets are
+  entity-encoded (no new tags) and every `on\w+=` handler is stripped. The
+  previously documented `" autofocus o&#110;focus=alert(1) x="` does **not**
+  work: character references are never expanded in attribute *names*, only in
+  attribute values and text. Chrome keeps the attribute literally named
+  `o&#110;focus` (verified with `--dump-dom`: `hasAttribute('onfocus')` is false
+  and the beacon stayed silent). No JS sink is reached.
 
 ### waf-bypass-level4
 
@@ -34,8 +40,10 @@ Classic WAF bypass filters: keyword strip, event strip, quote escape, single-sid
 
 `/waf-bypass/level5/?query=%3Csvg%20onload=alert(1)%3E`
 
-- payload: `<svg onload=alert(1)>`
-- context: only `<` stripped — defensive stub; no working tag-opening bypass
+- payload: `no payload — control`
+- context: every `<` is stripped, so no tag can open in the body context —
+  served output is the inert text `svg onload=alert(1)>`. A defensive stub with
+  no tag-opening bypass.
 
 ### waf-bypass-level6
 

--- a/solutions/xsleak.md
+++ b/solutions/xsleak.md
@@ -11,33 +11,33 @@ Sign in first via `/xsleak/login?as=admin` to observe the admin branch.
 
 `/xsleak/search?q=admin`
 
-- payload: `q=admin` (no XSS — control)
-- context: body-size oracle; admin returns ~60 results plus hidden filler, guest ~6 — the response length leaks the role. No sink to inject.
+- payload: `no payload — control`
+- context: body-size oracle (probe with `q=admin`); admin returns ~60 results plus hidden filler, guest ~6 — the response length leaks the role. No sink to inject. XS-Leak, not XSS.
 
 ### xsleak-level2
 
 `/xsleak/frame?q=admin`
 
-- payload: `q=admin` (no XSS — control)
-- context: frame-count oracle; admin embeds 12 subframes, guest 1 — `window.frames.length` leaks the role cross-origin. No sink to inject.
+- payload: `no payload — control`
+- context: frame-count oracle (probe with `q=admin`); admin embeds 12 subframes, guest 1 — `window.frames.length` leaks the role cross-origin. No sink to inject. XS-Leak, not XSS.
 
 ### xsleak-level3
 
 `/xsleak/avatar.gif?q=admin`
 
-- payload: `q=admin` (no XSS — control)
-- context: image load/error oracle; admin gets a valid GIF (onload), guest a 404 (onerror). No sink to inject.
+- payload: `no payload — control`
+- context: image load/error oracle (probe with `q=admin`); admin gets a valid GIF (onload), guest a 404 (onerror). No sink to inject. XS-Leak, not XSS.
 
 ### xsleak-level4
 
 `/xsleak/timing?q=admin`
 
-- payload: `q=admin` (no XSS — control)
-- context: response-timing oracle; the guest branch sleeps ~250ms, admin ~10ms — measurable cross-origin. No sink to inject.
+- payload: `no payload — control`
+- context: response-timing oracle (probe with `q=admin`); the guest branch sleeps ~250ms, admin ~10ms — measurable cross-origin. No sink to inject. XS-Leak, not XSS.
 
 ### xsleak-level5
 
 `/xsleak/redirect?q=admin`
 
-- payload: `q=admin` (no XSS — control)
-- context: redirect-chain-length oracle; admin follows 5 hops, guest 1 — observable via fetch/redirect counting. No sink to inject.
+- payload: `no payload — control`
+- context: redirect-chain-length oracle (probe with `q=admin`); admin follows 5 hops, guest 1 — observable via fetch/redirect counting. No sink to inject. XS-Leak, not XSS.

--- a/spec/solutions_spec.cr
+++ b/spec/solutions_spec.cr
@@ -46,4 +46,41 @@ describe "solutions answer key" do
     sample["context"].as_s.should_not be_empty
     sample["url"].as_s.should_not be_empty
   end
+
+  # A maze marked `exploitable: false` in the catalog is a deliberate true
+  # negative — a scanner that reports nothing there is *correct*. Its answer-key
+  # entry must read as a control, not a live exploit, or `/solutions.json` and
+  # `/map/json` contradict each other and a scanner author is told a control is
+  # exploitable. That is precisely the drift the earlier parity checks cannot
+  # catch: they assert an entry *exists*, never that it is *true*.
+  #
+  # The cheap, unfakeable marker is the payload field. A control has no working
+  # payload, so its `- payload:` states as much and carries the word "control";
+  # the parser keeps only the code-span text, so the marker has to live inside
+  # the span (`\`no payload — control\``), not trail it. We match the substring
+  # rather than an exact string to leave the wording free, and no real exploit
+  # payload (`<script>…`, `javascript:…`, `" onerror=…`) carries it by accident.
+  control_marker = "control"
+
+  it "documents every `exploitable: false` maze as a control, not an exploit" do
+    offenders = Xssmaze.get.reject(&.exploitable?).compact_map do |maze|
+      sol = entries[maze.name]?
+      next if sol.nil? # a missing entry is the parity check's job, not this one
+      "#{maze.name}  (payload: #{sol.payload.inspect})" \
+        unless sol.payload.downcase.includes?(control_marker)
+    end.sort!
+
+    unless offenders.empty?
+      fail <<-MSG
+        #{offenders.size} control(s) have a solution payload that reads as a live exploit:
+          #{offenders.join("\n  ")}
+
+        A maze with `exploitable: false` is a true negative — there is no working
+        payload. Its `- payload:` line must say so: the standard marker is
+        `no payload — control` (inside the code span), with the reasoning — and any
+        different-bug-class detail, e.g. the open redirect or the XS-Leak oracle —
+        moved into `- context:`.
+        MSG
+    end
+  end
 end


### PR DESCRIPTION
## What changed

The triage passes marked **28** endpoints `exploitable: false` (`non-xss-control`) — deliberate true negatives where a scanner reporting nothing is *correct*. But `solutions/` still documented a working exploit for most of them, so `/solutions.json` and `/map/json` contradicted each other and a scanner author reading the answer key was told a control is exploitable. The parity spec only asserted an entry *exists*, never that it is *true* — this closes that hole.

- **All 28 control entries rewritten** so `- payload:` states there is no working payload (carrying a `control` marker inside the code span) and `- context:` explains why no breakout exists — naming the real bug for the different-bug-class cases (open redirect, XS-Leak oracle, CSP, content-type).
- **`spec/solutions_spec.cr` gains a control-parity check** (see "Why this spec shape" below).

Files touched: `solutions/**`, `spec/solutions_spec.cr` only.

## How I verified

Derived the control set from a running build (rebased onto `origin/main`, which grew it from 21 → 28): crossed `/map/json` (`vuln.exploitable == false`) against `/solutions.json`. Where execution was the question I settled it in real headless Chrome via the `/beacon` oracle, **running a known-exploitable endpoint (`basic-level1`) through the same harness first** so a "not fired" result is proof, not a broken test:

```
fired: ['ctl']    # basic-level1 control group fired; all 6 navigable controls stayed silent
```

**Every one of the 28 is a genuine control; none flipped to a metadata bug.**

## Reconciliation table

| endpoint | documented payload | tested → result | Chrome / evidence | outcome |
|---|---|---|---|---|
| bugbounty-level10 | `<script>alert(1)</script>` (json sniff) | served `application/json`; Chrome renders body as escaped text in `<pre>` | beacon silent | rewrite → control |
| dom-level10 | `javascript:alert(1)` | `img.src` never runs `javascript:` | (already control) | rewrite → control |
| encmix-level2 | `&#x3c;script&#x3e;…` | served `&#x3c;script…` — entity in text node = visible text | served HTML | rewrite → control |
| encoding-bypass-level6 | `%3Cscript%3E…` (double-enc) | served `scriptalert(1)/script` — angles stripped | served HTML | rewrite → control |
| metarefresh-level2 | `data:text/html,<script>…` | meta refresh to `data:` refused top-level | beacon silent, no nav | rewrite → control |
| modern-bypass-level19 | postMessage `eval` | inline script is a SyntaxError (`/https://…/`); listener never registers | node parse error confirmed | rewrite → control |
| mutfilter-level1 | `%3Cimg…%3E` | served literal `%3Cimg…%3E` text | served HTML | rewrite → control |
| realworld_input-level4 | `javascript:alert(1)` | `Location:` js: not executed | beacon silent | rewrite → control (open redirect) |
| redirect-level1 | `javascript:alert(1)` | `Location:` js: not executed | Chrome nav + beacon silent | rewrite → control (open redirect) |
| redirect-level2/3/4 | nested `javascript` | `Location` reassembles to `javascript:alert(1)` but redirect sink can't execute | served headers | rewrite → control (open redirect) |
| sanitizer-level5 | `test` | double-escaped; served `&amp;lt;script…` | served HTML | rewrite → control |
| stored-level2 | `<script>alert(1)</script>` | `strip_angles` removes `<>` before storage | served HTML | rewrite → control |
| waf-bypass-level3 | `" autofocus o&#110;focus=alert(1) x="` | **payload provably wrong** | Chrome `--dump-dom`: attr literally named `o&#110;focus`, `hasAttribute('onfocus')`=false, beacon silent | rewrite → control |
| waf-bypass-level5 | `<svg onload=alert(1)>` | only `<` stripped; served `svg onload=…>` | served HTML | rewrite → control |
| xsleak-level1..5 | `q=admin` oracles | size / frame-count / img / timing / redirect-chain oracles, no injection sink | by design | rewrite → control (XS-Leak) |
| csp-bypass-level3 | `";alert(1);//` | CSP `script-src 'unsafe-eval'` (no unsafe-inline) → inline `<script>` blocked | beacon silent vs firing control | rewrite → control (CSP) |
| csp-bypass-level4 | `<img … onerror=…>` | CSP `default-src 'self'; script-src 'self'` blocks data: iframe + inline listener | beacon silent | rewrite → control (CSP) |
| cspbypass-level3 | `";alert(1);//` | CSP `script-src 'self' 'unsafe-eval'` (no unsafe-inline) → inline script blocked | beacon silent | rewrite → control (CSP) |
| nonce-level2 | `');alert(1)//` | CSP `nonce-X 'unsafe-hashes'` with no hash listed → inline `onclick` blocked | beacon silent | rewrite → control (CSP) |
| json-xss-level2 | `<img … onerror=…>` | served `application/json`, not parsed as HTML | beacon silent vs firing control | rewrite → control |
| json-xss-level3 | `</script><script>…` | `application/json`, quotes/`\` escaped | beacon silent | rewrite → control |
| realworld-level6 | `<script>alert(1)</script>` | served `text/plain`, not sniffed | beacon silent vs firing control | rewrite → control |

## Why this spec shape

The new `it "documents every exploitable:false maze as a control…"` iterates `Xssmaze.get.reject(&.exploitable?)` and requires each maze's parsed `Solution.payload` to contain the substring `control`. A control has no working payload, so the payload field is the natural place to mark it — and because the markdown parser keeps only the code-span text, the marker must live *inside* the span (`` `no payload — control` ``), which is exactly where a live-exploit payload (`<script>…`, `javascript:…`) would never have it. Substring rather than exact string keeps the wording free; the check only ever reads control entries, so it can never reject a real exploit. The failure message lists each offender with its payload and tells the author precisely what to write.

**Confirmed the check bites** — reintroducing an exploit payload for `json-xss-level2`:

```
1 control(s) have a solution payload that reads as a live exploit:
  json-xss-level2  (payload: "<img src=x onerror=alert(1)>")

A maze with `exploitable: false` is a true negative — there is no working
payload. Its `- payload:` line must say so: the standard marker is
`no payload — control` (inside the code span)...
```

## Verification commands

- `crystal spec` → `194 examples, 0 failures, 0 errors, 0 pending`
- `crystal tool format --check` → clean
- `bin/ameba` → `206 inspected, 0 failures`

## For the reviewer to double-check

- **No `src/**` changes** — all 28 were confirmed as true controls, so the metadata is right and nothing belongs in `src/mazes/**`. The one provably-false answer-key payload (waf-bypass-level3) was an answer-key error, now fixed in `solutions/`.
- The `control` marker is deliberately loose (substring). If you'd prefer a stricter sentinel (e.g. exact `no payload — control`), it's a one-line change.
