### PR TITLE
fix(mazes): default missing query/body params instead of 500 (slice S3)

### DIFF
--- a/src/mazes/attribute_event_xss.cr
+++ b/src/mazes/attribute_event_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("attr-event-level1", "/attr-event/level1/?query=a", "reflection in onmouseover JS string context",
   vuln: "reflected-attr", delivery: ["query"], note: "the handler only runs on hover; the enclosing attribute is double-quoted, so break out of it to inject a self-firing tag")
 maze_get "/attr-event/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div onmouseover=\"show('#{query}')\">hover me</div></body></html>"
 end
@@ -15,7 +15,7 @@ end
 Xssmaze.push("attr-event-level2", "/attr-event/level2/?query=a", "reflection in onsubmit JS string context",
   vuln: "reflected-attr", delivery: ["query"], note: "the handler only runs on form submit; the enclosing attribute is double-quoted, so break out of it to inject a self-firing tag")
 maze_get "/attr-event/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><form onsubmit=\"validate('#{query}'); return false\"><input type=\"submit\" value=\"Submit\"></form></body></html>"
 end
@@ -26,7 +26,7 @@ end
 Xssmaze.push("attr-event-level3", "/attr-event/level3/?query=a", "reflection in body onload JS string context",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/attr-event/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body onload=\"init('#{query}')\"><p>Page loaded</p></body></html>"
 end
@@ -38,7 +38,7 @@ end
 Xssmaze.push("attr-event-level4", "/attr-event/level4/?query=a", "reflection in img onerror JS string context",
   vuln: "reflected-attr", delivery: ["query"], note: "the img src is deliberately broken, so the onerror handler fires without interaction")
 maze_get "/attr-event/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><img src=\"/nonexistent.jpg\" onerror=\"report('#{query}')\"></body></html>"
 end
@@ -49,7 +49,7 @@ end
 Xssmaze.push("attr-event-level5", "/attr-event/level5/?query=a", "reflection in input onblur JS string context",
   vuln: "reflected-attr", delivery: ["query"], note: "the handler only runs when the input loses focus; the enclosing attribute is double-quoted, so break out of it to inject a self-firing tag")
 maze_get "/attr-event/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><input value=\"test\" onblur=\"save('#{query}')\"></body></html>"
 end
@@ -60,7 +60,7 @@ end
 Xssmaze.push("attr-event-level6", "/attr-event/level6/?query=a", "reflection in button onclick JS string context",
   vuln: "reflected-attr", delivery: ["query"], note: "the handler only runs on click; the enclosing attribute is double-quoted, so break out of it to inject a self-firing tag")
 maze_get "/attr-event/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><button onclick=\"action('#{query}')\">Click</button></body></html>"
 end

--- a/src/mazes/char_limit_filter_xss.cr
+++ b/src/mazes/char_limit_filter_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("charlimit-level1", "/charlimit/level1/?query=a", "strips angle brackets, reflects in input value attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped; break out of the double-quoted input value and add an event handler")
 maze_get "/charlimit/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("<", "").gsub(">", "")
 
   "<html><body>
@@ -17,7 +17,7 @@ end
 Xssmaze.push("charlimit-level2", "/charlimit/level2/?query=a", "strips double quotes, reflects in single-quoted attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "double quotes are stripped; the title attribute is single-quoted")
 maze_get "/charlimit/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("\"", "")
 
   "<html><body>
@@ -31,7 +31,7 @@ end
 Xssmaze.push("charlimit-level3", "/charlimit/level3/?query=a", "strips all quotes, reflects raw in body",
   vuln: "reflected-html", delivery: ["query"], note: "both quote characters are stripped, so the payload has to be quote-free: <img src=x onerror=alert(1)>")
 maze_get "/charlimit/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("'", "").gsub("\"", "")
 
   "<html><body>
@@ -45,7 +45,7 @@ end
 Xssmaze.push("charlimit-level4", "/charlimit/level4/?query=a", "strips parentheses, reflects raw in body",
   vuln: "reflected-html", delivery: ["query"], note: "parentheses are stripped; use a backtick call such as <img src=x onerror=alert`1`>")
 maze_get "/charlimit/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("(", "").gsub(")", "")
 
   "<html><body>
@@ -59,7 +59,7 @@ end
 Xssmaze.push("charlimit-level5", "/charlimit/level5/?query=a", "strips forward slash, reflects raw in body",
   vuln: "reflected-html", delivery: ["query"], note: "forward slashes are stripped, so no closing tag survives; use a void element such as <img src=x onerror=alert(1)>")
 maze_get "/charlimit/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("/", "")
 
   "<html><body>
@@ -73,7 +73,7 @@ end
 Xssmaze.push("charlimit-level6", "/charlimit/level6/?query=a", "strips equals sign, reflects raw in body",
   vuln: "reflected-html", delivery: ["query"], note: "= is stripped, so no attribute takes a value; <script>alert(1)</script> needs none")
 maze_get "/charlimit/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("=", "")
 
   "<html><body>

--- a/src/mazes/conditional_reflect_xss.cr
+++ b/src/mazes/conditional_reflect_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("condreflect-level1", "/condreflect/level1/?query=a", "reflects only if input length > 5",
   vuln: "reflected-html", delivery: ["query"], note: "nothing is reflected unless the value is longer than 5 characters, so a short scanner marker sees no reflection")
 maze_get "/condreflect/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.size > 5
     "<html><body><div>#{query}</div></body></html>"
@@ -17,7 +17,7 @@ end
 Xssmaze.push("condreflect-level2", "/condreflect/level2/?query=a", "reflects only if input contains a digit",
   vuln: "reflected-html", delivery: ["query"], note: "nothing is reflected unless the value contains a digit, so a purely alphabetic marker sees no reflection")
 maze_get "/condreflect/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.matches?(/[0-9]/)
     "<html><body><div>#{query}</div></body></html>"
@@ -31,7 +31,7 @@ end
 Xssmaze.push("condreflect-level3", "/condreflect/level3/?query=a", "reflects only if input does not start with <",
   vuln: "reflected-html", delivery: ["query"], note: "a value starting with < is not reflected at all; prefix the payload with any other character")
 maze_get "/condreflect/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if !query.starts_with?("<")
     "<html><body><div>#{query}</div></body></html>"
@@ -45,7 +45,7 @@ end
 Xssmaze.push("condreflect-level4", "/condreflect/level4/?query=a", "double reflection when input contains <",
   vuln: "reflected-html", delivery: ["query"], note: "a value containing < is reflected twice, once in a div and once in a p")
 maze_get "/condreflect/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.includes?("<")
     "<html><body><div>#{query}</div><p>Also: #{query}</p></body></html>"
@@ -58,7 +58,7 @@ end
 Xssmaze.push("condreflect-level5", "/condreflect/level5/?query=a", "wraps in code tag if lang param present, div otherwise",
   vuln: "reflected-html", delivery: ["query"], note: "an extra lang parameter of any value switches the wrapper from <div> to <code>; the payload always lands in query")
 maze_get "/condreflect/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   has_lang = env.params.query.has_key?("lang")
 
   if has_lang
@@ -73,7 +73,7 @@ end
 Xssmaze.push("condreflect-level6", "/condreflect/level6/?query=a", "raw reflection if input < 100 chars, encoded otherwise",
   vuln: "reflected-html", delivery: ["query"], note: "values of 100 characters or more are entity-encoded, so keep the payload short")
 maze_get "/condreflect/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.size < 100
     "<html><body><div>#{query}</div></body></html>"

--- a/src/mazes/csti_xss.cr
+++ b/src/mazes/csti_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("csti-level1", "/csti/level1/?query=a", "AngularJS 1.x template injection via ng-app",
   vuln: "csti", delivery: ["query"], note: "AngularJS 1.8.3 ng-app scope; payload is a {{ }} template expression")
 maze_get "/csti/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html>
   <head><script src='https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.8.3/angular.min.js'></script></head>
@@ -14,7 +14,7 @@ end
 Xssmaze.push("csti-level2", "/csti/level2/?query=a", "AngularJS 1.x sandbox escape (older version)",
   vuln: "csti", delivery: ["query"], note: "AngularJS 1.6.0 ng-app scope; sandbox-escape expression")
 maze_get "/csti/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html>
   <head><script src='https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.0/angular.min.js'></script></head>
@@ -27,7 +27,7 @@ end
 Xssmaze.push("csti-level3", "/csti/level3/?query=a", "Vue.js v-html directive injection",
   vuln: "dom", sources: ["server-reflected"], sinks: ["vue.v-html"], delivery: ["query"], note: "not template evaluation: the value is server-inlined into Vue data and rendered by the v-html innerHTML sink")
 maze_get "/csti/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html>
   <head><script src='https://cdnjs.cloudflare.com/ajax/libs/vue/2.7.14/vue.min.js'></script></head>
@@ -48,7 +48,7 @@ end
 Xssmaze.push("csti-level4", "/csti/level4/?query=a", "Vue.js template compilation injection",
   vuln: "csti", delivery: ["query"], note: "Vue 2 compiles #app as a template; payload is a {{ }} expression")
 maze_get "/csti/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html>
   <head><script src='https://cdnjs.cloudflare.com/ajax/libs/vue/2.7.14/vue.min.js'></script></head>
@@ -64,7 +64,7 @@ end
 Xssmaze.push("csti-level5", "/csti/level5/?query=a", "jQuery html() method injection",
   vuln: "dom", sources: ["server-reflected"], sinks: ["jquery.html"], delivery: ["query"], note: "not template evaluation: the value reaches jQuery .html(), an innerHTML sink")
 maze_get "/csti/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html>
   <head><script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js'></script></head>

--- a/src/mazes/custom_tag_xss.cr
+++ b/src/mazes/custom_tag_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("customtag-level1", "/customtag/level1/?query=a", "raw reflection in custom element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/customtag/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><custom-element>#{query}</custom-element></body></html>"
 end
@@ -15,7 +15,7 @@ end
 Xssmaze.push("customtag-level2", "/customtag/level2/?query=a", "reflection in custom element data-value attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/customtag/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><x-widget data-value=\"#{query}\">content</x-widget></body></html>"
 end
@@ -26,7 +26,7 @@ end
 Xssmaze.push("customtag-level3", "/customtag/level3/?query=a", "raw reflection in customized built-in element (is= attribute)",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/customtag/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div is=\"custom-div\">#{query}</div></body></html>"
 end
@@ -37,7 +37,7 @@ end
 Xssmaze.push("customtag-level4", "/customtag/level4/?query=a", "reflection in slot name attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/customtag/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><slot name=\"#{query}\">default</slot></body></html>"
 end
@@ -49,7 +49,7 @@ end
 Xssmaze.push("customtag-level5", "/customtag/level5/?query=a", "raw reflection inside template element",
   vuln: "reflected-html", delivery: ["query"], note: "content parsed inside <template> is inert and never executes; close the template tag first, then inject")
 maze_get "/customtag/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><template id=\"tmpl\"><div>#{query}</div></template></body></html>"
 end
@@ -60,7 +60,7 @@ end
 Xssmaze.push("customtag-level6", "/customtag/level6/?query=a", "raw reflection in output element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/customtag/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><output name=\"result\">#{query}</output></body></html>"
 end

--- a/src/mazes/dataurl_xss.cr
+++ b/src/mazes/dataurl_xss.cr
@@ -1,27 +1,27 @@
 Xssmaze.push("dataurl-level1", "/dataurl/level1/?query=a", "anchor href with data:text/html under user control (executes on click)",
   vuln: "reflected-attr", delivery: ["query"], note: "single-quoted anchor href holding a data:text/html URL; on click the browser renders the reflected bytes as their own HTML document")
 maze_get "/dataurl/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<a href='data:text/html,#{query}'>open</a>"
 end
 
 Xssmaze.push("dataurl-level2", "/dataurl/level2/?query=a", "iframe src=data:text/html with reflected body",
   vuln: "reflected-attr", delivery: ["query"], note: "iframe src=data:text/html; the reflected bytes render as the iframe own HTML document on load")
 maze_get "/dataurl/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<iframe src='data:text/html;charset=utf-8,#{query}'></iframe>"
 end
 
 Xssmaze.push("dataurl-level3", "/dataurl/level3/?query=a", "object data=data:text/html with reflected payload",
   vuln: "reflected-attr", delivery: ["query"], note: "object data=data:text/html; the reflected bytes render as the object document")
 maze_get "/dataurl/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<object data='data:text/html,#{query}'></object>"
 end
 
 Xssmaze.push("dataurl-level4", "/dataurl/level4/?query=a", "embed src=data:text/html with reflected payload",
   vuln: "reflected-attr", delivery: ["query"], note: "embed src=data:text/html; the reflected bytes render as the embedded document")
 maze_get "/dataurl/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<embed src='data:text/html,#{query}'>"
 end

--- a/src/mazes/double_reflection_xss.cr
+++ b/src/mazes/double_reflection_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("doublereflect-level1", "/doublereflect/level1/?query=a", "query reflected twice in body",
   vuln: "reflected-html", delivery: ["query"], note: "the same value is reflected twice into paragraph text")
 maze_get "/doublereflect/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Double Reflection Level 1</h1>
@@ -15,7 +15,7 @@ end
 Xssmaze.push("doublereflect-level2", "/doublereflect/level2/?query=a", "body raw + attribute with quotes encoded",
   vuln: "reflected-html", delivery: ["query"], note: "the input value attribute entity-encodes double quotes; the div copy is raw")
 maze_get "/doublereflect/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   attr_escaped = query.gsub("\"", "&quot;")
 
   "<html><body>
@@ -29,7 +29,7 @@ end
 Xssmaze.push("doublereflect-level3", "/doublereflect/level3/?query=a", "first reflection encoded, second raw",
   vuln: "reflected-html", delivery: ["query"], note: "the first copy entity-encodes angle brackets; the second is raw")
 maze_get "/doublereflect/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = Filters.encode_angles(query)
 
   "<html><body>
@@ -43,7 +43,7 @@ end
 Xssmaze.push("doublereflect-level4", "/doublereflect/level4/?query=a", "reflection in title + body",
   vuln: "reflected-html", delivery: ["query"], note: "the <title> copy is RCDATA; the div copy is a plain HTML context")
 maze_get "/doublereflect/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head>
   <title>#{query}</title>
@@ -57,7 +57,7 @@ end
 Xssmaze.push("doublereflect-level5", "/doublereflect/level5/?query=a", "4 encoded reflections + 1 raw at end",
   vuln: "reflected-html", delivery: ["query"], note: "four copies entity-encode angle brackets; only the fifth is raw")
 maze_get "/doublereflect/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   encoded = Filters.encode_angles(query)
 
   "<html><body>
@@ -74,7 +74,7 @@ end
 Xssmaze.push("doublereflect-level6", "/doublereflect/level6/?query=a", "script string (quotes escaped) + div raw",
   vuln: "reflected-html", delivery: ["query"], note: "the <script> copy escapes double quotes but not </script>; the div copy is raw")
 maze_get "/doublereflect/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   js_escaped = query.gsub("\"", "\\\"")
 
   "<html><body>

--- a/src/mazes/edge_case_xss.cr
+++ b/src/mazes/edge_case_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("edge-level1", "/edge/level1/?query=a", "null byte before filter",
   vuln: "reflected-html", delivery: ["query"], note: "the angle-bracket check only inspects the bytes before the first NUL, so a %00 prefix carries the payload past it unfiltered")
 maze_get "/edge/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Strip everything after null byte for filter, but reflect original
   check = query.split('\0').first || query
   if check.includes?("<") || check.includes?(">")
@@ -25,7 +25,7 @@ end
 Xssmaze.push("edge-level3", "/edge/level3/?query=a", "JSON island in script tag",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is placed in a <script type=application/json> island with its double quotes escaped, then JSON.parse'd and written with innerHTML — a tag payload reaches the sink with no breakout")
 maze_get "/edge/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   escaped = query.gsub("\"", "\\\"")
 
   "<html><body>
@@ -44,7 +44,7 @@ end
 Xssmaze.push("edge-level4", "/edge/level4/?query=a", "HTML entity in event handler attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are entity-encoded, but the value sits in a single-quoted JS string inside an onclick handler; the handler only runs on click, so break out of the double-quoted attribute to inject a self-firing tag")
 maze_get "/edge/level4/" do |env|
-  query = Filters.encode_angles(env.params.query["query"])
+  query = Filters.encode_angles(env.params.query.fetch("query", ""))
 
   "<html><body><div onclick=\"handle('#{query}')\">Click</div></body></html>"
 end
@@ -63,7 +63,7 @@ end
 Xssmaze.push("edge-level6", "/edge/level6/?query=a", "SVG fill attribute injection",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into an SVG <rect fill>; inside <svg> an injected <script> is an SVG script element and still runs")
 maze_get "/edge/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><svg><rect fill=\"#{query}\" width=\"100\" height=\"100\"/></svg></body></html>"
 end
@@ -83,7 +83,7 @@ end
 Xssmaze.push("edge-level8", "/edge/level8/?query=a", "textarea body (close tag allowed)",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into <textarea> RCDATA; close </textarea> first")
 maze_get "/edge/level8/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><textarea>#{query}</textarea></body></html>"
 end

--- a/src/mazes/embed_context_xss.cr
+++ b/src/mazes/embed_context_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("embedctx-level1", "/embedctx/level1/?query=a", "reflection in object data attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/embedctx/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Embed Context XSS Level 1</h1>
@@ -16,7 +16,7 @@ end
 Xssmaze.push("embedctx-level2", "/embedctx/level2/?query=a", "reflection in embed src attribute with text/html type",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/embedctx/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Embed Context XSS Level 2</h1>
@@ -29,7 +29,7 @@ end
 Xssmaze.push("embedctx-level3", "/embedctx/level3/?query=a", "reflection in param value inside object tag",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into a <param value> nested inside <object>")
 maze_get "/embedctx/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Embed Context XSS Level 3</h1>
@@ -45,7 +45,7 @@ end
 Xssmaze.push("embedctx-level4", "/embedctx/level4/?query=a", "reflection in deprecated applet code attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "<applet> is not a recognised element in modern parsers, but its start tag still tokenises, so the attribute breakout works")
 maze_get "/embedctx/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Embed Context XSS Level 4</h1>
@@ -58,7 +58,7 @@ end
 Xssmaze.push("embedctx-level5", "/embedctx/level5/?query=a", "reflection in param value inside nested object",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into a <param value> nested inside <object>")
 maze_get "/embedctx/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Embed Context XSS Level 5</h1>
@@ -74,7 +74,7 @@ end
 Xssmaze.push("embedctx-level6", "/embedctx/level6/?query=a", "reflection in embed src with dimensions",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/embedctx/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Embed Context XSS Level 6</h1>

--- a/src/mazes/encoding_bypass_xss.cr
+++ b/src/mazes/encoding_bypass_xss.cr
@@ -4,7 +4,7 @@ require "base64"
 Xssmaze.push("encoding-bypass-level1", "/encoding-bypass/level1/?query=a", "recursive script strip (other tags allowed)",
   vuln: "reflected-html", delivery: ["query"], note: "script is stripped recursively so nesting does not help; every other tag and event handler is untouched")
 maze_get "/encoding-bypass/level1/" do |env|
-  query = Filters.strip_keyword_recursive(env.params.query["query"], "script")
+  query = Filters.strip_keyword_recursive(env.params.query.fetch("query", ""), "script")
 
   "<html><body>#{query}</body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("encoding-bypass-level2", "/encoding-bypass/level2/?query=a", "single < > strip (only first occurrence)",
   vuln: "reflected-html", delivery: ["query"], note: "only the first < and the first > are removed; double them up")
 maze_get "/encoding-bypass/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.sub("<", "")
   query = query.sub(">", "")
 
@@ -24,7 +24,7 @@ end
 Xssmaze.push("encoding-bypass-level3", "/encoding-bypass/level3/?query=a", "alert keyword strip (non-recursive)",
   vuln: "reflected-html", delivery: ["query"], note: "only the literal alert keyword is stripped, in a single pass; alalertert survives, and any other sink is untouched")
 maze_get "/encoding-bypass/level3/" do |env|
-  query = Filters.strip_keyword_ci(env.params.query["query"], "alert")
+  query = Filters.strip_keyword_ci(env.params.query.fetch("query", ""), "alert")
 
   "<html><body>#{query}</body></html>"
 end
@@ -33,7 +33,7 @@ end
 Xssmaze.push("encoding-bypass-level4", "/encoding-bypass/level4/?query=a", "event handler strip + tag allowed",
   vuln: "reflected-html", delivery: ["query"], note: "on*= handlers are stripped, but tags are not")
 maze_get "/encoding-bypass/level4/" do |env|
-  query = Filters.strip_event_handlers(env.params.query["query"])
+  query = Filters.strip_event_handlers(env.params.query.fetch("query", ""))
 
   "<html><body>#{query}</body></html>"
 end
@@ -42,7 +42,7 @@ end
 Xssmaze.push("encoding-bypass-level5", "/encoding-bypass/level5/?query=a", "javascript: strip but data: allowed in href",
   vuln: "reflected-attr", delivery: ["query"], note: "javascript: is stripped and data: is not, but the double-quoted href can simply be broken out of")
 maze_get "/encoding-bypass/level5/" do |env|
-  query = Filters.strip_js_protocol(env.params.query["query"])
+  query = Filters.strip_js_protocol(env.params.query.fetch("query", ""))
 
   "<html><body><a href=\"#{query}\">Click</a></body></html>"
 end
@@ -51,7 +51,7 @@ end
 Xssmaze.push("encoding-bypass-level6", "/encoding-bypass/level6/?query=a", "URL decode + angle strip (double encode bypass)",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "the description promises a double-encoding bypass, but the angle-bracket strip runs after the decode, so no < or > can reach the body context")
 maze_get "/encoding-bypass/level6/" do |env|
-  query = URI.decode(env.params.query["query"])
+  query = URI.decode(env.params.query.fetch("query", ""))
   query = Filters.strip_angles(query)
 
   "<html><body>#{query}</body></html>"
@@ -63,7 +63,7 @@ end
 Xssmaze.push("encoding-bypass-level7", "/encoding-bypass/level7/?query=a", "tag whitelist (img/div/span only)",
   vuln: "reflected-html", delivery: ["query"], note: "only img/div/span survive the whitelist, and img carries onerror")
 maze_get "/encoding-bypass/level7/" do |env|
-  query = Filters.whitelist_tags(env.params.query["query"], ["img", "div", "span"])
+  query = Filters.whitelist_tags(env.params.query.fetch("query", ""), ["img", "div", "span"])
 
   "<html><body>#{query}</body></html>"
 end
@@ -72,7 +72,7 @@ end
 Xssmaze.push("encoding-bypass-level8", "/encoding-bypass/level8/?query=a", "60 char length limit in attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "the value is truncated to 60 characters, so the whole breakout has to fit")
 maze_get "/encoding-bypass/level8/" do |env|
-  query = env.params.query["query"][0, 60]
+  query = env.params.query.fetch("query", "")[0, 60]
 
   "<html><body><div class=\"#{query}\">Hello</div></body></html>"
 end

--- a/src/mazes/error_page_xss.cr
+++ b/src/mazes/error_page_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("errpage-level1", "/errpage/level1/?query=a", "404 error page with raw reflection in h1",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><h1>Page not found: #{query}</h1></body></html>"
 end
@@ -11,7 +11,7 @@ end
 Xssmaze.push("errpage-level2", "/errpage/level2/?query=a", "error message div with raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"error\">Invalid input: #{query}</div></body></html>"
 end
@@ -21,7 +21,7 @@ end
 Xssmaze.push("errpage-level3", "/errpage/level3/?query=a", "debug page with reflection in pre tag",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><h2>Debug Info</h2><pre>Request param: #{query}</pre></body></html>"
 end
@@ -31,7 +31,7 @@ end
 Xssmaze.push("errpage-level4", "/errpage/level4/?query=a", "search results page with reflection in paragraph",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><p>No results for \"#{query}\"</p></body></html>"
 end
@@ -41,7 +41,7 @@ end
 Xssmaze.push("errpage-level5", "/errpage/level5/?query=a", "error page with reflection in title and h1",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into both <title> RCDATA and the <h1> body")
 maze_get "/errpage/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><title>Error - #{query}</title></head><body><h1>Error: #{query}</h1></body></html>"
 end
@@ -51,7 +51,7 @@ end
 Xssmaze.push("errpage-level6", "/errpage/level6/?query=a", "stack trace page with reflection in code tag",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/errpage/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><h2>Application Error</h2><code>NameError: undefined variable '#{query}'</code></body></html>"
 end

--- a/src/mazes/global_attr_xss.cr
+++ b/src/mazes/global_attr_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("globalattr-level1", "/globalattr/level1/?query=a", "reflection in div id attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Global Attribute XSS Level 1</h1>
@@ -16,7 +16,7 @@ end
 Xssmaze.push("globalattr-level2", "/globalattr/level2/?query=a", "reflection in p class attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Global Attribute XSS Level 2</h1>
@@ -29,7 +29,7 @@ end
 Xssmaze.push("globalattr-level3", "/globalattr/level3/?query=a", "reflection in span accesskey attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Global Attribute XSS Level 3</h1>
@@ -42,7 +42,7 @@ end
 Xssmaze.push("globalattr-level4", "/globalattr/level4/?query=a", "reflection in div spellcheck attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Global Attribute XSS Level 4</h1>
@@ -55,7 +55,7 @@ end
 Xssmaze.push("globalattr-level5", "/globalattr/level5/?query=a", "reflection in p draggable attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Global Attribute XSS Level 5</h1>
@@ -68,7 +68,7 @@ end
 Xssmaze.push("globalattr-level6", "/globalattr/level6/?query=a", "reflection in div lang attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/globalattr/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Global Attribute XSS Level 6</h1>

--- a/src/mazes/inframe_xss.cr
+++ b/src/mazes/inframe_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("inframe-xss-level1", "/inframe/level1/?url=a", "src attribute in iframe tag", "GET", ["url"],
   vuln: "reflected-attr", sinks: ["iframe.src"], delivery: ["query"], note: "the parameter is url, not query; both a quote breakout and a javascript: URL work")
 maze_get "/inframe/level1/" do |env|
-  query = env.params.query["url"]
+  query = env.params.query.fetch("url", "")
 
   "<iframe src='#{query}'></iframe>"
 end
@@ -9,7 +9,7 @@ end
 Xssmaze.push("inframe-xss-level2", "/inframe/level2/?url=a", "src attribute in iframe tag", "GET", ["url"],
   vuln: "reflected-attr", sinks: ["iframe.src"], delivery: ["query"], note: "the parameter is url, not query; quotes are stripped so the attribute cannot be broken out, leaving a javascript: URL in the frame src")
 maze_get "/inframe/level2/" do |env|
-  query = env.params.query["url"]
+  query = env.params.query.fetch("url", "")
 
   "<iframe src='#{query.gsub("'", "").gsub("\"", "")}'></iframe>"
 end
@@ -17,7 +17,7 @@ end
 Xssmaze.push("inframe-xss-level3", "/inframe/level3/?url=a", "src attribute in iframe tag", "GET", ["url"],
   vuln: "reflected-attr", sinks: ["iframe.src"], delivery: ["query"], note: "the parameter is url, not query; the value is lowercased and javascript: removed in one pass, so nest it as javajavascript:script:")
 maze_get "/inframe/level3/" do |env|
-  query = env.params.query["url"]
+  query = env.params.query.fetch("url", "")
 
   "<iframe src='#{query.gsub("'", "").gsub("\"", "").downcase.gsub("javascript:", "")}'></iframe>"
 end
@@ -25,7 +25,7 @@ end
 Xssmaze.push("inframe-xss-level4", "/inframe/level4/?url=a", "src attribute in iframe tag", "GET", ["url"],
   vuln: "reflected-attr", sinks: ["iframe.src"], delivery: ["query"], note: "the parameter is url, not query; javascript: and alert are each removed in one pass, so nest both: javajavascript:script:alalertert`1`")
 maze_get "/inframe/level4/" do |env|
-  query = env.params.query["url"]
+  query = env.params.query.fetch("url", "")
 
   "<iframe src='#{query.gsub("'", "").gsub("\"", "").downcase.gsub("javascript:", "").gsub("alert", "")}'></iframe>"
 end

--- a/src/mazes/injs_xss.cr
+++ b/src/mazes/injs_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("injs-xss-level1", "/injs/level1/?query=a", "injs-xss",
   vuln: "reflected-js", delivery: ["query"], note: "unquoted JS expression context, so a bare statement runs")
 maze_get "/injs/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<script>
       var data = #{query};
@@ -11,7 +11,7 @@ end
 Xssmaze.push("injs-xss-level2", "/injs/level2/?query=a", "injs-xss - in single quote",
   vuln: "reflected-js", delivery: ["query"])
 maze_get "/injs/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<script>
       var data = '#{query}';
@@ -21,7 +21,7 @@ end
 Xssmaze.push("injs-xss-level3", "/injs/level3/?query=a", "injs-xss - in double quote",
   vuln: "reflected-js", delivery: ["query"])
 maze_get "/injs/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<script>
       var data = \"#{query}\";
@@ -31,7 +31,7 @@ end
 Xssmaze.push("injs-xss-level4", "/injs/level4/?query=a", "injs-xss - in single quote and double quote",
   vuln: "reflected-js", delivery: ["query"], note: "single quotes are stripped, so close the <script> block instead of the string")
 maze_get "/injs/level4/" do |env|
-  query = env.params.query["query"].gsub("'", "")
+  query = env.params.query.fetch("query", "").gsub("'", "")
 
   "<script>
       var data = '#{query}' // this is '#{query}';
@@ -41,7 +41,7 @@ end
 Xssmaze.push("injs-xss-level5", "/injs/level5/?query=a", "injs-xss - in comments style 1",
   vuln: "reflected-js", delivery: ["query"], note: "inside a block comment; close it with */ first")
 maze_get "/injs/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<script>
       /* this is '#{query}' */
@@ -51,7 +51,7 @@ end
 Xssmaze.push("injs-xss-level6", "/injs/level6/?query=a", "injs-xss - in comments style 2",
   vuln: "reflected-js", delivery: ["query"], note: "inside a line comment; a newline (%0a) ends it")
 maze_get "/injs/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<script>
       // this is '#{query}'

--- a/src/mazes/js_string_escape_xss.cr
+++ b/src/mazes/js_string_escape_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("jsescape-level1", "/jsescape/level1/?query=a", "JS string double-quote escaped but script tag not blocked",
   vuln: "reflected-js", delivery: ["query"], note: "double quotes are backslash-escaped; close the <script> block instead of the string")
 maze_get "/jsescape/level1/" do |env|
-  query = env.params.query["query"].gsub("\"", "\\\"")
+  query = env.params.query.fetch("query", "").gsub("\"", "\\\"")
 
   "<html><body><script>var msg = \"#{query}\";</script></body></html>"
 end
@@ -15,7 +15,7 @@ end
 Xssmaze.push("jsescape-level2", "/jsescape/level2/?query=a", "JS string single-quote escaped but script tag not blocked",
   vuln: "reflected-js", delivery: ["query"], note: "the backslash itself is not escaped, so a leading backslash neutralises the quote escape and closes the string; closing the <script> block also works")
 maze_get "/jsescape/level2/" do |env|
-  query = env.params.query["query"].gsub("'", "\\'")
+  query = env.params.query.fetch("query", "").gsub("'", "\\'")
 
   "<html><body><script>var msg = '#{query}';</script></body></html>"
 end
@@ -26,7 +26,7 @@ end
 Xssmaze.push("jsescape-level3", "/jsescape/level3/?query=a", "JS template literal quotes escaped but backtick and script tag not blocked",
   vuln: "reflected-js", delivery: ["query"], note: "template literal: the backtick is not escaped, and a ${...} substitution evaluates without any breakout")
 maze_get "/jsescape/level3/" do |env|
-  query = env.params.query["query"].gsub("\"", "\\\"").gsub("'", "\\'")
+  query = env.params.query.fetch("query", "").gsub("\"", "\\\"").gsub("'", "\\'")
 
   "<html><body><script>var msg = `#{query}`;</script></body></html>"
 end
@@ -41,7 +41,7 @@ end
 Xssmaze.push("jsescape-level4", "/jsescape/level4/?query=a", "JS string with backslash and quote both escaped but script tag not blocked",
   vuln: "reflected-js", delivery: ["query"], note: "backslashes are escaped before quotes, so the string itself holds; close the <script> block")
 maze_get "/jsescape/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub("\\", "\\\\") # \ -> \\
   query = query.gsub("\"", "\\\"") # " -> \"
 
@@ -55,7 +55,7 @@ end
 Xssmaze.push("jsescape-level5", "/jsescape/level5/?query=a", "JS string with < encoded but raw reflection in body",
   vuln: "reflected-html", delivery: ["query"], note: "the script-string copy encodes < and the quote, but the same value is reflected raw into the div just after it")
 maze_get "/jsescape/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   js_query = query.gsub("<", "\\x3c").gsub("\"", "\\\"")
 
   "<html><body><script>var msg = \"#{js_query}\";</script><div>Search: #{query}</div></body></html>"
@@ -68,7 +68,7 @@ end
 Xssmaze.push("jsescape-level6", "/jsescape/level6/?query=a", "JS string single-quote HTML-entity escaped (ineffective in JS)",
   vuln: "reflected-js", delivery: ["query"], note: "quotes are replaced with an HTML entity, which is literal text inside a script element and never decodes; close the <script> block")
 maze_get "/jsescape/level6/" do |env|
-  query = env.params.query["query"].gsub("'", "&#39;")
+  query = env.params.query.fetch("query", "").gsub("'", "&#39;")
 
   "<html><body><script>var msg = '#{query}';</script></body></html>"
 end

--- a/src/mazes/link_context_xss.cr
+++ b/src/mazes/link_context_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("linkcontext-level1", "/linkcontext/level1/?query=a", "reflection in a href attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "an anchor href takes a javascript: URL, but that needs a click; a quote breakout does not")
 maze_get "/linkcontext/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Link Context XSS Level 1</h1>
@@ -14,7 +14,7 @@ end
 Xssmaze.push("linkcontext-level2", "/linkcontext/level2/?query=a", "reflection in link href attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "a stylesheet href does not run javascript: URLs; break out of the double-quoted attribute")
 maze_get "/linkcontext/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head>
   <link rel=\"stylesheet\" href=\"#{query}\">
@@ -28,7 +28,7 @@ end
 Xssmaze.push("linkcontext-level3", "/linkcontext/level3/?query=a", "reflection in a ping attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "the ping attribute only fires a background POST and never executes; break out of the quote")
 maze_get "/linkcontext/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Link Context XSS Level 3</h1>
@@ -40,7 +40,7 @@ end
 Xssmaze.push("linkcontext-level4", "/linkcontext/level4/?query=a", "reflection in area href attribute inside map",
   vuln: "reflected-attr", delivery: ["query"], note: "the usemap image does not exist, so the area is not clickable; break out of the quoted attribute instead of using a javascript: URL")
 maze_get "/linkcontext/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Link Context XSS Level 4</h1>
@@ -53,7 +53,7 @@ end
 Xssmaze.push("linkcontext-level5", "/linkcontext/level5/?query=a", "reflection in base href attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/linkcontext/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head>
   <base href=\"#{query}\">
@@ -67,7 +67,7 @@ end
 Xssmaze.push("linkcontext-level6", "/linkcontext/level6/?query=a", "reflection in a title attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/linkcontext/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Link Context XSS Level 6</h1>

--- a/src/mazes/misc_context_xss.cr
+++ b/src/mazes/misc_context_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("misc-context-level1", "/misc-context/level1/?query=a", "progress element title attribute reflection",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div style=\"padding:20px\"><label>Upload Progress:</label><br><progress value=\"50\" max=\"100\" title=\"#{query}\">50%</progress></div></body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("misc-context-level2", "/misc-context/level2/?query=a", "meter element title attribute reflection",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div style=\"padding:20px\"><label>Disk Usage:</label><br><meter min=\"0\" max=\"100\" value=\"75\" title=\"#{query}\">75%</meter></div></body></html>"
 end
@@ -23,7 +23,7 @@ end
 Xssmaze.push("misc-context-level3", "/misc-context/level3/?query=a", "time element datetime attribute reflection",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div style=\"padding:20px\"><p>Published on <time datetime=\"#{query}\">March 2024</time></p></div></body></html>"
 end
@@ -33,7 +33,7 @@ end
 Xssmaze.push("misc-context-level4", "/misc-context/level4/?query=a", "data element value attribute reflection",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div style=\"padding:20px\"><p>Product ID: <data value=\"#{query}\">Product 123</data></p></div></body></html>"
 end
@@ -43,7 +43,7 @@ end
 Xssmaze.push("misc-context-level5", "/misc-context/level5/?query=a", "cite element title attribute reflection",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div style=\"padding:20px\"><blockquote><p>The only way to do great work is to love what you do.</p><footer>-- <cite title=\"#{query}\">Source Name</cite></footer></blockquote></div></body></html>"
 end
@@ -53,7 +53,7 @@ end
 Xssmaze.push("misc-context-level6", "/misc-context/level6/?query=a", "q element cite attribute reflection",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/misc-context/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div style=\"padding:20px\"><p>As they say: <q cite=\"#{query}\">quoted text</q></p></div></body></html>"
 end

--- a/src/mazes/mutation_filter_xss.cr
+++ b/src/mazes/mutation_filter_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("mutfilter-level1", "/mutfilter/level1/?query=a", "< replaced with %3C in body",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "< and > are replaced with the literal text %3C/%3E and nothing decodes them client-side, so no tag can form")
 maze_get "/mutfilter/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub("<", "%3C").gsub(">", "%3E")
 
   "<html><body>#{query}</body></html>"
@@ -13,7 +13,7 @@ end
 Xssmaze.push("mutfilter-level2", "/mutfilter/level2/?query=a", "HTML comment strip only",
   vuln: "reflected-html", delivery: ["query"], note: "only HTML comments are stripped; other tags survive")
 maze_get "/mutfilter/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub(/<!--.*?-->/m, "")
 
   "<html><body>#{query}</body></html>"
@@ -23,7 +23,7 @@ end
 Xssmaze.push("mutfilter-level3", "/mutfilter/level3/?query=a", "on* prefix replaced with off*",
   vuln: "reflected-html", delivery: ["query"], note: "on* handlers are rewritten to off*; use a <script> tag or other non-event vector")
 maze_get "/mutfilter/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub(/\bon(\w)/i) { "off#{$1}" }
 
   "<html><body>#{query}</body></html>"
@@ -33,7 +33,7 @@ end
 Xssmaze.push("mutfilter-level4", "/mutfilter/level4/?query=a", "dangerous attribute strip (src/href/action)",
   vuln: "reflected-html", delivery: ["query"], note: "src/href/action attributes are neutralized; use a <script> tag or an event handler")
 maze_get "/mutfilter/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub(/\b(src|href|action|formaction)\s*=/i, "data-removed=")
 
   "<html><body>#{query}</body></html>"
@@ -43,7 +43,7 @@ end
 Xssmaze.push("mutfilter-level5", "/mutfilter/level5/?query=a", "no filter (basic reflection)",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/mutfilter/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><p>#{query}</p></body></html>"
 end
@@ -52,7 +52,7 @@ end
 Xssmaze.push("mutfilter-level6", "/mutfilter/level6/?query=a", "all whitespace removed in body reflection",
   vuln: "reflected-html", delivery: ["query"], note: "whitespace is stripped; use / as an attribute separator or a <script> tag")
 maze_get "/mutfilter/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub(/\s/, "")
 
   "<html><body>#{query}</body></html>"

--- a/src/mazes/mxss.cr
+++ b/src/mazes/mxss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("mxss-level1", "/mxss/level1/?query=a", "mutation XSS via innerHTML round-trip",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "innerHTML serialize/re-parse round-trip; needs a mutation vector rather than a plain tag")
 maze_get "/mxss/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>mXSS Level 1</h1>
@@ -18,7 +18,7 @@ end
 Xssmaze.push("mxss-level2", "/mxss/level2/?query=a", "mutation XSS via DOMParser + innerHTML re-serialize",
   vuln: "dom", sources: ["server-reflected"], sinks: ["DOMParser", "innerHTML"], delivery: ["query"], note: "DOMParser parse then re-serialize into innerHTML")
 maze_get "/mxss/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>mXSS Level 2</h1>
@@ -36,7 +36,7 @@ end
 Xssmaze.push("mxss-level3", "/mxss/level3/?query=a", "mutation XSS via template + namespace confusion",
   vuln: "dom", sources: ["server-reflected"], sinks: ["template.innerHTML", "innerHTML"], delivery: ["query"], note: "template context to document context namespace confusion")
 maze_get "/mxss/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>mXSS Level 3</h1>
@@ -57,7 +57,7 @@ end
 Xssmaze.push("mxss-level4", "/mxss/level4/?query=a", "mutation XSS via SVG foreignObject namespace switch",
   vuln: "dom", sources: ["server-reflected"], sinks: ["DOMParser", "innerHTML"], delivery: ["query"], note: "SVG foreignObject namespace switch on re-serialization")
 maze_get "/mxss/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>mXSS Level 4</h1>
@@ -78,7 +78,7 @@ end
 Xssmaze.push("mxss-level5", "/mxss/level5/?query=a", "mutation XSS via math/style element parsing differential",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "math/style parsing differential on re-serialization")
 maze_get "/mxss/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>mXSS Level 5</h1>

--- a/src/mazes/nonce_bypass_xss.cr
+++ b/src/mazes/nonce_bypass_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("nonce-level1", "/nonce/level1/?query=a", "CSP nonce with reflection inside nonced script string",
   vuln: "reflected-js", delivery: ["query"], note: "the nonce is random per request, so no injected <script> can carry it; the only route is breaking the double-quoted string inside the already-nonced block")
 maze_get "/nonce/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   nonce = Random::Secure.hex(16)
   env.response.headers["Content-Security-Policy"] = "script-src 'nonce-#{nonce}'"
 
@@ -20,7 +20,7 @@ end
 Xssmaze.push("nonce-level2", "/nonce/level2/?query=a", "CSP nonce with reflection in onclick (unsafe-hashes)",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "script-src 'nonce-X' 'unsafe-hashes' lists no hash source, so 'unsafe-hashes' enables nothing and the onclick handler holding the reflection never runs; an injected handler or script is blocked too and the nonce is random, so nothing reaches a JS sink")
 maze_get "/nonce/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   nonce = Random::Secure.hex(16)
   env.response.headers["Content-Security-Policy"] = "script-src 'nonce-#{nonce}' 'unsafe-hashes'"
 
@@ -39,7 +39,7 @@ end
 Xssmaze.push("nonce-level3", "/nonce/level3/?query=/", "CSP script-src self with base tag href injection",
   vuln: "reflected-attr", delivery: ["query"], note: "script-src 'self' blocks inline scripts and event handlers, and also blocks the intended <base href> redirect of /js/app.js to another origin; what does work is the \" attribute breakout plus a same-origin <script src=...> include")
 maze_get "/nonce/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.headers["Content-Security-Policy"] = "script-src 'self'"
 
   "<html><head>
@@ -56,7 +56,7 @@ end
 Xssmaze.push("nonce-level4", "/nonce/level4/?query=a", "script single-quote string with backslash escape bypass",
   vuln: "reflected-js", delivery: ["query"], note: "single quotes are backslash-escaped but backslashes are not, so a leading backslash escapes the added one and frees the quote: \\';alert(1)//")
 maze_get "/nonce/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # Only escape single quotes by prepending backslash (but not backslashes themselves)
   escaped = query.gsub("'", "\\'")

--- a/src/mazes/obfuscation_xss.cr
+++ b/src/mazes/obfuscation_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("obfuscation-level1", "/obfuscation/level1/?query=a", "server lowercases input then reflects (lowercase payloads work)",
   vuln: "reflected-html", delivery: ["query"], note: "input lowercased; lowercase payloads survive")
 maze_get "/obfuscation/level1/" do |env|
-  query = env.params.query["query"].downcase
+  query = env.params.query.fetch("query", "").downcase
 
   "<html><body>
   <h1>Obfuscation Level 1</h1>
@@ -16,7 +16,7 @@ end
 Xssmaze.push("obfuscation-level2", "/obfuscation/level2/?query=a", "server uppercases input then reflects (HTML is case-insensitive)",
   vuln: "reflected-html", delivery: ["query"], note: "input uppercased, but HTML tags are case-insensitive")
 maze_get "/obfuscation/level2/" do |env|
-  query = env.params.query["query"].upcase
+  query = env.params.query.fetch("query", "").upcase
 
   "<html><body>
   <h1>Obfuscation Level 2</h1>
@@ -29,7 +29,7 @@ end
 Xssmaze.push("obfuscation-level3", "/obfuscation/level3/?query=a", "reflects reversed + original (original is exploitable)",
   vuln: "reflected-html", delivery: ["query"], note: "the reversed copy is a decoy; the original is reflected raw")
 maze_get "/obfuscation/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   reversed = query.reverse
 
   "<html><body>
@@ -44,7 +44,7 @@ end
 Xssmaze.push("obfuscation-level4", "/obfuscation/level4/?query=a", "server strips all spaces then reflects (use / separator)",
   vuln: "reflected-html", delivery: ["query"], note: "spaces stripped; use / as an attribute separator")
 maze_get "/obfuscation/level4/" do |env|
-  query = env.params.query["query"].gsub(" ", "")
+  query = env.params.query.fetch("query", "").gsub(" ", "")
 
   "<html><body>
   <h1>Obfuscation Level 4</h1>
@@ -57,7 +57,7 @@ end
 Xssmaze.push("obfuscation-level5", "/obfuscation/level5/?query=a", "server strips = chars then reflects (use script tag)",
   vuln: "reflected-html", delivery: ["query"], note: "= is stripped; use a tag that needs no attribute value")
 maze_get "/obfuscation/level5/" do |env|
-  query = env.params.query["query"].gsub("=", "")
+  query = env.params.query.fetch("query", "").gsub("=", "")
 
   "<html><body>
   <h1>Obfuscation Level 5</h1>
@@ -71,7 +71,7 @@ end
 Xssmaze.push("obfuscation-level6", "/obfuscation/level6/?query=a", "server strips parentheses then reflects (use backticks)",
   vuln: "reflected-html", delivery: ["query"], note: "parentheses stripped; use backticks or a paren-free vector")
 maze_get "/obfuscation/level6/" do |env|
-  query = env.params.query["query"].gsub("(", "").gsub(")", "")
+  query = env.params.query.fetch("query", "").gsub("(", "").gsub(")", "")
 
   "<html><body>
   <h1>Obfuscation Level 6</h1>

--- a/src/mazes/payload_filter_xss.cr
+++ b/src/mazes/payload_filter_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("payloadfilt-level1", "/payloadfilt/level1/?query=a", "blocks < and > together, reflected in input value (attr breakout)",
   vuln: "reflected-attr", delivery: ["query"], note: "the request is only blocked when it contains both < and >; the reflection is in an input value, so an attribute breakout needs neither")
 maze_get "/payloadfilt/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.includes?("<") && query.includes?(">")
     "<html><body><p>Blocked: angle brackets not allowed</p></body></html>"
@@ -15,7 +15,7 @@ end
 Xssmaze.push("payloadfilt-level2", "/payloadfilt/level2/?query=a", "blocks 'script' keyword (case insensitive), use img/svg tags",
   vuln: "reflected-html", delivery: ["query"], note: "requests containing \"script\" are blocked; other tags are not")
 maze_get "/payloadfilt/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.downcase.includes?("script")
     "<html><body><p>Blocked: script keyword detected</p></body></html>"
@@ -28,7 +28,7 @@ end
 Xssmaze.push("payloadfilt-level3", "/payloadfilt/level3/?query=a", "blocks input >80 chars with <, use short payload",
   vuln: "reflected-html", delivery: ["query"], note: "only blocked when the value is over 80 characters *and* contains <")
 maze_get "/payloadfilt/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.size > 80 && query.includes?("<")
     "<html><body><p>Blocked: payload too long with HTML</p></body></html>"
@@ -41,7 +41,7 @@ end
 Xssmaze.push("payloadfilt-level4", "/payloadfilt/level4/?query=a", "blocks alert(/confirm(/prompt(, use alternative JS functions",
   vuln: "reflected-html", delivery: ["query"], note: "alert(, confirm( and prompt( are blocked by name; other calls are not")
 maze_get "/payloadfilt/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.downcase.includes?("alert(") || query.downcase.includes?("confirm(") || query.downcase.includes?("prompt(")
     "<html><body><p>Blocked: dangerous function call detected</p></body></html>"
@@ -54,7 +54,7 @@ end
 Xssmaze.push("payloadfilt-level5", "/payloadfilt/level5/?query=a", "blocks opening HTML tag pattern, reflected in attr (attr breakout)",
   vuln: "reflected-attr", delivery: ["query"], note: "the block pattern is <\\w+ followed by a space or slash, so <script> and </script> slip past it entirely; the reflection is in an input value")
 maze_get "/payloadfilt/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.matches?(/<\w+[\s\/]/)
     "<html><body><p>Blocked: HTML tag pattern detected</p></body></html>"
@@ -67,7 +67,7 @@ end
 Xssmaze.push("payloadfilt-level6", "/payloadfilt/level6/?query=a", "blocks on...= pattern (event handlers), use script tags instead",
   vuln: "reflected-html", delivery: ["query"], note: "any on...= sequence is blocked, so use a tag that needs no event handler")
 maze_get "/payloadfilt/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   if query.matches?(/on.+=/i)
     "<html><body><p>Blocked: event handler pattern detected</p></body></html>"

--- a/src/mazes/post.cr
+++ b/src/mazes/post.cr
@@ -4,7 +4,7 @@ maze_get "/post/level1/" do |_|
   "<form action='/post/level1/' method='post'><input type='text' name='query' value='a'><input type='submit'></form>"
 end
 maze_post "/post/level1/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "").as(String)
   "query: #{query}"
 end
 
@@ -22,6 +22,6 @@ maze_get "/post/level2/" do |_|
        </script>"
 end
 maze_post "/post/level2/" do |env|
-  query = env.params.json["query"].as(String)
+  query = env.params.json.fetch("query", "").as(String)
   "query: #{query}"
 end

--- a/src/mazes/prototype_pollution_xss.cr
+++ b/src/mazes/prototype_pollution_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("prototype-pollution-level1", "/prototype-pollution/level1/?query=a", "prototype pollution via __proto__ + innerHTML gadget",
   vuln: "prototype-pollution", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "JSON merged into Object.prototype; the polluted `html` key is the innerHTML gadget")
 maze_get "/prototype-pollution/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Prototype Pollution Level 1</h1>
@@ -38,7 +38,7 @@ end
 Xssmaze.push("prototype-pollution-level2", "/prototype-pollution/level2/?query=a", "prototype pollution via constructor.prototype + src gadget",
   vuln: "prototype-pollution", sources: ["server-reflected"], sinks: ["script.src"], delivery: ["query"], note: "the polluted `src` key becomes the src of a dynamically created <script>")
 maze_get "/prototype-pollution/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Prototype Pollution Level 2</h1>
@@ -74,7 +74,7 @@ end
 Xssmaze.push("prototype-pollution-level3", "/prototype-pollution/level3/?query=a", "prototype pollution via Object.assign + srcdoc gadget",
   vuln: "prototype-pollution", sources: ["server-reflected"], sinks: ["srcdoc"], delivery: ["query"], note: "the polluted `srcdoc` key reaches an iframe srcdoc")
 maze_get "/prototype-pollution/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Prototype Pollution Level 3</h1>

--- a/src/mazes/recursive_filter_xss.cr
+++ b/src/mazes/recursive_filter_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("recfilt-level1", "/recfilt/level1/?query=a", "strip <script non-recursively (single pass)",
   vuln: "reflected-html", delivery: ["query"], note: "only the literal <script prefix is stripped, in a single pass; every other tag is untouched")
 maze_get "/recfilt/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/<script/i, "")
 
   "<html><body>#{filtered}</body></html>"
@@ -12,7 +12,7 @@ end
 Xssmaze.push("recfilt-level2", "/recfilt/level2/?query=a", "strip on* event handlers non-recursively",
   vuln: "reflected-html", delivery: ["query"], note: "event-handler attributes are stripped, but tags are not")
 maze_get "/recfilt/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/\bon\w+\s*=/i, "")
 
   "<html><body>#{filtered}</body></html>"
@@ -22,7 +22,7 @@ end
 Xssmaze.push("recfilt-level3", "/recfilt/level3/?query=a", "replace first < only",
   vuln: "reflected-html", delivery: ["query"], note: "only the first < is removed; double it")
 maze_get "/recfilt/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.sub("<", "")
 
   "<html><body>#{filtered}</body></html>"
@@ -32,7 +32,7 @@ end
 Xssmaze.push("recfilt-level4", "/recfilt/level4/?query=a", "strip javascript: non-recursively in href context",
   vuln: "reflected-attr", delivery: ["query"], note: "javascript: is stripped in a single pass, so javajavascript:script: survives it; the double-quoted href can also just be broken out of")
 maze_get "/recfilt/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/javascript:/i, "")
 
   "<html><body><a href=\"#{filtered}\">link</a></body></html>"
@@ -42,7 +42,7 @@ end
 Xssmaze.push("recfilt-level5", "/recfilt/level5/?query=a", "double-escape quotes in JS string context",
   vuln: "reflected-js", delivery: ["query"], note: "the backslash is not escaped, so a leading backslash neutralises the quote escape; closing the <script> block also works")
 maze_get "/recfilt/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub("\"", "\\\"")
 
   "<html><body>
@@ -54,7 +54,7 @@ end
 Xssmaze.push("recfilt-level6", "/recfilt/level6/?query=a", "strip parentheses non-recursively",
   vuln: "reflected-html", delivery: ["query"], note: "parentheses are stripped from the input, but an entity-encoded paren inside an injected attribute decodes after the filter, and tagged-template syntax needs none at all")
 maze_get "/recfilt/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/[()]/, "")
 
   "<html><body>#{filtered}</body></html>"

--- a/src/mazes/response_header_xss.cr
+++ b/src/mazes/response_header_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("respheader-level1", "/respheader/level1/?query=a", "nosniff header with text/html, raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "nosniff is not a control here: the response really is text/html, so the reflection executes")
 maze_get "/respheader/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
   env.response.headers["X-Content-Type-Options"] = "nosniff"
 
@@ -18,7 +18,7 @@ end
 Xssmaze.push("respheader-level2", "/respheader/level2/?query=a", "X-XSS-Protection disabled, raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "X-XSS-Protection is dead in every current browser, so the header changes nothing either way")
 maze_get "/respheader/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
   env.response.headers["X-XSS-Protection"] = "0"
 
@@ -33,7 +33,7 @@ end
 Xssmaze.push("respheader-level3", "/respheader/level3/?query=a", "cache-control headers with raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/respheader/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
   env.response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
   env.response.headers["Pragma"] = "no-cache"
@@ -50,7 +50,7 @@ end
 Xssmaze.push("respheader-level4", "/respheader/level4/?query=a", "query in Set-Cookie and body reflection",
   vuln: "reflected-html", delivery: ["query"], note: "the two Set-Cookie copies drop the bytes a cookie value cannot carry; the body reflection is the raw one")
 maze_get "/respheader/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
   # The cookie copies drop the bytes RFC 6265 forbids because Crystal
   # refuses to emit them; the body reflection below stays raw.
@@ -68,7 +68,7 @@ end
 Xssmaze.push("respheader-level5", "/respheader/level5/?query=a", "CORS allow-all with raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/respheader/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
   env.response.headers["Access-Control-Allow-Origin"] = "*"
   env.response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
@@ -85,7 +85,7 @@ end
 Xssmaze.push("respheader-level6", "/respheader/level6/?query=a", "all security headers except CSP, raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "every security header here is present except the one that would matter; with no CSP the inline reflection still runs")
 maze_get "/respheader/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
   env.response.headers["X-Content-Type-Options"] = "nosniff"
   env.response.headers["X-Frame-Options"] = "DENY"

--- a/src/mazes/semantic_tag_xss.cr
+++ b/src/mazes/semantic_tag_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("semantictag-level1", "/semantictag/level1/?query=a", "reflection in article > p element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Semantic Tag XSS Level 1</h1>
@@ -14,7 +14,7 @@ end
 Xssmaze.push("semantictag-level2", "/semantictag/level2/?query=a", "reflection in section > h2 element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Semantic Tag XSS Level 2</h1>
@@ -26,7 +26,7 @@ end
 Xssmaze.push("semantictag-level3", "/semantictag/level3/?query=a", "reflection in aside element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Semantic Tag XSS Level 3</h1>
@@ -38,7 +38,7 @@ end
 Xssmaze.push("semantictag-level4", "/semantictag/level4/?query=a", "reflection in nav > a link text",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Semantic Tag XSS Level 4</h1>
@@ -50,7 +50,7 @@ end
 Xssmaze.push("semantictag-level5", "/semantictag/level5/?query=a", "reflection in footer element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Semantic Tag XSS Level 5</h1>
@@ -62,7 +62,7 @@ end
 Xssmaze.push("semantictag-level6", "/semantictag/level6/?query=a", "reflection in main > blockquote element",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/semantictag/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Semantic Tag XSS Level 6</h1>

--- a/src/mazes/sink_xss.cr
+++ b/src/mazes/sink_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("sink-level1", "/sink/level1/?query=a", "href with onclick JS handler",
   vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; lands in the JS string of an onclick attribute")
 maze_get "/sink/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><a href=\"#\" onclick=\"location='#{query}'\">Go</a></body></html>"
 end
@@ -11,7 +11,7 @@ end
 Xssmaze.push("sink-level2", "/sink/level2/?query=a", "script location assignment",
   vuln: "reflected-js", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; double quotes are backslash-escaped, so close the <script> block")
 maze_get "/sink/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   escaped = query.gsub("\"", "\\\"")
 
   "<script>if(false) window.location = \"#{escaped}\";</script>"
@@ -21,7 +21,7 @@ end
 Xssmaze.push("sink-level3", "/sink/level3/?query=a", "form action attribute injection",
   vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; reflected into a form action attribute")
 maze_get "/sink/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><form action=\"#{query}\" method=\"get\"><input type=\"submit\" value=\"Go\"></form></body></html>"
 end
@@ -30,7 +30,7 @@ end
 Xssmaze.push("sink-level4", "/sink/level4/?query=a", "embed src attribute injection",
   vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; reflected into an embed src attribute")
 maze_get "/sink/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><embed src=\"#{query}\" type=\"text/html\"></body></html>"
 end
@@ -39,7 +39,7 @@ end
 Xssmaze.push("sink-level5", "/sink/level5/?query=a", "link stylesheet href injection",
   vuln: "reflected-attr", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; reflected into a <link> href, break out and add onload")
 maze_get "/sink/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><link rel=\"stylesheet\" href=\"#{query}\"></head><body>Page</body></html>"
 end
@@ -48,7 +48,7 @@ end
 Xssmaze.push("sink-level6", "/sink/level6/?query=a", "data attribute to innerHTML pipeline",
   vuln: "dom", sources: ["dataset"], sinks: ["innerHTML"], delivery: ["query"], note: "the server reflects into data-content and client JS copies dataset.content into innerHTML — the only genuine DOM flow in this category")
 maze_get "/sink/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <div id=\"target\" data-content=\"#{query}\"></div>
@@ -62,7 +62,7 @@ end
 Xssmaze.push("sink-level7", "/sink/level7/?query=a", "textarea value with form action",
   vuln: "reflected-html", delivery: ["query"], note: "despite the category name this is a server-side reflection, not a client-side DOM sink; reflected inside <textarea>, close the tag first")
 maze_get "/sink/level7/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <form action=\"/sink/level7/result\" method=\"get\">

--- a/src/mazes/slot_xss.cr
+++ b/src/mazes/slot_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("slot-level1", "/slot/level1/?query=a", "shadow DOM <slot> content unfiltered (light DOM reflection)",
   vuln: "reflected-html", delivery: ["query"], note: "light-DOM content slotted into an open shadow root")
 maze_get "/slot/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<x-card>#{query}</x-card>
    <script>
      customElements.define('x-card', class extends HTMLElement {
@@ -16,7 +16,7 @@ end
 Xssmaze.push("slot-level2", "/slot/level2/?query=a", "named slot reflected into element attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into a single-quoted slot= attribute")
 maze_get "/slot/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<x-tab><span slot='#{query}'>tab body</span></x-tab>
    <script>
      customElements.define('x-tab', class extends HTMLElement {
@@ -31,7 +31,7 @@ end
 Xssmaze.push("slot-level3", "/slot/level3/?query=a", "slotchange handler innerHTMLs assignedNodes",
   vuln: "reflected-html", sources: ["textContent"], sinks: ["innerHTML"], delivery: ["query"], note: "the light-DOM reflection already fires; a slotchange handler additionally relays textContent into shadow innerHTML")
 maze_get "/slot/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<x-list>#{query}</x-list>
    <script>
      customElements.define('x-list', class extends HTMLElement {
@@ -51,7 +51,7 @@ end
 Xssmaze.push("slot-level4", "/slot/level4/?query=a", "shadow root opens with mode=open, host innerHTML sink",
   vuln: "dom", sources: ["server-reflected"], sinks: ["attachShadow.innerHTML"], delivery: ["query"], note: "query.to_json blocks JS-string breakout, but the value still reaches innerHTML as raw HTML")
 maze_get "/slot/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<x-host></x-host>
    <script>
      var el = document.querySelector('x-host');

--- a/src/mazes/special_tag_xss.cr
+++ b/src/mazes/special_tag_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("specialtag-level1", "/specialtag/level1/?query=a", "reflection in option value attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/specialtag/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><select><option value=\"#{query}\">Choose</option></select></body></html>"
 end
@@ -11,7 +11,7 @@ end
 Xssmaze.push("specialtag-level2", "/specialtag/level2/?query=a", "reflection in meta tag content",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/specialtag/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><meta name=\"description\" content=\"#{query}\"></head><body>Page</body></html>"
 end
@@ -20,7 +20,7 @@ end
 Xssmaze.push("specialtag-level3", "/specialtag/level3/?query=a", "button value attribute (formaction possible)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/specialtag/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><form><button type=\"submit\" value=\"#{query}\">Submit</button></form></body></html>"
 end
@@ -29,7 +29,7 @@ end
 Xssmaze.push("specialtag-level4", "/specialtag/level4/?query=a", "base tag href injection",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/specialtag/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><base href=\"#{query}\"></head><body><a href=\"/test\">Link</a></body></html>"
 end
@@ -38,7 +38,7 @@ end
 Xssmaze.push("specialtag-level5", "/specialtag/level5/?query=a", "img alt attribute (angle stripped)",
   vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped, so break out of the quote and add a handler to the image itself; /logo.png does not exist, so an injected onerror fires on its own")
 maze_get "/specialtag/level5/" do |env|
-  query = Filters.strip_angles(env.params.query["query"])
+  query = Filters.strip_angles(env.params.query.fetch("query", ""))
 
   "<html><body><img src=\"/logo.png\" alt=\"#{query}\"></body></html>"
 end
@@ -47,7 +47,7 @@ end
 Xssmaze.push("specialtag-level6", "/specialtag/level6/?query=a", "iframe srcdoc attribute injection",
   vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "the srcdoc attribute is double-quoted, so quote the injected markup with single quotes or entities")
 maze_get "/specialtag/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><iframe srcdoc=\"#{query}\"></iframe></body></html>"
 end
@@ -56,7 +56,7 @@ end
 Xssmaze.push("specialtag-level7", "/specialtag/level7/?query=a", "object data attribute injection",
   vuln: "reflected-attr", delivery: ["query"], note: "an object data URL is not a script sink on its own; break out of the double-quoted attribute")
 maze_get "/specialtag/level7/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><object data=\"#{query}\" type=\"text/html\"></object></body></html>"
 end
@@ -65,7 +65,7 @@ end
 Xssmaze.push("specialtag-level8", "/specialtag/level8/?query=a", "unquoted src attribute injection",
   vuln: "reflected-attr", delivery: ["query"], note: "the src attribute is unquoted, so a space is enough to start a new attribute")
 maze_get "/specialtag/level8/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><img src=#{query} alt=image></body></html>"
 end

--- a/src/mazes/svg_context_xss.cr
+++ b/src/mazes/svg_context_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("svgctx-level1", "/svgctx/level1/?query=a", "SVG text element injection (break out and inject onload)",
   vuln: "reflected-html", delivery: ["query"], note: "the reflection sits in SVG foreign content; close </text> before injecting")
 maze_get "/svgctx/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG Context Level 1</h1>
@@ -19,7 +19,7 @@ end
 Xssmaze.push("svgctx-level2", "/svgctx/level2/?query=a", "SVG desc element injection (break out of desc)",
   vuln: "reflected-html", delivery: ["query"], note: "SVG <desc> holds parsed content; close </desc> before injecting")
 maze_get "/svgctx/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG Context Level 2</h1>
@@ -35,7 +35,7 @@ end
 Xssmaze.push("svgctx-level3", "/svgctx/level3/?query=a", "SVG title element injection (break out of title)",
   vuln: "reflected-html", delivery: ["query"], note: "this is the SVG <title>, not the document title; close </title> before injecting")
 maze_get "/svgctx/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG Context Level 3</h1>
@@ -51,7 +51,7 @@ end
 Xssmaze.push("svgctx-level4", "/svgctx/level4/?query=a", "SVG xlink:href attribute injection (javascript: protocol)",
   vuln: "reflected-attr", delivery: ["query"], note: "an SVG anchor takes a javascript: URL, but that needs a click; a quote breakout does not")
 maze_get "/svgctx/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG Context Level 4</h1>
@@ -68,7 +68,7 @@ end
 Xssmaze.push("svgctx-level5", "/svgctx/level5/?query=a", "SVG foreignObject HTML injection",
   vuln: "reflected-html", delivery: ["query"], note: "inside foreignObject the content is ordinary XHTML, so a plain HTML payload works with no SVG-specific tricks")
 maze_get "/svgctx/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG Context Level 5</h1>
@@ -87,7 +87,7 @@ end
 Xssmaze.push("svgctx-level6", "/svgctx/level6/?query=a", "SVG animate values attribute injection (break out of attribute)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/svgctx/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG Context Level 6</h1>

--- a/src/mazes/template_injection.cr
+++ b/src/mazes/template_injection.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("template-injection-level1", "/template/level1/?query=a", "Server-side template injection (basic)",
   vuln: "reflected-html", delivery: ["query"], note: "no template engine runs: the placeholder is filled by a plain string substitution and the result reflected raw, so this is an ordinary HTML-context reflection")
 maze_get "/template/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   template = "Hello {{user_input}}"
   output = template.gsub("{{user_input}}", query)
 
@@ -14,7 +14,7 @@ end
 Xssmaze.push("template-injection-level2", "/template/level2/?query=a", "Client-side template injection (Handlebars style)",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "no Handlebars runs; the value is server-inlined into a JS string and reaches innerHTML through a plain string replace")
 maze_get "/template/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection Level 2</h1>
@@ -32,7 +32,7 @@ end
 Xssmaze.push("template-injection-level3", "/template/level3/?query=a", "Template injection with expression evaluation",
   vuln: "dom", sources: ["server-reflected"], sinks: ["eval", "innerHTML"], delivery: ["query"], note: "the value is server-inlined into a JS string and then concatenated into an eval; breaking out of the outer string literal works too")
 maze_get "/template/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection Level 3</h1>
@@ -53,7 +53,7 @@ end
 Xssmaze.push("template-injection-level4", "/template/level4/?query=a", "Template injection with conditional rendering",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the ternary is decoration; the server-inlined string is concatenated straight into innerHTML")
 maze_get "/template/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection Level 4</h1>
@@ -69,7 +69,7 @@ end
 Xssmaze.push("template-injection-level5", "/template/level5/?query=a", "Template injection with loop rendering",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined as the single element of a JS array that is concatenated into innerHTML")
 maze_get "/template/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection Level 5</h1>
@@ -88,7 +88,7 @@ end
 Xssmaze.push("template-injection-level6", "/template/level6/?query=a", "Template injection with sanitization bypass",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "script tags are entity-encoded before the value is inlined into the JS string, but every other tag reaches innerHTML intact")
 maze_get "/template/level6/" do |env|
-  query = env.params.query["query"].gsub("<script", "&lt;script").gsub("</script>", "&lt;/script&gt;")
+  query = env.params.query.fetch("query", "").gsub("<script", "&lt;script").gsub("</script>", "&lt;/script&gt;")
 
   "<html><body>
   <h1>Template Injection Level 6</h1>

--- a/src/mazes/trusted_types_xss.cr
+++ b/src/mazes/trusted_types_xss.cr
@@ -2,7 +2,7 @@ Xssmaze.push("trustedtypes-level1", "/trustedtypes/level1/?query=a", "Trusted Ty
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "Trusted Types is sent report-only, so the sink is not blocked")
 maze_get "/trustedtypes/level1/" do |env|
   env.response.headers["Content-Security-Policy-Report-Only"] = "require-trusted-types-for 'script'"
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      document.getElementById('out').innerHTML = #{query.to_json};
@@ -13,7 +13,7 @@ Xssmaze.push("trustedtypes-level2", "/trustedtypes/level2/?query=a", "TT enforce
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "Trusted Types enforced, but the page installs a permissive 'default' policy")
 maze_get "/trustedtypes/level2/" do |env|
   env.response.headers["Content-Security-Policy"] = "require-trusted-types-for 'script'; trusted-types default"
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      if (window.trustedTypes && trustedTypes.createPolicy) {
@@ -27,7 +27,7 @@ Xssmaze.push("trustedtypes-level3", "/trustedtypes/level3/?query=a", "TT policy 
   vuln: "dom", sources: ["server-reflected"], sinks: ["trustedtypes.createHTML", "innerHTML"], delivery: ["query"], note: "the Trusted Types policy wraps the value but does not sanitize it")
 maze_get "/trustedtypes/level3/" do |env|
   env.response.headers["Content-Security-Policy"] = "require-trusted-types-for 'script'; trusted-types loose"
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      var p = trustedTypes.createPolicy('loose', { createHTML: function (s) { return '<span>' + s + '</span>'; } });
@@ -38,7 +38,7 @@ end
 Xssmaze.push("trustedtypes-level4", "/trustedtypes/level4/?query=a", "TT only enforced for script, not innerHTML",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "no Trusted Types header is sent on this level at all")
 maze_get "/trustedtypes/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      document.getElementById('out').innerHTML = #{query.to_json};
@@ -49,7 +49,7 @@ Xssmaze.push("trustedtypes-level5", "/trustedtypes/level5/?query=a", "policy str
   vuln: "dom", sources: ["server-reflected"], sinks: ["trustedtypes.createHTML", "innerHTML"], delivery: ["query"], note: "the policy strips <script> only; event-handler attributes still fire")
 maze_get "/trustedtypes/level5/" do |env|
   env.response.headers["Content-Security-Policy"] = "require-trusted-types-for 'script'; trusted-types nso"
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      var p = trustedTypes.createPolicy('nso', {

--- a/src/mazes/unicode_xss.cr
+++ b/src/mazes/unicode_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("unicode-level1", "/unicode/level1/?query=a", "fullwidth normalization (regular ASCII angles still work)",
   vuln: "reflected-html", delivery: ["query"], note: "nothing is filtered here; the fullwidth normalization only adds a second way in beside plain ASCII angles")
 maze_get "/unicode/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Normalize fullwidth to ASCII
   query = query.gsub("\uFF1C", "<").gsub("\uFF1E", ">")
 
@@ -19,7 +19,7 @@ end
 Xssmaze.push("unicode-level2", "/unicode/level2/?query=a", "strip ASCII angles then normalize fullwidth (order-of-ops bypass)",
   vuln: "reflected-html", delivery: ["query"], note: "ASCII angle brackets are stripped before the fullwidth normalization runs, so send U+FF1C and U+FF1E instead")
 maze_get "/unicode/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Step 1: Strip ASCII angle brackets
   query = query.gsub("<", "").gsub(">", "")
   # Step 2: Normalize fullwidth to ASCII (vulnerable: fullwidth survives step 1)
@@ -36,7 +36,7 @@ end
 Xssmaze.push("unicode-level3", "/unicode/level3/?query=a", "null byte stripping only (all other chars reflected)",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/unicode/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub("\0", "")
 
   "<html><body>
@@ -50,7 +50,7 @@ end
 Xssmaze.push("unicode-level4", "/unicode/level4/?query=a", "UTF-7 charset with raw reflection",
   vuln: "reflected-html", delivery: ["query"], note: "no modern browser decodes UTF-7, but the reflection is raw, so a plain payload works regardless of the declared charset")
 maze_get "/unicode/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html; charset=utf-7"
 
   "<html><body>
@@ -64,7 +64,7 @@ end
 Xssmaze.push("unicode-level5", "/unicode/level5/?query=a", "reflection in attribute (RLO/bidi chars allowed)",
   vuln: "reflected-attr", delivery: ["query"], note: "the bidi angle is a red herring: nothing is filtered, so this is a plain double-quoted attribute breakout")
 maze_get "/unicode/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Unicode XSS Level 5</h1>
@@ -77,7 +77,7 @@ end
 Xssmaze.push("unicode-level6", "/unicode/level6/?query=a", "backslash stripping only (angles and quotes allowed)",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/unicode/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub("\\", "")
 
   "<html><body>

--- a/src/mazes/worker_xss.cr
+++ b/src/mazes/worker_xss.cr
@@ -5,7 +5,7 @@
 Xssmaze.push("worker-level1", "/worker/level1/?query=a", "page innerHTMLs whatever the worker postMessages back",
   vuln: "dom", sources: ["worker-message"], sinks: ["innerHTML"], delivery: ["query"])
 maze_get "/worker/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      var b = new Blob(['onmessage = function (e) { self.postMessage(e.data) }'], { type: 'application/javascript' });
@@ -18,7 +18,7 @@ end
 Xssmaze.push("worker-level2", "/worker/level2/?query=a", "Worker source built by string concat (untrusted code in worker)",
   vuln: "dom", sources: ["worker-message"], sinks: ["worker-source", "innerHTML"], delivery: ["query"], note: "the value is concatenated into the Worker source, so it also runs as JS inside the worker")
 maze_get "/worker/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      // The query is concatenated into the worker source; any code there runs in
@@ -33,7 +33,7 @@ end
 Xssmaze.push("worker-level3", "/worker/level3/?query=a", "importScripts() with attacker-controlled URL",
   vuln: "dom", sources: ["worker-message"], sinks: ["importScripts", "innerHTML"], delivery: ["query"], note: "the worker importScripts() an attacker URL; its postMessage output lands in page innerHTML")
 maze_get "/worker/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      // Worker pulls remote script via importScripts(query); any side-effect the
@@ -48,7 +48,7 @@ end
 Xssmaze.push("worker-level4", "/worker/level4/?query=a", "worker eval gadget: page posts query, worker eval()s, returns to innerHTML",
   vuln: "dom", sources: ["worker-message"], sinks: ["eval", "innerHTML"], delivery: ["query"])
 maze_get "/worker/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      var src = 'onmessage = function (e) { try { self.postMessage(eval(e.data)) } catch (err) { self.postMessage(String(err)) } }';

--- a/src/mazes/wrapper_context_xss.cr
+++ b/src/mazes/wrapper_context_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("wrappercontext-level1", "/wrappercontext/level1/?query=a", "reflection wrapped in bold+italic tags",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><b><i>#{query}</i></b></body></html>"
 end
@@ -11,7 +11,7 @@ end
 Xssmaze.push("wrappercontext-level2", "/wrappercontext/level2/?query=a", "reflection wrapped in styled span",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><span style=\"color:red\">#{query}</span></body></html>"
 end
@@ -20,7 +20,7 @@ end
 Xssmaze.push("wrappercontext-level3", "/wrappercontext/level3/?query=a", "reflection wrapped in anchor tag text",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><a href=\"#\">#{query}</a></body></html>"
 end
@@ -29,7 +29,7 @@ end
 Xssmaze.push("wrappercontext-level4", "/wrappercontext/level4/?query=a", "reflection wrapped in small+em tags",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><small><em>#{query}</em></small></body></html>"
 end
@@ -38,7 +38,7 @@ end
 Xssmaze.push("wrappercontext-level5", "/wrappercontext/level5/?query=a", "reflection wrapped in mark tag",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><mark>#{query}</mark></body></html>"
 end
@@ -47,7 +47,7 @@ end
 Xssmaze.push("wrappercontext-level6", "/wrappercontext/level6/?query=a", "reflection wrapped in abbr tag",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/wrappercontext/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><abbr title=\"abbreviation\">#{query}</abbr></body></html>"
 end


### PR DESCRIPTION
## What changed

768 of 1031 GET mazes on `main` answered **HTTP 500** to a bare request with no query
string, because a non-optional read (`env.params.query["query"]`) raises `KeyError` when the
parameter is absent and Kemal turns that into a 500. A scanner that crawls `/sitemap.xml`
(paths with the query string stripped) or fuzzes one parameter at a time hits a wall of 500s
instead of a reflection — the maze never gets to teach its lesson.

This slice (**S3**) converts every non-optional query/body/json read in its 36 files to a
defaulting read, the same bargain the lab already struck for cookies in
`Xssmaze.cookie_value`:

- `env.params.query["x"]` → `env.params.query.fetch("x", "")`
- `env.params.body["x"].as(String)` → `env.params.body.fetch("x", "").as(String)`
- `env.params.json["x"].as(String)` → `env.params.json.fetch("x", "").as(String)`

**200 reads across 36 files** (199 query/body + 1 json). The default is a plain empty string
everywhere; wrapping filters, `gsub` chains and the `[0, 60]` slice are preserved verbatim
(`"".fetch(...)[0, 60]` is `""`, no `IndexError`). No `Xssmaze.push(...)` metadata touched, no
`env.params.url[...]` path reads touched, no header reads touched.

## How I verified it

Built a **before** binary from `origin/main`'s version of my 36 files and an **after** binary
from this branch, then ran identical sweeps against both (205 mazes in the slice).

**1. Bare-GET sweep** (each maze path, no query string; POST mazes get an empty body):

| | 5xx count |
|---|---|
| before | **199** |
| after | **0** |

**2. Isolated-parameter sweep** — every maze declaring >1 parameter (`edge-level5` q1/q2,
`edge-level7` a/b/c), each parameter sent alone with a payload: **0 5xx** before and after
(those two already used `fetch`; the sweep confirms sending one param no longer trips the
others).

**3. Nothing else moved** — captured each maze's response body at its catalog URL
(present-parameter path) on both binaries and diffed:

```
$ diff -rq before after
Files before/nonce-level1 and after/nonce-level1 differ
Files before/nonce-level2 and after/nonce-level2 differ
```

Those two carry a per-request random CSP nonce (`Random::Secure.hex(16)`); masking the 32-hex
nonce makes both **byte-identical**. The other **203 bodies are byte-for-byte equal**.

**4. CI gates**

```
crystal spec          194 examples, 0 failures, 0 errors, 0 pending
crystal tool format --check   clean
ameba src/            196 inspected, 0 failures
```

## For the reviewer

- Rebased on current `main` (after S1 #54 / S2 #53 merged); my files are disjoint from theirs.
- `spec/smoke_spec.cr` is intentionally left alone — the orchestrator extends it once all
  slices land.
- The only intentional behaviour change is for the *absent*-parameter case; the
  present-parameter reflection stays raw and byte-identical (proof above).
