### PR TITLE
fix(mazes): stop S1 mazes 5xx-ing when a parameter is absent

### DIFF
--- a/src/mazes/advanced_html5_sanitizer_bypass.cr
+++ b/src/mazes/advanced_html5_sanitizer_bypass.cr
@@ -58,7 +58,7 @@ Xssmaze.push(
   "Mock sanitizer: strips <script>/<iframe>/<object> but allows MathML structures",
   vuln: "reflected-html", delivery: ["query"], note: "server reflects raw into a <div>; the tag/event blacklist misses MathML namespace vectors")
 maze_get "/html5-sanitizer/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # Naive sanitizer: only strips dangerous HTML tags, doesn't understand namespaces
   sanitized = query
@@ -86,7 +86,7 @@ Xssmaze.push(
   "Parser differential: <math><xmp><iframe srcdoc=...></xmp></math> namespace confusion",
   vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; the recursive script/event/js: filters miss the math/xmp/iframe-srcdoc parser differential")
 maze_get "/html5-sanitizer/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # More sophisticated sanitizer: removes dangerous tags AND their content recursively
   # But still doesn't handle namespace switching properly
@@ -130,7 +130,7 @@ Xssmaze.push(
   "MathML annotation-xml encoding=text/html with iframe srcdoc bypass",
   vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; iframe is stripped in HTML context but annotation-xml switches to HTML parsing")
 maze_get "/html5-sanitizer/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # Sanitizer strips iframe but doesn't check inside MathML annotation-xml
   sanitized = Filters.strip_tags(query, ["iframe", "script", "object"])
@@ -154,7 +154,7 @@ Xssmaze.push(
   "Template + MathML double namespace confusion with srcdoc",
   vuln: "reflected-js", sinks: ["innerHTML"], delivery: ["query"], note: "reflected raw into a backtick template literal, then assigned to innerHTML; break out with a backtick or use ${...}")
 maze_get "/html5-sanitizer/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # Sanitizer that handles single-level namespace but not nested namespaces
   sanitized = Filters.strip_tags(query, ["script"])
@@ -183,7 +183,7 @@ Xssmaze.push(
   "SVG foreignObject + MathML namespace chain with srcdoc bypass",
   vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; script/js: filters miss the SVG foreignObject to MathML namespace chain")
 maze_get "/html5-sanitizer/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # Sanitizer that strips script but doesn't understand SVG + MathML namespace chains
   sanitized = Filters.strip_keyword_recursive(query, "script")
@@ -208,7 +208,7 @@ Xssmaze.push(
   "MathML with form element name collision + srcdoc XSS",
   vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; leaves the MathML form-name-clobbering + iframe srcdoc vector")
 maze_get "/html5-sanitizer/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # Sanitizer allows form elements but doesn't check for DOM clobbering in MathML context
   sanitized = Filters.strip_tags(query, ["script", "object"])
@@ -237,7 +237,7 @@ Xssmaze.push(
   "MathML + srcdoc with data URI base64 encoding bypass",
   vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; the single data:/script strip is bypassable with entity-encoded data: URIs")
 maze_get "/html5-sanitizer/level7/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # Sanitizer that strips data: protocol but doesn't check inside srcdoc in MathML
   sanitized = query.gsub(/data:/i, "")
@@ -263,7 +263,7 @@ Xssmaze.push(
   "Shadow DOM slot + MathML namespace with srcdoc bypass",
   vuln: "reflected-html", delivery: ["query"], note: "reflected raw into a <div>; script/event filters miss the declarative-shadow-DOM template vector")
 maze_get "/html5-sanitizer/level8/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # Sanitizer doesn't understand Shadow DOM boundaries combined with MathML
   sanitized = Filters.strip_tags(query, ["script"])

--- a/src/mazes/aria_attr_xss.cr
+++ b/src/mazes/aria_attr_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("ariaattr-level1", "/ariaattr/level1/?query=a", "reflection in aria-label attribute (double-quoted)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <div role=\"alert\" aria-label=\"#{query}\">notification</div>
@@ -15,7 +15,7 @@ end
 Xssmaze.push("ariaattr-level2", "/ariaattr/level2/?query=a", "reflection in aria-describedby attribute (double-quoted)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <input aria-describedby=\"#{query}\" type=\"text\">
@@ -27,7 +27,7 @@ end
 Xssmaze.push("ariaattr-level3", "/ariaattr/level3/?query=a", "reflection in aria-atomic attribute (double-quoted)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <span aria-live=\"polite\" aria-atomic=\"#{query}\">updates</span>
@@ -39,7 +39,7 @@ end
 Xssmaze.push("ariaattr-level4", "/ariaattr/level4/?query=a", "reflection in aria-hidden attribute (double-quoted)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <div role=\"tooltip\" aria-hidden=\"#{query}\">tooltip text</div>
@@ -51,7 +51,7 @@ end
 Xssmaze.push("ariaattr-level5", "/ariaattr/level5/?query=a", "reflection in nav aria-label attribute (double-quoted)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <nav aria-label=\"#{query}\">
@@ -65,7 +65,7 @@ end
 Xssmaze.push("ariaattr-level6", "/ariaattr/level6/?query=a", "reflection in role attribute (double-quoted)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/ariaattr/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <div role=\"#{query}\" aria-relevant=\"additions\">content</div>

--- a/src/mazes/attrname_xss.cr
+++ b/src/mazes/attrname_xss.cr
@@ -1,27 +1,27 @@
 Xssmaze.push("attrname-level1", "/attrname/level1/?query=a", "user controls attribute name on a tag",
   vuln: "reflected-attr", delivery: ["query"], note: "the value lands in attribute-name position, so no quote breakout is needed: onmouseover=alert(1) x works as-is")
 maze_get "/attrname/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div #{query}='value'>hi</div>"
 end
 
 Xssmaze.push("attrname-level2", "/attrname/level2/?query=a", "attribute name on a button (onclick injection)",
   vuln: "reflected-attr", delivery: ["query"], note: "the attribute value is fixed to alert(1); supply only the name, e.g. autofocus onfocus, so it fires without a click")
 maze_get "/attrname/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<button #{query}='alert(1)'>click</button>"
 end
 
 Xssmaze.push("attrname-level3", "/attrname/level3/?query=a", "attribute name with space stripped (newline bypass)",
   vuln: "reflected-attr", delivery: ["query"], note: "literal spaces are stripped, so separate attributes with a tab or newline; the trailing =go value is not callable, so bring your own handler")
 maze_get "/attrname/level3/" do |env|
-  query = env.params.query["query"].gsub(" ", "")
+  query = env.params.query.fetch("query", "").gsub(" ", "")
   "<input type='text' #{query}='go'>"
 end
 
 Xssmaze.push("attrname-level4", "/attrname/level4/?query=a", "attribute name on <a>, equals stripped (boolean attr bypass)",
   vuln: "reflected-attr", delivery: ["query"], note: "= is stripped, so no attribute can be given a value; close the tag and inject <script>alert(1)</script>, which needs no =")
 maze_get "/attrname/level4/" do |env|
-  query = env.params.query["query"].gsub("=", "")
+  query = env.params.query.fetch("query", "").gsub("=", "")
   "<a href='#' #{query}>link</a>"
 end

--- a/src/mazes/basic.cr
+++ b/src/mazes/basic.cr
@@ -1,44 +1,44 @@
 Xssmaze.push("basic-level1", "/basic/level1/?query=a", "no escape",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/basic/level1/" do |env|
-  env.params.query["query"]
+  env.params.query.fetch("query", "")
 end
 
 Xssmaze.push("basic-level2", "/basic/level2/?query=a", "escape to double-quot",
   vuln: "reflected-html", delivery: ["query"], note: "only double quotes are entity-encoded, which the HTML body context does not need")
 maze_get "/basic/level2/" do |env|
-  Filters.escape_double_quote(env.params.query["query"])
+  Filters.escape_double_quote(env.params.query.fetch("query", ""))
 end
 
 Xssmaze.push("basic-level3", "/basic/level3/?query=a", "escape to single-quot",
   vuln: "reflected-html", delivery: ["query"], note: "only single quotes are entity-encoded, which the HTML body context does not need")
 maze_get "/basic/level3/" do |env|
-  Filters.escape_single_quote(env.params.query["query"])
+  Filters.escape_single_quote(env.params.query.fetch("query", ""))
 end
 
 Xssmaze.push("basic-level4", "/basic/level4/?query=a", "escape to all quot",
   vuln: "reflected-html", delivery: ["query"], note: "both quote characters are entity-encoded; angle brackets pass through untouched")
 maze_get "/basic/level4/" do |env|
-  Filters.escape_quotes(env.params.query["query"])
+  Filters.escape_quotes(env.params.query.fetch("query", ""))
 end
 
 Xssmaze.push("basic-level5", "/basic/level5/?query=a", "escape to parenthesis",
   vuln: "reflected-html", delivery: ["query"], note: "parentheses are stripped, so alert(1) never survives; use a paren-free call such as alert`1`")
 maze_get "/basic/level5/" do |env|
-  Filters.strip_parens(env.params.query["query"])
+  Filters.strip_parens(env.params.query.fetch("query", ""))
 end
 
 Xssmaze.push("basic-level6", "/basic/level6/?query=a", "escape to all quot and parenthesis",
   vuln: "reflected-html", delivery: ["query"], note: "quotes are encoded and parentheses stripped; a backtick call such as alert`1` still works")
 maze_get "/basic/level6/" do |env|
-  query = Filters.escape_quotes(env.params.query["query"])
+  query = Filters.escape_quotes(env.params.query.fetch("query", ""))
   Filters.strip_parens(query)
 end
 
 Xssmaze.push("basic-level7", "/basic/level7/?query=a", "escape to all quot and parenthesis and backtick",
   vuln: "reflected-html", delivery: ["query"], note: "quotes, parentheses and backticks are all removed, so the call has to come from a handler assignment: <script>onerror=alert;throw 1</script>")
 maze_get "/basic/level7/" do |env|
-  query = Filters.escape_quotes(env.params.query["query"])
+  query = Filters.escape_quotes(env.params.query.fetch("query", ""))
   query = Filters.strip_parens(query)
   query.gsub("`", "")
 end

--- a/src/mazes/case_manipulation_xss.cr
+++ b/src/mazes/case_manipulation_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("casemanip-level1", "/casemanip/level1/?query=a", "lowercase tag names only, attributes untouched",
   vuln: "reflected-html", delivery: ["query"], note: "only tag names are lowercased; lowercase payloads reflect unchanged into the body")
 maze_get "/casemanip/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Lowercase only the tag name portion: <TAG -> <tag
   result = query.gsub(/<([A-Za-z]+)/) do |_|
     tag = $1
@@ -18,7 +18,7 @@ end
 Xssmaze.push("casemanip-level2", "/casemanip/level2/?query=a", "capitalize first letter only, HTML still valid",
   vuln: "reflected-html", delivery: ["query"], note: "only the first letter is uppercased; <Img ...> is still valid HTML")
 maze_get "/casemanip/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   result = if query.size > 0
              query[0].upcase + query[1..]
            else
@@ -33,7 +33,7 @@ end
 Xssmaze.push("casemanip-level3", "/casemanip/level3/?query=a", "swap case of all alpha chars, HTML case-insensitive",
   vuln: "reflected-html", delivery: ["query"], note: "case is swapped, but HTML tags are case-insensitive")
 maze_get "/casemanip/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   result = query.chars.map do |ch|
     if ch.uppercase?
       ch.downcase
@@ -52,7 +52,7 @@ end
 Xssmaze.push("casemanip-level4", "/casemanip/level4/?query=a", "ROT13 display but raw reflection in hidden input",
   vuln: "reflected-attr", delivery: ["query"], note: "the ROT13 body copy is a decoy; the raw value is reflected into a hidden input value attribute")
 maze_get "/casemanip/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   rot13 = query.chars.map do |ch|
     if ch >= 'a' && ch <= 'z'
       ((((ch.ord - 'a'.ord) + 13) % 26) + 'a'.ord).chr
@@ -71,7 +71,7 @@ end
 Xssmaze.push("casemanip-level5", "/casemanip/level5/?query=a", "strip uppercase letters only, lowercase payloads work",
   vuln: "reflected-html", delivery: ["query"], note: "only uppercase letters are stripped; an all-lowercase payload survives")
 maze_get "/casemanip/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   result = query.gsub(/[A-Z]/, "")
 
   "<html><body>#{result}</body></html>"
@@ -82,7 +82,7 @@ end
 Xssmaze.push("casemanip-level6", "/casemanip/level6/?query=a", "titlecase words, HTML case-insensitive",
   vuln: "reflected-html", delivery: ["query"], note: "words are title-cased, but HTML tags are case-insensitive")
 maze_get "/casemanip/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   result = query.split(" ").map do |word|
     if word.size > 0
       word[0].upcase + word[1..]

--- a/src/mazes/comment_injection_xss.cr
+++ b/src/mazes/comment_injection_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("commentinj-level1", "/commentinj/level1/?query=a", "reflected inside HTML comment",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside an HTML comment; close it with --> to inject markup")
 maze_get "/commentinj/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><!-- #{query} --><p>Safe content</p></body></html>"
 end
 
@@ -10,7 +10,7 @@ end
 Xssmaze.push("commentinj-level2", "/commentinj/level2/?query=a", "reflected inside JS block comment in script tag",
   vuln: "reflected-js", delivery: ["query"], note: "reflected inside a /* */ block comment in a <script>; close the comment or the </script>")
 maze_get "/commentinj/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><script>/* #{query} */var x=1;</script><p>Safe content</p></body></html>"
 end
 
@@ -18,7 +18,7 @@ end
 Xssmaze.push("commentinj-level3", "/commentinj/level3/?query=a", "reflected inside JS single-line comment in script tag",
   vuln: "reflected-js", delivery: ["query"], note: "reflected inside a // line comment in a <script>; a newline or </script> ends it")
 maze_get "/commentinj/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><script>// #{query}\nvar x=1;</script><p>Safe content</p></body></html>"
 end
 
@@ -26,7 +26,7 @@ end
 Xssmaze.push("commentinj-level4", "/commentinj/level4/?query=a", "reflected inside conditional comment",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside a downlevel conditional comment; close it with <![endif]--> to inject markup")
 maze_get "/commentinj/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><!--[if IE]>#{query}<![endif]--><p>Safe content</p></body></html>"
 end
 
@@ -34,7 +34,7 @@ end
 Xssmaze.push("commentinj-level5", "/commentinj/level5/?query=a", "reflected inside HTML comment with --> stripped (use --!> to close)",
   vuln: "reflected-html", delivery: ["query"], note: "--> is stripped once; --!> also closes the HTML comment")
 maze_get "/commentinj/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("-->", "")
   "<html><body><!-- #{filtered} --><p>Safe content</p></body></html>"
 end
@@ -43,6 +43,6 @@ end
 Xssmaze.push("commentinj-level6", "/commentinj/level6/?query=a", "reflected inside JS block comment - close comment and script tag",
   vuln: "reflected-js", delivery: ["query"], note: "reflected inside a /* */ block comment in a <script>; close the comment then the </script>")
 maze_get "/commentinj/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><script>/* #{query} */</script><p>Safe content</p></body></html>"
 end

--- a/src/mazes/content_type_xss.cr
+++ b/src/mazes/content_type_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("ctype-level1", "/ctype/level1/?query=a", "text/xml content type with raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "parsed as an XML document: the payload must stay well-formed and carry the XHTML namespace on its script element")
 maze_get "/ctype/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/xml"
 
   "<?xml version=\"1.0\"?><root>#{query}</root>"
@@ -12,7 +12,7 @@ end
 Xssmaze.push("ctype-level2", "/ctype/level2/?query=a", "application/xhtml+xml with raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "parsed as XHTML, so the payload must be well-formed XML or the document fails to render at all")
 maze_get "/ctype/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "application/xhtml+xml"
 
   "<?xml version=\"1.0\"?>
@@ -26,7 +26,7 @@ end
 Xssmaze.push("ctype-level3", "/ctype/level3/?query=a", "text/html with CDATA section reflection",
   vuln: "reflected-html", delivery: ["query"], note: "the HTML parser treats <![CDATA[ as a bogus comment that ends at the first >, so lead the payload with > to escape it")
 maze_get "/ctype/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "<html><body><![CDATA[#{query}]]></body></html>"
@@ -46,7 +46,7 @@ end
 Xssmaze.push("ctype-level5", "/ctype/level5/?query=a", "image/svg+xml with SVG text reflection",
   vuln: "reflected-html", delivery: ["query"], note: "standalone SVG document: scripts run on direct navigation but not when the URL is used as an <img> source, and the payload must be well-formed XML")
 maze_get "/ctype/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "image/svg+xml"
 
   "<svg xmlns=\"http://www.w3.org/2000/svg\"><text>#{query}</text></svg>"
@@ -56,7 +56,7 @@ end
 Xssmaze.push("ctype-level6", "/ctype/level6/?query=a", "text/html with nosniff and raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "the nosniff header is not a control here: the response really is text/html, so the reflection executes")
 maze_get "/ctype/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
   env.response.headers["X-Content-Type-Options"] = "nosniff"
 

--- a/src/mazes/csp_bypass_xss.cr
+++ b/src/mazes/csp_bypass_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("cspbypass-level1", "/cspbypass/level1/?query=a", "CSP unsafe-inline allows raw script injection",
   vuln: "reflected-html", delivery: ["query"], note: "script-src 'unsafe-inline', so an injected inline <script> executes")
 maze_get "/cspbypass/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'unsafe-inline'"
 
   "<html><head></head><body>
@@ -15,7 +15,7 @@ end
 Xssmaze.push("cspbypass-level2", "/cspbypass/level2/?query=a", "CSP nonce script with reflection in JS string context",
   vuln: "reflected-js", delivery: ["query"], note: "reflected inside a nonce'd inline <script>; break the double-quoted string to run under the nonce, which is the fixed literal r4nd0mN0nc3")
 maze_get "/cspbypass/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   nonce = "r4nd0mN0nc3"
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'nonce-#{nonce}'"
 
@@ -32,7 +32,7 @@ end
 Xssmaze.push("cspbypass-level3", "/cspbypass/level3/?query=a", "CSP unsafe-eval with reflection in eval'd JS string",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "script-src 'self' 'unsafe-eval' carries no 'unsafe-inline', so the inline <script> holding the reflection never executes and an injected script or event handler is blocked as well; reporting no XSS here is the correct result")
 maze_get "/cspbypass/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' 'unsafe-eval'"
 
   "<html><head></head><body>
@@ -48,7 +48,7 @@ end
 Xssmaze.push("cspbypass-level4", "/cspbypass/level4/?query=a", "no CSP but single-pass script tag strip",
   vuln: "reflected-html", delivery: ["query"], note: "<script> and </script> are stripped in a single pass; use another tag or nest the keyword")
 maze_get "/cspbypass/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Single-pass removal of <script> and </script> tags
   filtered = query.gsub(/<\/?script[^>]*>/i, "")
 
@@ -62,7 +62,7 @@ end
 Xssmaze.push("cspbypass-level5", "/cspbypass/level5/?query=a", "CSP unsafe-inline with alert keyword stripped",
   vuln: "reflected-js", delivery: ["query"], note: "\"alert\" is stripped case-insensitively; 'unsafe-inline' is set, so a </script> breakout works as well as a string breakout")
 maze_get "/cspbypass/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/alert/i, "")
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'unsafe-inline'"
 
@@ -78,7 +78,7 @@ end
 Xssmaze.push("cspbypass-level6", "/cspbypass/level6/?query=a", "CSP misconfigured with script-src * allowing all scripts",
   vuln: "reflected-html", delivery: ["query"], note: "script-src * matches URL sources only — an inline <script> or event handler is still blocked, so the payload has to load an external script, e.g. <script src=//host/x.js></script>")
 maze_get "/cspbypass/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.headers["Content-Security-Policy"] = "default-src 'self'; script-src *"
 
   "<html><head></head><body>

--- a/src/mazes/data_attribute_xss.cr
+++ b/src/mazes/data_attribute_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("dataattr-level1", "/data-attribute/level1/?query=a", "reflected in data-value double-quoted attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/data-attribute/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div data-value=\"#{query}\">content</div></body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("dataattr-level2", "/data-attribute/level2/?query=a", "reflected in single-quoted data-config JSON attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "single-quoted data-config attribute holding JSON")
 maze_get "/data-attribute/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div data-config='{\"name\":\"" + query + "\"}'>config</div></body></html>"
 end
@@ -23,7 +23,7 @@ end
 Xssmaze.push("dataattr-level3", "/data-attribute/level3/?query=a", "reflected in data-tooltip double-quoted attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/data-attribute/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><span data-tooltip=\"#{query}\" class=\"tip\">hover me</span></body></html>"
 end
@@ -33,7 +33,7 @@ end
 Xssmaze.push("dataattr-level4", "/data-attribute/level4/?query=a", "reflected in data-action Stimulus-style attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/data-attribute/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><button data-action=\"click->controller##{query}\">Click</button></body></html>"
 end
@@ -43,7 +43,7 @@ end
 Xssmaze.push("dataattr-level5", "/data-attribute/level5/?query=a", "reflected in single-quoted data-src (double-quote encoded only)",
   vuln: "reflected-attr", delivery: ["query"], note: "double quotes are encoded; the attribute is single-quoted")
 maze_get "/data-attribute/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = query.gsub("\"", "&quot;")
 
   "<html><body><div data-src='#{encoded}'>image</div></body></html>"
@@ -54,7 +54,7 @@ end
 Xssmaze.push("dataattr-level6", "/data-attribute/level6/?query=a", "reflected in data-url attribute inside table row",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/data-attribute/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><table><tr data-url=\"#{query}\"><td>Row 1</td></tr></table></body></html>"
 end

--- a/src/mazes/decode.cr
+++ b/src/mazes/decode.cr
@@ -3,7 +3,7 @@ require "base64"
 Xssmaze.push("decode-level1", "/decode/level1/?query=a", "base64 decode",
   vuln: "reflected-html", delivery: ["query"], note: "the value must be valid base64; anything else answers Decode Error, so the payload is the base64 of the markup")
 maze_get "/decode/level1/" do |env|
-  Base64.decode_string(env.params.query["query"])
+  Base64.decode_string(env.params.query.fetch("query", ""))
 rescue
   "Decode Error"
 end
@@ -11,10 +11,10 @@ end
 Xssmaze.push("decode-level2", "/decode/level2/?query=a", "url decode",
   vuln: "reflected-html", delivery: ["query"], note: "a literal < is rejected, but the server URL-decodes once afterwards, so send %253C (which arrives as %3C)")
 maze_get "/decode/level2/" do |env|
-  if env.params.query["query"].includes?("<")
+  if env.params.query.fetch("query", "").includes?("<")
     "Detect Special Character"
   else
-    URI.decode(env.params.query["query"])
+    URI.decode(env.params.query.fetch("query", ""))
   end
 rescue
   "Decode Error"
@@ -23,7 +23,7 @@ end
 Xssmaze.push("decode-level3", "/decode/level3/?query=a", "double url decode",
   vuln: "reflected-html", delivery: ["query"], note: "URL-decoded once, checked for <, then decoded again; send %25253C so the check sees %3C")
 maze_get "/decode/level3/" do |env|
-  data = URI.decode(env.params.query["query"])
+  data = URI.decode(env.params.query.fetch("query", ""))
   if data.includes?("<")
     "Detect Special Character"
   else
@@ -36,7 +36,7 @@ end
 Xssmaze.push("decode-level4", "/decode/level4/?query=a", "double base64 decode",
   vuln: "reflected-html", delivery: ["query"], note: "the value is base64-decoded twice; anything else answers Decode Error")
 maze_get "/decode/level4/" do |env|
-  data = Base64.decode_string(env.params.query["query"])
+  data = Base64.decode_string(env.params.query.fetch("query", ""))
   Base64.decode_string(data)
 rescue
   "Decode Error"

--- a/src/mazes/dragdrop_xss.cr
+++ b/src/mazes/dragdrop_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("dragdrop-level1", "/dragdrop/level1/?query=a", "drop handler innerHTMLs dataTransfer.getData('text/html') (reflected prefix)",
   vuln: "dom", sources: ["dataTransfer"], sinks: ["innerHTML"], delivery: ["query"], note: "the reflected prefix only reaches innerHTML when the user drops content on the zone")
 maze_get "/dragdrop/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='zone' style='border:1px dashed #999;padding:30px'>drop here</div>
    <div id='out'></div>
    <script>
@@ -20,7 +20,7 @@ end
 Xssmaze.push("dragdrop-level2", "/dragdrop/level2/?query=a", "dragstart sets reflected text/html (XSS fires in target page)",
   vuln: "dom", sources: ["server-reflected"], sinks: ["dataTransfer.setData"], delivery: ["query"], note: "requires a user drag; execution happens in the drop-target page, not here")
 maze_get "/dragdrop/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='src' draggable='true' style='cursor:move;padding:8px;border:1px solid #ccc'>drag me</div>
    <p>Dragging this element copies attacker-controlled HTML onto the dataTransfer; XSS fires in any drop target that innerHTMLs text/html.</p>
    <script>
@@ -33,7 +33,7 @@ end
 Xssmaze.push("dragdrop-level3", "/dragdrop/level3/?query=a", "drop builds <a href> from dropped text/uri-list (no escaping)",
   vuln: "dom", sources: ["dataTransfer"], sinks: ["innerHTML"], delivery: ["query"], note: "requires a user drop; the dropped URI is concatenated into an unquoted <a href>")
 maze_get "/dragdrop/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='zone' style='padding:30px;border:1px solid #ccc'>drop link</div>
    <div id='out'></div>
    <script>
@@ -51,7 +51,7 @@ end
 Xssmaze.push("dragdrop-level4", "/dragdrop/level4/?query=a", "drop reads files[0] as text/html via FileReader.innerHTML",
   vuln: "dom", sources: ["dataTransfer"], sinks: ["innerHTML"], delivery: ["query"], note: "requires the user to drop a file; the FileReader result is concatenated into innerHTML")
 maze_get "/dragdrop/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='zone' style='padding:30px;border:1px solid #ccc'>drop file</div>
    <div id='out'></div>
    <script>

--- a/src/mazes/edge_filter_xss.cr
+++ b/src/mazes/edge_filter_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("edgefilter-level1", "/edgefilter/level1/?query=a", "strips script keyword but allows other tags and event handlers",
   vuln: "reflected-html", delivery: ["query"], note: "script is stripped case-insensitively; other tags and their event handlers pass through untouched")
 maze_get "/edgefilter/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/script/i, "")
 
   "<html><head></head><body>
@@ -16,7 +16,7 @@ end
 Xssmaze.push("edgefilter-level2", "/edgefilter/level2/?query=a", "single-pass tag regex strip (double-wrap bypass)",
   vuln: "reflected-html", delivery: ["query"], note: "one pass of a <...> regex; nest a throwaway tag inside the payload so the surviving halves rejoin")
 maze_get "/edgefilter/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Single-pass strip: matches <...> greedily
   filtered = query.gsub(/<[^>]+>/, "")
 
@@ -31,7 +31,7 @@ end
 Xssmaze.push("edgefilter-level3", "/edgefilter/level3/?query=a", "angle bracket filter only before alpha chars, reflection in attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "< is only encoded when a letter follows it; break out of the double-quoted value attribute rather than injecting a tag")
 maze_get "/edgefilter/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Encode < only when followed by a letter (tries to block tags but misses attribute escape)
   filtered = query.gsub(/<([a-zA-Z])/) { |_match| "&lt;#{$1}" }
 
@@ -45,7 +45,7 @@ end
 Xssmaze.push("edgefilter-level4", "/edgefilter/level4/?query=a", "strips event handlers but allows script tags",
   vuln: "reflected-html", delivery: ["query"], note: "event-handler attributes are stripped, but tags are not")
 maze_get "/edgefilter/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Remove event handler attributes like onclick=, onerror=, onload=, etc.
   filtered = query.gsub(/on[a-zA-Z]+\s*=/i, "")
 
@@ -60,7 +60,7 @@ end
 Xssmaze.push("edgefilter-level5", "/edgefilter/level5/?query=a", "strips angle brackets and quotes but reflects in raw JS context",
   vuln: "reflected-js", delivery: ["query"], note: "angle brackets and both quote characters are stripped, but the value lands unquoted in a JS statement, so plain code such as 1;alert(1) runs")
 maze_get "/edgefilter/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("<", "").gsub(">", "").gsub("\"", "").gsub("'", "")
 
   "<html><head></head><body>
@@ -73,7 +73,7 @@ end
 Xssmaze.push("edgefilter-level6", "/edgefilter/level6/?query=a", "HTML encode first 20 chars only, rest is raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "only the first 20 characters are entity-encoded; pad the payload past that offset")
 maze_get "/edgefilter/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   if query.size > 20
     head = query[0, 20]
     tail = query[20..]

--- a/src/mazes/encoding_mix_xss.cr
+++ b/src/mazes/encoding_mix_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("encmix-level1", "/encmix/level1/?query=a", "UTF-7 charset in Content-Type with raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "no modern browser decodes UTF-7, but the reflection is raw, so a plain payload works regardless of the declared charset")
 maze_get "/encmix/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html; charset=utf-7"
 
   "<html><body>
@@ -20,7 +20,7 @@ end
 Xssmaze.push("encmix-level2", "/encmix/level2/?query=a", "HTML entity encode < > but not & (double-entity bypass)",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "both angle brackets are entity-encoded before reflection, and an entity in a text node decodes to a character rather than markup, so the numeric-entity payload only renders as visible text")
 maze_get "/encmix/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Only encode literal < and > but leave & untouched
   filtered = query.gsub("<", "&lt;").gsub(">", "&gt;")
 
@@ -37,7 +37,7 @@ end
 Xssmaze.push("encmix-level3", "/encmix/level3/?query=a", "JS string with backslash escape but no unicode filtering",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "backslashes and single quotes are escaped, so neither a string breakout nor a unicode escape survives; the value still reaches innerHTML as raw HTML")
 maze_get "/encmix/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Escape single quotes and backslashes for the JS string
   escaped = query.gsub("\\", "\\\\").gsub("'", "\\'")
 
@@ -58,7 +58,7 @@ end
 Xssmaze.push("encmix-level4", "/encmix/level4/?query=a", "JSON context served as text/html",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined raw into a double-quoted JS string and then written to innerHTML; closing the <script> block works too")
 maze_get "/encmix/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "<html><body>
@@ -81,7 +81,7 @@ end
 Xssmaze.push("encmix-level5", "/encmix/level5/?query=a", "HTML encode only first < and > (second reflection raw)",
   vuln: "reflected-html", delivery: ["query"], note: "the server URL-decodes once, then entity-encodes only the first < and the first >")
 maze_get "/encmix/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   begin
     decoded = URI.decode(query)
@@ -105,7 +105,7 @@ end
 Xssmaze.push("encmix-level6", "/encmix/level6/?query=a", "ISO-8859-1 charset with raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "the iso-8859-1 charset is incidental; the reflection itself is raw")
 maze_get "/encmix/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html; charset=iso-8859-1"
 
   "<html>

--- a/src/mazes/fragment_xss.cr
+++ b/src/mazes/fragment_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("fragment-level1", "/fragment/level1/?query=a", "reflection in option value inside select (break out of option/select)",
   vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected into an <option value> attribute")
 maze_get "/fragment/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><select><option value=\"#{query}\">Choose</option></select></body></html>"
 end
@@ -16,7 +16,7 @@ end
 Xssmaze.push("fragment-level2", "/fragment/level2/?query=a", "reflection in pre tag with .sub encoding (only first <> encoded)",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; only the first < and > are entity-encoded")
 maze_get "/fragment/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.sub("<", "&lt;").sub(">", "&gt;")
 
   "<html><body><pre>#{filtered}</pre></body></html>"
@@ -28,7 +28,7 @@ end
 Xssmaze.push("fragment-level3", "/fragment/level3/?query=a", "reflection inside svg tag as text node",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected as an <svg><text> node")
 maze_get "/fragment/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><svg><text x=\"10\" y=\"20\">#{query}</text></svg></body></html>"
 end
@@ -39,7 +39,7 @@ end
 Xssmaze.push("fragment-level4", "/fragment/level4/?query=a", "reflection inside math tag (close tag escape)",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected inside <math><mi>")
 maze_get "/fragment/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><math><mi>#{query}</mi></math></body></html>"
 end
@@ -50,7 +50,7 @@ end
 Xssmaze.push("fragment-level5", "/fragment/level5/?query=a", "reflection inside details/summary (break out and inject)",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected inside <details><summary>")
 maze_get "/fragment/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><details><summary>#{query}</summary><p>Details content here.</p></details></body></html>"
 end
@@ -61,7 +61,7 @@ end
 Xssmaze.push("fragment-level6", "/fragment/level6/?query=a", "reflection inside marquee tag (close tag escape)",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side HTML-context reflection, not a location.hash DOM flow; reflected inside <marquee>")
 maze_get "/fragment/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><marquee>#{query}</marquee></body></html>"
 end

--- a/src/mazes/iframe_srcdoc_xss.cr
+++ b/src/mazes/iframe_srcdoc_xss.cr
@@ -1,34 +1,34 @@
 Xssmaze.push("srcdoc-level1", "/srcdoc/level1/?query=a", "iframe srcdoc raw reflection",
   vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"])
 maze_get "/srcdoc/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<iframe srcdoc=\"#{query}\"></iframe>"
 end
 
 Xssmaze.push("srcdoc-level2", "/srcdoc/level2/?query=a", "srcdoc with double-quote strip (single-quote bypass)",
   vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "double quotes stripped; use single quotes")
 maze_get "/srcdoc/level2/" do |env|
-  query = env.params.query["query"].gsub("\"", "")
+  query = env.params.query.fetch("query", "").gsub("\"", "")
   "<iframe srcdoc=\"#{query}\"></iframe>"
 end
 
 Xssmaze.push("srcdoc-level3", "/srcdoc/level3/?query=a", "srcdoc HTML-encoded outside, parsed inside",
   vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "entity-encoded in the outer document but decoded again when srcdoc is parsed")
 maze_get "/srcdoc/level3/" do |env|
-  query = env.params.query["query"].gsub("\"", "&quot;")
+  query = env.params.query.fetch("query", "").gsub("\"", "&quot;")
   "<iframe srcdoc=\"<p>#{query}</p>\"></iframe>"
 end
 
 Xssmaze.push("srcdoc-level4", "/srcdoc/level4/?query=a", "srcdoc with sandbox=allow-scripts",
   vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "sandbox='allow-scripts' still permits script execution inside the frame")
 maze_get "/srcdoc/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<iframe sandbox='allow-scripts' srcdoc=\"#{query}\"></iframe>"
 end
 
 Xssmaze.push("srcdoc-level5", "/srcdoc/level5/?query=a", "srcdoc built from concat, &lt;script&gt; stripped only",
   vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "<script> tags stripped; use an event handler")
 maze_get "/srcdoc/level5/" do |env|
-  query = env.params.query["query"].gsub(/<script[^>]*>/i, "").gsub("</script>", "")
+  query = env.params.query.fetch("query", "").gsub(/<script[^>]*>/i, "").gsub("</script>", "")
   "<iframe srcdoc=\"&lt;html&gt;&lt;body&gt;#{query}&lt;/body&gt;&lt;/html&gt;\"></iframe>"
 end

--- a/src/mazes/import_map_xss.cr
+++ b/src/mazes/import_map_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("import-map-level1", "/import-map/level1/?query=a", "import map injection via script type=importmap with dynamic import().then()",
   vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"], note: "the value becomes the import-map address for the specifier the page then import()s, so a data:text/javascript,... address executes with no breakout; a </script> breakout out of the importmap block also reaches plain HTML")
 maze_get "/import-map/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Import Map Level 1</h1>
@@ -27,7 +27,7 @@ end
 Xssmaze.push("import-map-level2", "/import-map/level2/?query=a", "import map injection in single-quoted context with module hijacking",
   vuln: "reflected-js", delivery: ["query"], note: "the value lands in a single-quoted JS string before it ever reaches the import map, so the breakout happens first")
 maze_get "/import-map/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Import Map Level 2</h1>
@@ -63,7 +63,7 @@ end
 Xssmaze.push("import-map-level3", "/import-map/level3/?query=a", "import map with double-quoted JSON property and data: URL hijacking",
   vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"], note: "the value becomes the import-map address for the specifier the page then import()s, so a data:text/javascript,... address executes with no breakout; a </script> breakout out of the importmap block also reaches plain HTML")
 maze_get "/import-map/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Import Map Level 3</h1>
@@ -89,7 +89,7 @@ end
 Xssmaze.push("import-map-level4", "/import-map/level4/?query=a", "import map module overwrite with attacker-controlled domain",
   vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"], note: "the value becomes the import-map address for the specifier the page then import()s, so a data:text/javascript,... address executes with no breakout; a </script> breakout out of the importmap block also reaches plain HTML")
 maze_get "/import-map/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Import Map Level 4</h1>
@@ -117,7 +117,7 @@ end
 Xssmaze.push("import-map-level5", "/import-map/level5/?query=a", "scoped import map with bare module specifier hijacking",
   vuln: "dom", sources: ["server-reflected"], sinks: ["dynamic-import"], delivery: ["query"], note: "the value becomes the import-map address for the specifier the page then import()s, so a data:text/javascript,... address executes with no breakout; a </script> breakout out of the importmap block also reaches plain HTML")
 maze_get "/import-map/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Import Map Level 5</h1>
@@ -147,7 +147,7 @@ end
 Xssmaze.push("import-map-level6", "/import-map/level6/?query=a", "import map with trailing slash scope and path manipulation",
   vuln: "reflected-html", delivery: ["query"], note: "the injected address sits under the import-map scope /app/, which never matches this page's own URL, so import() never resolves to it; the only working route is a </script> breakout out of the importmap block")
 maze_get "/import-map/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Import Map Level 6</h1>

--- a/src/mazes/input_transform_xss.cr
+++ b/src/mazes/input_transform_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("inputtransform-level1", "/inputtransform/level1/?query=a", "server prepends prefix before reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/inputtransform/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>User: #{query}</body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("inputtransform-level2", "/inputtransform/level2/?query=a", "server wraps query in bold tags",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/inputtransform/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><b>#{query}</b></body></html>"
 end
@@ -23,7 +23,7 @@ end
 Xssmaze.push("inputtransform-level3", "/inputtransform/level3/?query=a", "truncate at first space",
   vuln: "reflected-html", delivery: ["query"], note: "everything from the first space onwards is dropped, so use a space-free payload such as <svg/onload=alert(1)>")
 maze_get "/inputtransform/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.split(" ", 2).first
 
   "<html><body>#{query}</body></html>"
@@ -34,7 +34,7 @@ end
 Xssmaze.push("inputtransform-level4", "/inputtransform/level4/?query=a", "split on ampersand, reflect first part",
   vuln: "reflected-html", delivery: ["query"], note: "only the part before the first & is reflected, and the & has to be percent-encoded to reach the handler at all")
 maze_get "/inputtransform/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.split("&", 2).first
 
   "<html><body>#{query}</body></html>"
@@ -46,7 +46,7 @@ end
 Xssmaze.push("inputtransform-level5", "/inputtransform/level5/?query=a", "reversed reflection + original in HTML comment",
   vuln: "reflected-html", delivery: ["query"], note: "the visible <div> copy is character-reversed and unusable; the original lands in an HTML comment, so close it with -->")
 maze_get "/inputtransform/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   reversed = query.reverse
 
   "<html><body><!-- #{query} --><div>#{reversed}</div></body></html>"
@@ -57,7 +57,7 @@ end
 Xssmaze.push("inputtransform-level6", "/inputtransform/level6/?query=a", "lowercase conversion before reflection",
   vuln: "reflected-html", delivery: ["query"], note: "the value is lowercased, but HTML tag and attribute names are case-insensitive, so lowercase payloads still work")
 maze_get "/inputtransform/level6/" do |env|
-  query = env.params.query["query"].downcase
+  query = env.params.query.fetch("query", "").downcase
 
   "<html><body>#{query}</body></html>"
 end

--- a/src/mazes/jf_xss.cr
+++ b/src/mazes/jf_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("jf-xss-level1", "/jf/level1/?query=a", "escape a-Z",
   vuln: "reflected-js", delivery: ["query"], note: "every ASCII letter is stripped and the value lands as a bare statement inside <script>, so the payload has to be letter-free JavaScript (JSFuck-style []()!+)")
 maze_get "/jf/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<script>
       #{query.gsub(/[a-zA-Z]/, "")}

--- a/src/mazes/json_xss.cr
+++ b/src/mazes/json_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("json-xss-level1", "/json/level1/?query=a", "JSON response XSS (JSONP)", "GET", ["query", "callback"],
   vuln: "reflected-js", delivery: ["query"], note: "JSONP served as application/javascript: both query (inside a JS string) and the unfiltered callback name are reflected, but the response only executes when it is loaded as a <script> — browsing to the URL renders nothing")
 maze_get "/json/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   callback = env.params.query["callback"]? || "callback"
   env.response.content_type = "application/javascript"
 
@@ -11,7 +11,7 @@ end
 Xssmaze.push("json-xss-level2", "/json/level2/?query=a", "JSON XSS with HTML entities bypass",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "the payload is reflected raw, but the response is served as application/json, which no modern browser parses as HTML, so the markup never executes; reporting no XSS here is the correct result")
 maze_get "/json/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "application/json"
 
   "{\"html_content\": \"<div>#{query}</div>\", \"escaped\": false}"
@@ -20,7 +20,7 @@ end
 Xssmaze.push("json-xss-level3", "/json/level3/?query=a", "JSON XSS with Unicode escape",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "served as application/json, and quotes and backslashes are escaped, so the value cannot even break out of its JSON string")
 maze_get "/json/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "application/json"
 
   # Simulate improper Unicode handling
@@ -31,7 +31,7 @@ end
 Xssmaze.push("json-xss-level4", "/json/level4/?query=a", "JSON XSS in script tag context",
   vuln: "reflected-js", delivery: ["query"], note: "the value lands in a double-quoted JS string; that same string is later written with innerHTML, so a tag payload also fires without a breakout")
 maze_get "/json/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>JSON XSS Level 4</h1>
@@ -45,7 +45,7 @@ end
 Xssmaze.push("json-xss-level5", "/json/level5/?query=a", "JSON XSS with array injection",
   vuln: "reflected-js", delivery: ["query"], note: "the value lands in a JS array string literal that is then passed to document.write")
 maze_get "/json/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>JSON XSS Level 5</h1>
@@ -61,7 +61,7 @@ end
 Xssmaze.push("json-xss-level6", "/json/level6/?query=a", "JSON XSS with nested object injection",
   vuln: "reflected-js", delivery: ["query"], note: "the value lands in a nested JS object literal string that is later written with innerHTML")
 maze_get "/json/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>JSON XSS Level 6</h1>

--- a/src/mazes/media_context_xss.cr
+++ b/src/mazes/media_context_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("mediacontext-level1", "/mediacontext/level1/?query=a", "reflection in video src attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "a javascript: URL does not execute in a video src; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Media Context XSS Level 1</h1>
@@ -14,7 +14,7 @@ end
 Xssmaze.push("mediacontext-level2", "/mediacontext/level2/?query=a", "reflection in audio src attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "a javascript: URL does not execute in an audio src; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Media Context XSS Level 2</h1>
@@ -26,7 +26,7 @@ end
 Xssmaze.push("mediacontext-level3", "/mediacontext/level3/?query=a", "reflection in source src attribute inside video",
   vuln: "reflected-attr", delivery: ["query"], note: "a javascript: URL does not execute in a <source> src; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Media Context XSS Level 3</h1>
@@ -38,7 +38,7 @@ end
 Xssmaze.push("mediacontext-level4", "/mediacontext/level4/?query=a", "reflection in embed src attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "no browser still runs Flash, so the embed src is inert; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Media Context XSS Level 4</h1>
@@ -50,7 +50,7 @@ end
 Xssmaze.push("mediacontext-level5", "/mediacontext/level5/?query=a", "reflection in track src attribute inside video",
   vuln: "reflected-attr", delivery: ["query"], note: "a track src only ever loads a WebVTT file; break out of the double-quoted attribute instead")
 maze_get "/mediacontext/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Media Context XSS Level 5</h1>
@@ -62,7 +62,7 @@ end
 Xssmaze.push("mediacontext-level6", "/mediacontext/level6/?query=a", "reflection in img alt attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/mediacontext/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Media Context XSS Level 6</h1>

--- a/src/mazes/modern_framework_xss.cr
+++ b/src/mazes/modern_framework_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("modern-level1", "/modern/level1/?query=a", "dangerouslySetInnerHTML simulation",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is percent-encoded into the JS string and decoded client-side, so there is no string breakout; innerHTML does not run a bare <script>, so use <img src=x onerror=...>")
 maze_get "/modern/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <div id='app'></div>
@@ -17,7 +17,7 @@ end
 Xssmaze.push("modern-level2", "/modern/level2/?query=a", "markdown link rendering",
   vuln: "reflected-html", delivery: ["query"], note: "the whole value is reflected raw, so the markdown rewrite is not needed; [x](javascript:alert(1)) additionally builds a clickable href")
 maze_get "/modern/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Simple markdown-to-html: [text](url) -> <a href="url">text</a>
   html = query.gsub(/\[([^\]]*)\]\(([^)]*)\)/) do |_match|
     text = $1
@@ -32,7 +32,7 @@ end
 Xssmaze.push("modern-level3", "/modern/level3/?query=a", "GraphQL error message reflection",
   vuln: "reflected-html", delivery: ["query"], note: "the response is text/html and the JSON-looking envelope is just <pre> text, so the value is a plain HTML-body reflection")
 maze_get "/modern/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>GraphQL Error</h1>
@@ -44,7 +44,7 @@ end
 Xssmaze.push("modern-level4", "/modern/level4/?query=a", "SSR hydration with client innerHTML",
   vuln: "dom", sources: ["location.search"], sinks: ["innerHTML"], delivery: ["query"], note: "the server-side copy is entity-encoded and is a decoy; the page re-reads the raw query parameter into innerHTML, so use <img src=x onerror=...>")
 maze_get "/modern/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   server_safe = Filters.encode_angles(query)
 
   "<html><body>

--- a/src/mazes/multiline_xss.cr
+++ b/src/mazes/multiline_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("multiline-level1", "/multiline/level1/?query=a", "raw reflection in p tag",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/multiline/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Multiline XSS Level 1</h1>
@@ -15,7 +15,7 @@ end
 Xssmaze.push("multiline-level2", "/multiline/level2/?query=a", "reflected in JS string, newlines not escaped",
   vuln: "reflected-js", delivery: ["query"], note: "double quotes are backslash-escaped but newlines are not, so close the </script> block rather than the string")
 maze_get "/multiline/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Escape quotes but NOT newlines
   escaped = query.gsub("\"", "\\\"")
 
@@ -32,7 +32,7 @@ end
 Xssmaze.push("multiline-level3", "/multiline/level3/?query=a", "reflected in attribute value, newlines allowed",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/multiline/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Multiline XSS Level 3</h1>
@@ -45,7 +45,7 @@ end
 Xssmaze.push("multiline-level4", "/multiline/level4/?query=a", "reflected inside textarea tags",
   vuln: "reflected-html", delivery: ["query"], note: "<textarea> is a raw-text element, so the payload has to open with </textarea>")
 maze_get "/multiline/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Multiline XSS Level 4</h1>
@@ -58,7 +58,7 @@ end
 Xssmaze.push("multiline-level5", "/multiline/level5/?query=a", "split on newlines into li tags",
   vuln: "reflected-html", delivery: ["query"], note: "the value is split on newlines and each line is wrapped raw in its own <li>")
 maze_get "/multiline/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   lines = query.split("\n")
   items = lines.map { |line| "<li>#{line}</li>" }.join("\n")
 
@@ -75,7 +75,7 @@ end
 Xssmaze.push("multiline-level6", "/multiline/level6/?query=a", "reflected inside pre tags",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/multiline/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Multiline XSS Level 6</h1>

--- a/src/mazes/nested_filter_xss.cr
+++ b/src/mazes/nested_filter_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("nestedfilter-level1", "/nestedfilter/level1/?query=a", "strips script then img tags (svg survives)",
   vuln: "reflected-html", delivery: ["query"], note: "<script> and <img> tags are both stripped; <svg onload=alert(1)> survives")
 maze_get "/nestedfilter/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = Filters.strip_tags(query, ["script"])
   query = Filters.strip_tags(query, ["img"])
 
@@ -13,7 +13,7 @@ end
 Xssmaze.push("nestedfilter-level2", "/nestedfilter/level2/?query=a", "lowercase then strip script (img survives)",
   vuln: "reflected-html", delivery: ["query"], note: "the value is lowercased before <script> is stripped, so mixed case does not help; use <img src=x onerror=alert(1)>")
 maze_get "/nestedfilter/level2/" do |env|
-  query = env.params.query["query"].downcase
+  query = env.params.query.fetch("query", "").downcase
   query = Filters.strip_tags(query, ["script"])
 
   "<html><body>#{query}</body></html>"
@@ -24,7 +24,7 @@ end
 Xssmaze.push("nestedfilter-level3", "/nestedfilter/level3/?query=a", "strips event handlers then script (nested tag reconstruction)",
   vuln: "reflected-html", delivery: ["query"], note: "on*= handlers and <script> tags are each stripped in one pass, so nest the tag: <scr<script>ipt>alert(1)</scr</script>ipt>")
 maze_get "/nestedfilter/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub(/on[a-z]+=/, "")
   query = Filters.strip_tags(query, ["script"])
 
@@ -36,7 +36,7 @@ end
 Xssmaze.push("nestedfilter-level4", "/nestedfilter/level4/?query=a", "strips < and > (attribute breakout)",
   vuln: "reflected-attr", delivery: ["query"], note: "both angle brackets are stripped; break out of the double-quoted input value and add an event handler")
 maze_get "/nestedfilter/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub("<", "")
   query = query.gsub(">", "")
 
@@ -47,7 +47,7 @@ end
 Xssmaze.push("nestedfilter-level5", "/nestedfilter/level5/?query=a", "URL decode then strip script (img survives)",
   vuln: "reflected-html", delivery: ["query"], note: "the value is URL-decoded once before <script> is stripped, so encoding does not smuggle a script tag; <img src=x onerror=alert(1)> survives")
 maze_get "/nestedfilter/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   begin
     query = URI.decode(query)
   rescue
@@ -61,7 +61,7 @@ end
 Xssmaze.push("nestedfilter-level6", "/nestedfilter/level6/?query=a", "strips alert keyword then script tag (confirm survives)",
   vuln: "reflected-html", delivery: ["query"], note: "the literal lowercase alert and <script> tags are each stripped once; use confirm(1), or nest as alalertert")
 maze_get "/nestedfilter/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub("alert", "")
   query = Filters.strip_tags(query, ["script"])
 

--- a/src/mazes/partial_encode_xss.cr
+++ b/src/mazes/partial_encode_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("partialencode-level1", "/partial-encode/level1/?query=a", "only < encoded, reflected in input value attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "< is entity-encoded, so the body copy is inert; break out of the double-quoted input value instead")
 maze_get "/partial-encode/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = query.gsub("<", "&lt;")
 
   "<html><body>#{encoded}<br><input type=\"text\" value=\"#{encoded}\"></body></html>"
@@ -16,7 +16,7 @@ end
 Xssmaze.push("partialencode-level2", "/partial-encode/level2/?query=a", "only > encoded, reflected in div title attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "> is entity-encoded, so the tag cannot be closed; break out of the double-quoted title attribute and add an event handler")
 maze_get "/partial-encode/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = query.gsub(">", "&gt;")
 
   "<html><body><div title=\"#{encoded}\">content</div></body></html>"
@@ -27,7 +27,7 @@ end
 Xssmaze.push("partialencode-level3", "/partial-encode/level3/?query=a", "quotes encoded but angle brackets raw",
   vuln: "reflected-html", delivery: ["query"], note: "both quote characters are encoded but angle brackets are raw; use a quote-free payload")
 maze_get "/partial-encode/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = query.gsub("\"", "&quot;").gsub("'", "&#39;")
 
   "<html><body>#{encoded}</body></html>"
@@ -38,7 +38,7 @@ end
 Xssmaze.push("partialencode-level4", "/partial-encode/level4/?query=a", "script tags encoded but other tags raw",
   vuln: "reflected-html", delivery: ["query"], note: "only the exact <script> and </script> forms are encoded; <script src=x> or <img src=x onerror=alert(1)> passes")
 maze_get "/partial-encode/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = query.gsub(/<script>/i, "&lt;script&gt;").gsub(/<\/script>/i, "&lt;/script&gt;")
 
   "<html><body>#{encoded}</body></html>"
@@ -49,7 +49,7 @@ end
 Xssmaze.push("partialencode-level5", "/partial-encode/level5/?query=a", "only first < and > encoded (sub not gsub)",
   vuln: "reflected-html", delivery: ["query"], note: "only the first < and the first > are encoded (sub, not gsub); send a sacrificial <> before the payload")
 maze_get "/partial-encode/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = query.sub("<", "&lt;").sub(">", "&gt;")
 
   "<html><body>#{encoded}</body></html>"
@@ -60,7 +60,7 @@ end
 Xssmaze.push("partialencode-level6", "/partial-encode/level6/?query=a", "& and quotes encoded but angle brackets raw",
   vuln: "reflected-html", delivery: ["query"], note: "& is encoded, so an entity-encoded payload will not decode; angle brackets pass through raw")
 maze_get "/partial-encode/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = query.gsub("&", "&amp;").gsub("\"", "&quot;").gsub("'", "&#39;")
 
   "<html><body>#{encoded}</body></html>"

--- a/src/mazes/polyglot_xss.cr
+++ b/src/mazes/polyglot_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("polyglot-level1", "/polyglot/level1/?query=a", "HTML comment breakout",
   vuln: "reflected-html", delivery: ["query"], note: "lands inside an HTML comment; close it with --> first")
 maze_get "/polyglot/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Polyglot XSS Level 1</h1>
@@ -13,7 +13,7 @@ end
 Xssmaze.push("polyglot-level2", "/polyglot/level2/?query=a", "meta refresh with URL sink",
   vuln: "reflected-attr", delivery: ["query"], note: "the meta-refresh target is not a usable sink in modern browsers, which block javascript: and data: navigations; the working route is a \" breakout out of the content attribute")
 maze_get "/polyglot/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head>
   <meta http-equiv=\"refresh\" content=\"0;url=#{query}\">
@@ -26,7 +26,7 @@ end
 Xssmaze.push("polyglot-level3", "/polyglot/level3/?query=a", "triple URL decode",
   vuln: "reflected-html", delivery: ["query"], note: "the handler URL-decodes the already-decoded parameter three more times and rejects < after the second, so the payload needs four layers of encoding — %2525253C arrives as <")
 maze_get "/polyglot/level3/" do |env|
-  data = URI.decode(env.params.query["query"])
+  data = URI.decode(env.params.query.fetch("query", ""))
   data = URI.decode(data)
   if data.includes?("<")
     "Detect Special Character"

--- a/src/mazes/prototype_xss.cr
+++ b/src/mazes/prototype_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("prototype-pattern-level1", "/prototype-pattern/level1/?query=a", "WordPress-style input value reflection",
   vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; WordPress-style input value")
 maze_get "/prototype-pattern/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
 <div class=\"wrap\">
@@ -19,7 +19,7 @@ end
 Xssmaze.push("prototype-pattern-level2", "/prototype-pattern/level2/?query=a", "PHP error message reflection (raw injection)",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; PHP warning text")
 maze_get "/prototype-pattern/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
 <br />
@@ -32,7 +32,7 @@ end
 Xssmaze.push("prototype-pattern-level3", "/prototype-pattern/level3/?query=a", "ASP.NET-style error label reflection",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; ASP.NET error label")
 maze_get "/prototype-pattern/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
 <form method=\"post\" action=\"./Default.aspx\" id=\"form1\">
@@ -50,7 +50,7 @@ end
 Xssmaze.push("prototype-pattern-level4", "/prototype-pattern/level4/?query=a", "Angular-style ng-app reflection (raw injection)",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; Angular-shaped markup with no Angular loaded")
 maze_get "/prototype-pattern/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
 <div ng-app=\"myApp\" ng-controller=\"myCtrl\">
@@ -66,7 +66,7 @@ end
 Xssmaze.push("prototype-pattern-level5", "/prototype-pattern/level5/?query=a", "React-style server-rendered reflection (raw injection)",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; React-shaped server-rendered markup")
 maze_get "/prototype-pattern/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
 <div id=\"root\"><div data-reactroot=\"\"><div class=\"App\"><header class=\"App-header\"><h1>Welcome</h1><p>#{query}</p></header></div></div></div>
@@ -78,7 +78,7 @@ end
 Xssmaze.push("prototype-pattern-level6", "/prototype-pattern/level6/?query=a", "Flask/Jinja-style unescaped reflection",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a framework-shaped server-side reflection, not prototype pollution; Flask/Jinja-shaped welcome message")
 maze_get "/prototype-pattern/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
 <nav class=\"navbar\"><a class=\"brand\" href=\"/\">MyApp</a></nav>

--- a/src/mazes/query_method_xss.cr
+++ b/src/mazes/query_method_xss.cr
@@ -45,7 +45,7 @@ maze_get "/querymethod/level1/" do |_|
   query_driver("/querymethod/level1/", "QUERY Method XSS Level 1", "query", false)
 end
 maze_query "/querymethod/level1/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
 
   "<html><body>#{query}</body></html>"
 end
@@ -59,7 +59,7 @@ maze_get "/querymethod/level2/" do |_|
   query_driver("/querymethod/level2/", "QUERY Method XSS Level 2", "query", true)
 end
 maze_query "/querymethod/level2/" do |env|
-  query = env.params.json["query"].as(String)
+  query = env.params.json.fetch("query", "").as(String)
 
   "<html><body>#{query}</body></html>"
 end
@@ -73,7 +73,7 @@ maze_get "/querymethod/level3/" do |_|
   query_driver("/querymethod/level3/", "QUERY Method XSS Level 3", "query", false)
 end
 maze_query "/querymethod/level3/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
 
   "<html><body><input type=\"text\" value=\"#{query}\"></body></html>"
 end
@@ -87,7 +87,7 @@ maze_get "/querymethod/level4/" do |_|
   query_driver("/querymethod/level4/", "QUERY Method XSS Level 4", "query", false)
 end
 maze_query "/querymethod/level4/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
 
   "<html><body><script>var q = \"#{query}\";</script></body></html>"
 end
@@ -121,7 +121,7 @@ maze_get "/querymethod/level5/" do |env|
   </body></html>"
 end
 maze_query "/querymethod/level5/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
 
   "<html><body>QUERY says: #{query}</body></html>"
 end

--- a/src/mazes/realworld_encoding_xss.cr
+++ b/src/mazes/realworld_encoding_xss.cr
@@ -6,7 +6,7 @@ require "base64"
 Xssmaze.push("realworld-encoding-level1", "/realworld-encoding/level1/?query=a", "triple URL decode",
   vuln: "reflected-html", delivery: ["query"], note: "the framework decodes once before the handler's own three decodes, and an angle-bracket check runs between them, so the payload has to be percent-encoded four times on the wire, not three")
 maze_get "/realworld-encoding/level1/" do |env|
-  data = URI.decode(env.params.query["query"])
+  data = URI.decode(env.params.query.fetch("query", ""))
   if data.includes?("<") || data.includes?(">")
     "Detect Special Character"
   else
@@ -27,7 +27,7 @@ end
 Xssmaze.push("realworld-encoding-level2", "/realworld-encoding/level2/?query=a", "Unicode NFKC normalization bypass",
   vuln: "reflected-html", delivery: ["query"], note: "literal angle brackets are rejected, but the value is NFKC-normalized afterwards, so fullwidth forms such as U+FF1C become <")
 maze_get "/realworld-encoding/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   if query.includes?("<") || query.includes?(">")
     "Detect Special Character"
   else
@@ -46,7 +46,7 @@ end
 Xssmaze.push("realworld-encoding-level3", "/realworld-encoding/level3/?query=a", "HTML entity double decode",
   vuln: "reflected-html", delivery: ["query"], note: "literal angle brackets are rejected, but the chained entity decodes turn &lt; into a real < before reflection")
 maze_get "/realworld-encoding/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   if query.includes?("<") || query.includes?(">")
     "Detect Special Character"
   else
@@ -76,7 +76,7 @@ end
 Xssmaze.push("realworld-encoding-level4", "/realworld-encoding/level4/?query=a", "base64 then URL decode chain",
   vuln: "reflected-html", delivery: ["query"], note: "the parameter must be base64 of a URL-encoded payload; anything that fails to decode returns a fixed error string instead")
 maze_get "/realworld-encoding/level4/" do |env|
-  data = Base64.decode_string(env.params.query["query"])
+  data = Base64.decode_string(env.params.query.fetch("query", ""))
   decoded = URI.decode(data)
   "<html><body><h1>Mixed Encoding Chain Level</h1><div>#{decoded}</div></body></html>"
 rescue
@@ -89,7 +89,7 @@ end
 Xssmaze.push("realworld-encoding-level5", "/realworld-encoding/level5/?query=a", "CSS style attribute injection",
   vuln: "reflected-attr", delivery: ["query"], note: "expression() and url(javascript:) are long gone; break out of the double-quoted style attribute")
 maze_get "/realworld-encoding/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>CSS Style Attribute Injection Level</h1>
@@ -103,7 +103,7 @@ end
 Xssmaze.push("realworld-encoding-level6", "/realworld-encoding/level6/?query=a", "CSS style tag body injection",
   vuln: "reflected-html", delivery: ["query"], note: "CSS does not execute; close the </style> block and inject markup")
 maze_get "/realworld-encoding/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head>
   <style>
@@ -121,7 +121,7 @@ end
 Xssmaze.push("realworld-encoding-level7", "/realworld-encoding/level7/?query=a", "SVG with URL decode combo",
   vuln: "reflected-html", delivery: ["query"], note: "literal angle brackets are rejected before the handler's single decode, so percent-encode them twice on the wire; the value lands in SVG foreign content, so close </text></svg> before injecting HTML")
 maze_get "/realworld-encoding/level7/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   if query.includes?("<") || query.includes?(">")
     "Detect Special Character"
   else
@@ -142,7 +142,7 @@ end
 Xssmaze.push("realworld-encoding-level8", "/realworld-encoding/level8/?query=a", "JSON string with script tag breakout",
   vuln: "reflected-js", delivery: ["query"], note: "quotes and backslashes are escaped and the DOM sink is textContent, so the only way out is closing the <script> block")
 maze_get "/realworld-encoding/level8/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Escape quotes and backslashes (typical JSON string escaping)
   escaped = query.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("'", "\\'")
   # But notably does NOT filter </script>

--- a/src/mazes/realworld_xss.cr
+++ b/src/mazes/realworld_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("realworld-level1", "/realworld/level1/?query=a", "double reflection (safe comment + unsafe body)",
   vuln: "reflected-html", delivery: ["query"], note: "the HTML-comment copy has its angle brackets stripped; the <h2> copy is raw")
 maze_get "/realworld/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   safe = Filters.strip_angles(query)
 
   "<!-- search: #{safe} --><h2>Results for: #{query}</h2>"
@@ -12,7 +12,7 @@ end
 Xssmaze.push("realworld-level2", "/realworld/level2/?query=a&debug=1", "conditional reflection (requires debug=1)", "GET", ["query", "debug"],
   vuln: "reflected-html", delivery: ["query"], note: "nothing is reflected unless the request also carries debug=1")
 maze_get "/realworld/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   debug = env.params.query.fetch("debug", "0")
 
   if debug == "1"
@@ -26,7 +26,7 @@ end
 Xssmaze.push("realworld-level3", "/realworld/level3/?query=a", "truncated reflection (30 char limit)",
   vuln: "reflected-html", delivery: ["query"], note: "the reflection is truncated to 30 characters")
 maze_get "/realworld/level3/" do |env|
-  query = env.params.query["query"][0, 30]
+  query = env.params.query.fetch("query", "")[0, 30]
 
   "<div>#{query}</div>"
 end
@@ -54,7 +54,7 @@ end
 Xssmaze.push("realworld-level6", "/realworld/level6/?query=a", "content-type sniffing (text/plain)",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "the markup is reflected raw, but the response is served as text/plain, which no modern browser sniffs into HTML, so it never parses; reporting no XSS here is the correct result")
 maze_get "/realworld/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/plain"
 
   "<html><body>#{query}</body></html>"
@@ -64,7 +64,7 @@ end
 Xssmaze.push("realworld-level7", "/realworld/level7/?query=a", "JS newline injection (flawed escaping)",
   vuln: "reflected-js", delivery: ["query"], note: "single quotes are backslash-escaped but backslashes are not, so \\';alert(1)// frees the quote")
 maze_get "/realworld/level7/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Flawed escaping: escapes single quotes but not backslashes
   escaped = query.gsub("'", "\\'")
 

--- a/src/mazes/regex_filter_xss.cr
+++ b/src/mazes/regex_filter_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("regexfilt-level1", "/regexfilt/level1/?query=a", "regex strips script tags (non-greedy), use img/svg instead",
   vuln: "reflected-html", delivery: ["query"], note: "the pattern only removes a complete <script>...</script> pair, so another tag survives")
 maze_get "/regexfilt/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/<script[^>]*>.*?<\/script>/im, "")
 
   "<html><body>#{filtered}</body></html>"
@@ -12,7 +12,7 @@ end
 Xssmaze.push("regexfilt-level2", "/regexfilt/level2/?query=a", "regex strips event handlers (on*=), use script tags instead",
   vuln: "reflected-html", delivery: ["query"], note: "on...= handlers are stripped, so use a tag that needs none")
 maze_get "/regexfilt/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/on\w+\s*=/i, "")
 
   "<html><body>#{filtered}</body></html>"
@@ -22,7 +22,7 @@ end
 Xssmaze.push("regexfilt-level3", "/regexfilt/level3/?query=a", "regex strips script/img/svg/iframe tags, use other tags",
   vuln: "reflected-html", delivery: ["query"], note: "only script/img/svg/iframe openers are stripped; other tags survive")
 maze_get "/regexfilt/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/<(script|img|svg|iframe)[^>]*>/i, "")
 
   "<html><body>#{filtered}</body></html>"
@@ -32,7 +32,7 @@ end
 Xssmaze.push("regexfilt-level4", "/regexfilt/level4/?query=a", "regex strips javascript: in href, break out of attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "javascript: is stripped from the href, so break out of the double-quoted attribute instead")
 maze_get "/regexfilt/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/javascript:/i, "")
 
   "<html><body><a href=\"#{filtered}\">Click here</a></body></html>"
@@ -42,7 +42,7 @@ end
 Xssmaze.push("regexfilt-level5", "/regexfilt/level5/?query=a", "whitelist-style tag stripping, use unlisted tags",
   vuln: "reflected-html", delivery: ["query"], note: "six tag names are stripped in both open and close form; unlisted tags survive")
 maze_get "/regexfilt/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/<\/?(script|img|svg|iframe|object|embed)[^>]*>/i, "")
 
   "<html><body>#{filtered}</body></html>"
@@ -52,7 +52,7 @@ end
 Xssmaze.push("regexfilt-level6", "/regexfilt/level6/?query=a", "regex replaces alert with _alert_, use confirm/prompt",
   vuln: "reflected-html", delivery: ["query"], note: "\"alert\" becomes \"_alert_\"; confirm/prompt are untouched")
 maze_get "/regexfilt/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/alert/i, "_alert_")
 
   "<html><body>#{filtered}</body></html>"

--- a/src/mazes/sanitizer_edge_xss.cr
+++ b/src/mazes/sanitizer_edge_xss.cr
@@ -4,7 +4,7 @@ require "html"
 Xssmaze.push("sanitizer-edge-level1", "/sanitizer-edge/level1/?query=a", "strip tags, reflect in input value (attribute breakout)",
   vuln: "reflected-attr", delivery: ["query"], note: "tags are stripped but quotes are not escaped, so break out of the input value attribute")
 maze_get "/sanitizer-edge/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Strip all HTML tags but don't escape quotes
   sanitized = query.gsub(/<[^>]*>/, "")
 
@@ -15,7 +15,7 @@ end
 Xssmaze.push("sanitizer-edge-level2", "/sanitizer-edge/level2/?query=a", "HTML-encode special chars, reflect in unquoted script var",
   vuln: "reflected-js", delivery: ["query"], note: "<>\"' are all entity-encoded, but the value lands as a bare JS expression with no quotes to break out of, so plain JavaScript such as alert(1) runs as-is")
 maze_get "/sanitizer-edge/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Encode HTML special chars: < > " '
   sanitized = query.gsub("<", "&lt;").gsub(">", "&gt;").gsub("\"", "&quot;").gsub("'", "&#39;")
 
@@ -26,7 +26,7 @@ end
 Xssmaze.push("sanitizer-edge-level3", "/sanitizer-edge/level3/?query=a", "recursive script strip, other tags allowed",
   vuln: "reflected-html", delivery: ["query"], note: "script tags are stripped recursively, so nesting does not help; use another tag")
 maze_get "/sanitizer-edge/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Recursively strip <script> and </script> tags
   result = query
   loop do
@@ -42,7 +42,7 @@ end
 Xssmaze.push("sanitizer-edge-level4", "/sanitizer-edge/level4/?query=a", "tag whitelist but event attributes allowed on whitelisted tags",
   vuln: "reflected-html", delivery: ["query"], note: "the whitelist keeps b/i/u/em/strong but does not strip their attributes, so an event handler on a whitelisted tag survives")
 maze_get "/sanitizer-edge/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Whitelist: only allow b, i, u, em, strong tags (case-sensitive check)
   # Bug: checks tag name but does NOT strip attributes on whitelisted tags
   allowed = ["b", "i", "u", "em", "strong"]
@@ -56,7 +56,7 @@ end
 Xssmaze.push("sanitizer-edge-level5", "/sanitizer-edge/level5/?query=a", "style attribute allowed, breakout from style value",
   vuln: "reflected-attr", delivery: ["query"], note: "tags are stripped, so break out of the style attribute with a quote instead")
 maze_get "/sanitizer-edge/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Strip all HTML tags from query
   sanitized = query.gsub(/<[^>]*>/, "")
 
@@ -67,7 +67,7 @@ end
 Xssmaze.push("sanitizer-edge-level6", "/sanitizer-edge/level6/?query=a", "protocol strip in href, attribute breakout",
   vuln: "reflected-attr", delivery: ["query"], note: "javascript:/vbscript:/data: are stripped from the href, so break out of the attribute instead")
 maze_get "/sanitizer-edge/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Strip dangerous protocols
   sanitized = query.gsub(/javascript\s*:/i, "").gsub(/vbscript\s*:/i, "").gsub(/data\s*:/i, "")
 

--- a/src/mazes/social_media_xss.cr
+++ b/src/mazes/social_media_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("social-media-level1", "/social-media/level1/?query=a", "tweet/post content raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/social-media/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"tweet\" style=\"max-width:500px;border:1px solid #ccd6dd;border-radius:12px;padding:12px\"><div class=\"tweet-header\"><strong>User</strong> <span style=\"color:#657786\">@user - 1h</span></div><div class=\"tweet-text\"><p>#{query}</p></div></div></body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("social-media-level2", "/social-media/level2/?query=a", "username mention raw reflection in link text",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/social-media/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"post\" style=\"padding:10px\"><p>Check out this post by <a href=\"/user/profile\" class=\"mention\" style=\"color:#1da1f2;text-decoration:none\">@#{query}</a> about security.</p></div></body></html>"
 end
@@ -24,7 +24,7 @@ end
 Xssmaze.push("social-media-level3", "/social-media/level3/?query=a", "hashtag dual reflection in href and link text",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into both the href and the link text; the text is a direct HTML injection")
 maze_get "/social-media/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"post\" style=\"padding:10px\"><p>Trending now: <a href=\"/tag/#{query}\" class=\"hashtag\" style=\"color:#1da1f2;text-decoration:none\">##{query}</a></p></div></body></html>"
 end
@@ -34,7 +34,7 @@ end
 Xssmaze.push("social-media-level4", "/social-media/level4/?query=a", "user bio/description raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/social-media/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"profile-card\" style=\"max-width:400px;border:1px solid #e1e8ed;border-radius:12px;padding:16px\"><div class=\"profile-header\"><img src=\"/avatar.png\" alt=\"avatar\" width=\"48\" height=\"48\" style=\"border-radius:50%\"><h3 style=\"margin:8px 0 4px\">John Doe</h3><span style=\"color:#657786\">@johndoe</span></div><p class=\"bio-text\" style=\"margin-top:12px\">#{query}</p></div></body></html>"
 end
@@ -44,7 +44,7 @@ end
 Xssmaze.push("social-media-level5", "/social-media/level5/?query=a", "comment reply raw reflection in text span",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/social-media/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"comment-thread\" style=\"max-width:500px;padding:10px\"><div class=\"original-comment\" style=\"padding:8px;border-left:3px solid #ccc;margin-bottom:10px\"><span class=\"author\" style=\"font-weight:bold\">OriginalPoster</span>: <span>What do you think?</span></div><div class=\"reply\" style=\"padding:8px;margin-left:20px;border-left:3px solid #1da1f2\"><span class=\"author\" style=\"font-weight:bold\">user</span>: <span class=\"text\">#{query}</span></div></div></body></html>"
 end
@@ -54,7 +54,7 @@ end
 Xssmaze.push("social-media-level6", "/social-media/level6/?query=a", "share link reflection in href attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into the share href; break out with the quote and >")
 maze_get "/social-media/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"share-panel\" style=\"max-width:400px;padding:12px;border:1px solid #e1e8ed;border-radius:8px\"><p style=\"margin-bottom:10px\">Share this post:</p><a href=\"https://share.example.com/?text=#{query}\" class=\"share-btn\" style=\"display:inline-block;padding:8px 16px;background:#1da1f2;color:#fff;border-radius:4px;text-decoration:none\">Share</a></div></body></html>"
 end

--- a/src/mazes/stored_xss.cr
+++ b/src/mazes/stored_xss.cr
@@ -18,7 +18,7 @@ maze_get "/stored/level1/" do |_|
   </body></html>"
 end
 maze_post "/stored/level1/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
   stored_data["level1"] << query
   entries = stored_data["level1"].entries.map { |e| "<li>#{e}</li>" }.join
   "<html><body>
@@ -39,7 +39,7 @@ maze_get "/stored/level2/" do |_|
   </body></html>"
 end
 maze_post "/stored/level2/" do |env|
-  query = Filters.strip_angles(env.params.body["query"].as(String))
+  query = Filters.strip_angles(env.params.body.fetch("query", ""))
   stored_data["level2"] << query
   entries = stored_data["level2"].entries.map { |e| "<li>#{e}</li>" }.join
   "<html><body>
@@ -60,7 +60,7 @@ maze_get "/stored/level3/" do |_|
   </body></html>"
 end
 maze_post "/stored/level3/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
   stored_data["level3"] << query
   entries = stored_data["level3"].entries.map { |e| "<div title=\"#{e}\">#{Filters.encode_angles(e)}</div>" }.join
   "<html><body>
@@ -85,7 +85,7 @@ maze_get "/stored/level4/" do |_|
   </body></html>"
 end
 maze_post "/stored/level4/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
   stored_data["level4"] << query
   "<html><body>
   <h1>Stored XSS Level 4</h1>

--- a/src/mazes/table_context_xss.cr
+++ b/src/mazes/table_context_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("tablecontext-level1", "/tablecontext/level1/?query=a", "reflection in td element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Table Context XSS Level 1</h1>
@@ -14,7 +14,7 @@ end
 Xssmaze.push("tablecontext-level2", "/tablecontext/level2/?query=a", "reflection in th element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Table Context XSS Level 2</h1>
@@ -26,7 +26,7 @@ end
 Xssmaze.push("tablecontext-level3", "/tablecontext/level3/?query=a", "reflection in caption element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Table Context XSS Level 3</h1>
@@ -38,7 +38,7 @@ end
 Xssmaze.push("tablecontext-level4", "/tablecontext/level4/?query=a", "reflection in li element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Table Context XSS Level 4</h1>
@@ -50,7 +50,7 @@ end
 Xssmaze.push("tablecontext-level5", "/tablecontext/level5/?query=a", "reflection in dd element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Table Context XSS Level 5</h1>
@@ -62,7 +62,7 @@ end
 Xssmaze.push("tablecontext-level6", "/tablecontext/level6/?query=a", "reflection in figcaption element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/tablecontext/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Table Context XSS Level 6</h1>

--- a/src/mazes/timing_xss.cr
+++ b/src/mazes/timing_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("timing-level1", "/timing/level1/?query=a", "reflection in JS double-quoted string assignment",
   vuln: "reflected-js", delivery: ["query"])
 maze_get "/timing/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Timing XSS Level 1</h1>
@@ -16,7 +16,7 @@ end
 Xssmaze.push("timing-level2", "/timing/level2/?query=a", "reflection in JS object key",
   vuln: "reflected-js", delivery: ["query"], note: "the value lands where a JS object key goes, so it is parsed as an expression rather than a string")
 maze_get "/timing/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Timing XSS Level 2</h1>
@@ -29,7 +29,7 @@ end
 Xssmaze.push("timing-level3", "/timing/level3/?query=a", "reflection after JS line comment (newline breakout)",
   vuln: "reflected-js", delivery: ["query"], note: "the value follows a // line comment, so a newline (%0a) is needed to reach executable code")
 maze_get "/timing/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Timing XSS Level 3</h1>
@@ -42,7 +42,7 @@ end
 Xssmaze.push("timing-level4", "/timing/level4/?query=a", "reflection inside JS regex literal",
   vuln: "reflected-js", delivery: ["query"], note: "the value lands inside a regex literal; close it with / first")
 maze_get "/timing/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Timing XSS Level 4</h1>
@@ -55,7 +55,7 @@ end
 Xssmaze.push("timing-level5", "/timing/level5/?query=a", "reflection in JS single-quoted string",
   vuln: "reflected-js", delivery: ["query"])
 maze_get "/timing/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Timing XSS Level 5</h1>
@@ -68,7 +68,7 @@ end
 Xssmaze.push("timing-level6", "/timing/level6/?query=a", "reflection in JS template literal (backtick)",
   vuln: "reflected-js", delivery: ["query"], note: "template literal, so ${...} evaluates without closing the string at all")
 maze_get "/timing/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Timing XSS Level 6</h1>

--- a/src/mazes/waf_bypass_v2_xss.cr
+++ b/src/mazes/waf_bypass_v2_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("wafv2-level1", "/wafv2/level1/?query=a", "single-pass case-insensitive 'script' strip (rejoin bypass)",
   vuln: "reflected-html", delivery: ["query"], note: "\"script\" is removed case-insensitively in a single pass, so <scr<script>ipt> rejoins")
 maze_get "/wafv2/level1/" do |env|
-  query = Filters.strip_keyword_ci(env.params.query["query"], "script")
+  query = Filters.strip_keyword_ci(env.params.query.fetch("query", ""), "script")
 
   "<html><body>#{query}</body></html>"
 end
@@ -15,7 +15,7 @@ end
 Xssmaze.push("wafv2-level2", "/wafv2/level2/?query=a", "event handler on\\w+= pattern strip (script tag bypass)",
   vuln: "reflected-html", delivery: ["query"], note: "on...= handlers are stripped, and a plain <script> tag has none")
 maze_get "/wafv2/level2/" do |env|
-  query = Filters.strip_event_handlers(env.params.query["query"])
+  query = Filters.strip_event_handlers(env.params.query.fetch("query", ""))
 
   "<html><body>#{query}</body></html>"
 end
@@ -29,7 +29,7 @@ end
 Xssmaze.push("wafv2-level3", "/wafv2/level3/?query=a", "alert/confirm/prompt function name strip",
   vuln: "reflected-html", delivery: ["query"], note: "alert/confirm/prompt are stripped by name, so build the call another way")
 maze_get "/wafv2/level3/" do |env|
-  query = Filters.strip_keyword_ci(env.params.query["query"], "alert")
+  query = Filters.strip_keyword_ci(env.params.query.fetch("query", ""), "alert")
   query = Filters.strip_keyword_ci(query, "confirm")
   query = Filters.strip_keyword_ci(query, "prompt")
 
@@ -42,7 +42,7 @@ end
 Xssmaze.push("wafv2-level4", "/wafv2/level4/?query=a", "length limit: blocked if > 50 chars",
   vuln: "reflected-html", delivery: ["query"], note: "values over 50 characters are blocked outright")
 maze_get "/wafv2/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.size > 50
     "<html><body><p>Input too long — blocked by WAF.</p></body></html>"
@@ -57,7 +57,7 @@ end
 Xssmaze.push("wafv2-level5", "/wafv2/level5/?query=a", "strip <[a-zA-Z] pattern, reflected in value attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "< followed by a letter is stripped, so no tag can be opened; the reflection is in an input value, so break out of the attribute")
 maze_get "/wafv2/level5/" do |env|
-  query = env.params.query["query"].gsub(/<[a-zA-Z]/, "")
+  query = env.params.query.fetch("query", "").gsub(/<[a-zA-Z]/, "")
 
   "<html><body><input type=\"text\" value=\"#{query}\" class=\"search\"></body></html>"
 end
@@ -68,7 +68,7 @@ end
 Xssmaze.push("wafv2-level6", "/wafv2/level6/?query=a", "multi-filter: script tag strip + quote encode, but < > and ' allowed",
   vuln: "reflected-html", delivery: ["query"], note: "script tags are stripped and double quotes entity-encoded, but other tags and single quotes survive")
 maze_get "/wafv2/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Strip <script> and </script> tags (case-insensitive)
   query = query.gsub(/<\/?script[^>]*>/i, "")
   # Encode double quotes


### PR DESCRIPTION
## What changed

Slice **S1** of the missing-parameter 500 fix — **36 maze files**, handler bodies only.

Every non-optional param read raised `KeyError` (→ Kemal 500) when its input was
absent: a bare GET with no query string, an empty POST body, or a QUERY request
without the expected JSON key. This is the same defect class already fixed for
cookies in `Xssmaze.cookie_value` — a maze that crashes never teaches its lesson,
and `/sitemap.xml` lists query-stripped paths that scanners crawl before fuzzing.

Switched **199 reads** to defaulting reads, matching the `fetch(..., "")` style
already used elsewhere in these files:

| shape (before) | after | count |
|---|---|---|
| `env.params.query["query"]` | `env.params.query.fetch("query", "")` | 191 |
| `env.params.body["query"].as(String)` | `env.params.body.fetch("query", "")` | 8 |
| `env.params.json["query"].as(String)` | `env.params.json.fetch("query", "").as(String)` | 1 |

The default is always a plain empty string. **No `Xssmaze.push(...)` metadata was
touched**; the vulnerability, filters and reflection are all unchanged.

The one `.json` read (`querymethod/level2`) is beyond the brief's grep of
`.query`/`.body`, but it lives in an owned file and 500'd on the identical
missing-input path, so it's fixed the same way. `json_xss`'s `callback` read was
already optional (`["callback"]? || ...`) and was left alone.

## Verification (real commands, real output)

All sweeps run against `./bin/xssmaze -p 39117`, 205 S1 routes extracted from the
`push()` calls (196 GET, 4 POST, 5 QUERY).

**1. Bare-request sweep (no query string / empty body).**
- Before: `200: 16, 500: 189` → **189 5xx**
- After:  `200: 205` → **0 5xx**

**2. Isolated-parameter sweep.** No S1 maze declares more than one parameter, so
the bare sweep (zero params) is already the strongest missing-input case. As extra
coverage, each secondary param a handler reads (`callback`, `wsurl`, `debug`,
`tag`, `attr`) was sent **alone** with an XSS payload to the endpoints that read
it, plus a `?query=<payload>` on every maze → **0 5xx / 0 errors**.

**3. Present-parameter path unchanged.** Captured the response body of all 205
mazes at their catalog URLs (`?query=a`, form `query=a` for POST, JSON
`{"query":"a"}` for the QUERY/json level) against a pristine `HEAD` build and this
build, on fresh servers:

```
diff -rq before_bodies after_bodies
IDENTICAL — no files differ
```

(An earlier diff flagged 4 files; both causes were test artifacts, not code —
`stored/*` is a stateful guestbook contaminated by the isolated-sweep's own POSTs,
and `querymethod/level2` needs a JSON body, not form-encoded. Re-run on fresh
servers with correct encodings: identical.)

**4. CI gates.**
- `crystal tool format --check` → clean
- `crystal spec` → `194 examples, 0 failures, 0 errors`
- `ameba` (full project) → `206 inspected, 0 failures`

## For the reviewer

- Handler bodies only; `git status` shows exactly the 36 owned S1 files.
- `""[0, 30]` returns `""` in Crystal, so the one slicing read
  (`realworld_xss.cr`) is safe on the empty default — verified.
- `spec/smoke_spec.cr` untouched, per the brief (orchestrator extends it once all
  four slices land).