### PR TITLE
fix(mazes): default missing params instead of 500 (slice S4)

### DIFF
--- a/src/mazes/advanced_xss.cr
+++ b/src/mazes/advanced_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("advanced-xss-level1", "/advanced/level1/?query=a", "XSS with WAF bypass using encoding",
   vuln: "reflected-html", delivery: ["query"], note: "the filter strips script/javascript/onload in a single pass, so scrscriptipt survives; onerror is not filtered at all")
 maze_get "/advanced/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Simulate basic WAF filtering
   filtered_query = query.gsub("script", "").gsub("javascript", "").gsub("onload", "")
 
@@ -14,7 +14,7 @@ end
 Xssmaze.push("advanced-xss-level2", "/advanced/level2/?query=a", "XSS with mutation observer",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined into a JS string; a MutationObserver then re-applies the added text node's textContent as innerHTML")
 maze_get "/advanced/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Advanced XSS Level 2</h1>
@@ -47,7 +47,7 @@ end
 Xssmaze.push("advanced-xss-level3", "/advanced/level3/?query=a", "XSS with Service Worker",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "no service worker is ever registered; the value is server-inlined into a JS object literal and written to innerHTML on load")
 maze_get "/advanced/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Advanced XSS Level 3</h1>
@@ -70,7 +70,7 @@ end
 Xssmaze.push("advanced-xss-level4", "/advanced/level4/?query=a", "XSS with Web Components",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined into the custom element's connectedCallback innerHTML string")
 maze_get "/advanced/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Advanced XSS Level 4</h1>
@@ -95,7 +95,7 @@ end
 Xssmaze.push("advanced-xss-level5", "/advanced/level5/?query=a", "XSS with Trusted Types bypass",
   vuln: "dom", sources: ["server-reflected"], sinks: ["trustedtypes.createHTML", "innerHTML"], delivery: ["query"], note: "the policy returns its input unchanged, and browsers without Trusted Types take an identical unguarded innerHTML path")
 maze_get "/advanced/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Advanced XSS Level 5</h1>
@@ -126,7 +126,7 @@ end
 Xssmaze.push("advanced-xss-level6", "/advanced/level6/?query=a", "XSS with Proxy object manipulation",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is server-inlined into a JS string that a Proxy get trap forwards to innerHTML")
 maze_get "/advanced/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Advanced XSS Level 6</h1>

--- a/src/mazes/api_response_xss.cr
+++ b/src/mazes/api_response_xss.cr
@@ -5,7 +5,7 @@
 Xssmaze.push("api-response-level1", "/api-response/level1/?query=a", "JSON-like response with text/html content type",
   vuln: "reflected-html", delivery: ["query"], note: "JSON-shaped body served as text/html, so markup inside the string value is parsed as HTML")
 maze_get "/api-response/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "{\"message\":\"#{query}\",\"status\":\"ok\"}"
@@ -18,7 +18,7 @@ end
 Xssmaze.push("api-response-level2", "/api-response/level2/?query=a", "XML response with text/html content type",
   vuln: "reflected-html", delivery: ["query"], note: "XML-shaped body served as text/html, so the element text is parsed as HTML")
 maze_get "/api-response/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "<response><message>#{query}</message></response>"
@@ -31,7 +31,7 @@ end
 Xssmaze.push("api-response-level3", "/api-response/level3/?query=a", "CSV-like response with text/html content type",
   vuln: "reflected-html", delivery: ["query"], note: "CSV-shaped body served as text/html")
 maze_get "/api-response/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "name,value\nresult,#{query}"
@@ -44,7 +44,7 @@ end
 Xssmaze.push("api-response-level4", "/api-response/level4/?query=a", "JSONP callback response with text/html content type",
   vuln: "reflected-html", delivery: ["query"], note: "JSONP-shaped body served as text/html; it is never executed as script, so inject markup instead of breaking out of the JS string")
 maze_get "/api-response/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "jsonpCallback({\"data\":\"#{query}\"})"
@@ -56,7 +56,7 @@ end
 Xssmaze.push("api-response-level5", "/api-response/level5/?query=a", "HTML fragment response without full document structure",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/api-response/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "<div class=\"result\">#{query}</div>"
@@ -69,7 +69,7 @@ end
 Xssmaze.push("api-response-level6", "/api-response/level6/?query=a", "Plain text error response with text/html content type",
   vuln: "reflected-html", delivery: ["query"], note: "plain-text-looking body, but the response is served as text/html")
 maze_get "/api-response/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "Error: #{query}"

--- a/src/mazes/boolean_attr_xss.cr
+++ b/src/mazes/boolean_attr_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("booleanattr-level1", "/booleanattr/level1/?query=true", "boolean attr context in checkbox checked",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Boolean Attr XSS Level 1</h1>
@@ -14,7 +14,7 @@ end
 Xssmaze.push("booleanattr-level2", "/booleanattr/level2/?query=true", "boolean attr context in select multiple",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Boolean Attr XSS Level 2</h1>
@@ -26,7 +26,7 @@ end
 Xssmaze.push("booleanattr-level3", "/booleanattr/level3/?query=true", "boolean attr context in input readonly",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Boolean Attr XSS Level 3</h1>
@@ -38,7 +38,7 @@ end
 Xssmaze.push("booleanattr-level4", "/booleanattr/level4/?query=true", "boolean attr context in button disabled",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Boolean Attr XSS Level 4</h1>
@@ -50,7 +50,7 @@ end
 Xssmaze.push("booleanattr-level5", "/booleanattr/level5/?query=true", "boolean attr context in details open",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Boolean Attr XSS Level 5</h1>
@@ -62,7 +62,7 @@ end
 Xssmaze.push("booleanattr-level6", "/booleanattr/level6/?query=true", "boolean attr context in input autofocus",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/booleanattr/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Boolean Attr XSS Level 6</h1>

--- a/src/mazes/cms_pattern_xss.cr
+++ b/src/mazes/cms_pattern_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("cmspattern-level1", "/cmspattern/level1/?query=a", "WordPress post title raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><h1 class=\"entry-title\">#{query}</h1></body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("cmspattern-level2", "/cmspattern/level2/?query=a", "WordPress widget title raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"widget\"><h3 class=\"widget-title\">#{query}</h3></div></body></html>"
 end
@@ -23,7 +23,7 @@ end
 Xssmaze.push("cmspattern-level3", "/cmspattern/level3/?query=a", "Drupal field body raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"field field--name-body\"><p>#{query}</p></div></body></html>"
 end
@@ -33,7 +33,7 @@ end
 Xssmaze.push("cmspattern-level4", "/cmspattern/level4/?query=a", "Joomla module heading raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"moduletable\"><h3>#{query}</h3><div class=\"module-body\">content</div></div></body></html>"
 end
@@ -43,7 +43,7 @@ end
 Xssmaze.push("cmspattern-level5", "/cmspattern/level5/?query=a", "Ghost blog excerpt raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><p class=\"post-card-excerpt\">#{query}</p></body></html>"
 end
@@ -53,7 +53,7 @@ end
 Xssmaze.push("cmspattern-level6", "/cmspattern/level6/?query=a", "Medium-style article content raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/cmspattern/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><article><section><div class=\"section-content\"><p>#{query}</p></div></section></article></body></html>"
 end

--- a/src/mazes/context_escape_v2_xss.cr
+++ b/src/mazes/context_escape_v2_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("ctxv2-level1", "/ctxv2/level1/?query=a", "reflection inside HTML comment (close with -->)",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside an HTML comment; close it with -->")
 maze_get "/ctxv2/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><!-- Search query: #{query} --><div>Welcome</div></body></html>"
 end
@@ -16,7 +16,7 @@ end
 Xssmaze.push("ctxv2-level2", "/ctxv2/level2/?query=a", "reflection inside textarea tag (close tag escape)",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside <textarea> raw-text; close it with </textarea>")
 maze_get "/ctxv2/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><h2>Edit your message:</h2><textarea name=\"message\" rows=\"5\" cols=\"40\">#{query}</textarea></body></html>"
 end
@@ -28,7 +28,7 @@ end
 Xssmaze.push("ctxv2-level3", "/ctxv2/level3/?query=a", "reflection inside title tag (close tag escape)",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside <title> raw-text; close it with </title>")
 maze_get "/ctxv2/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><title>Search: #{query}</title></head><body><h2>Results</h2><p>Searching...</p></body></html>"
 end
@@ -40,7 +40,7 @@ end
 Xssmaze.push("ctxv2-level4", "/ctxv2/level4/?query=a", "reflection inside style tag (close tag escape)",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside <style>; close it with </style> to inject markup")
 maze_get "/ctxv2/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><style>.user-theme { color: #{query}; }</style></head><body><div class=\"user-theme\">Styled content</div></body></html>"
 end
@@ -52,7 +52,7 @@ end
 Xssmaze.push("ctxv2-level5", "/ctxv2/level5/?query=a", "reflection inside noscript tag (close tag escape)",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside <noscript>; close it with </noscript>")
 maze_get "/ctxv2/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><noscript>JavaScript required. Your search: #{query}</noscript><div>Main content</div></body></html>"
 end
@@ -67,7 +67,7 @@ end
 Xssmaze.push("ctxv2-level6", "/ctxv2/level6/?query=a", "reflection in iframe srcdoc (HTML entity injection via unescaped &)",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into an iframe srcdoc; < and > are entity-encoded but the quote and & are not, so break the attribute or send pre-encoded entities that decode inside the srcdoc")
 maze_get "/ctxv2/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Encode < and > to prevent direct attribute breakout, but leave & intact
   # This means pre-encoded HTML entities in the input survive and get rendered in srcdoc
   filtered = query.gsub("<", "&lt;").gsub(">", "&gt;")

--- a/src/mazes/dashboard_xss.cr
+++ b/src/mazes/dashboard_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("dashboard-level1", "/dashboard/level1/?query=a", "dashboard card header raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"card\"><div class=\"card-header\">#{query}</div></div></body></html>"
 end
@@ -14,7 +14,7 @@ end
 Xssmaze.push("dashboard-level2", "/dashboard/level2/?query=a", "admin table cell dual reflection (attr + body)",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into both a title attribute and the cell body; the body is a direct HTML injection")
 maze_get "/dashboard/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><table><tr><td class=\"text-truncate\" title=\"#{query}\">#{query}</td></tr></table></body></html>"
 end
@@ -24,7 +24,7 @@ end
 Xssmaze.push("dashboard-level3", "/dashboard/level3/?query=a", "notification alert raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"alert alert-info\" role=\"alert\">#{query}</div></body></html>"
 end
@@ -34,7 +34,7 @@ end
 Xssmaze.push("dashboard-level4", "/dashboard/level4/?query=a", "sidebar nav-link raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><ul class=\"nav\"><li class=\"nav-item\"><a class=\"nav-link\" href=\"#\">#{query}</a></li></ul></body></html>"
 end
@@ -44,7 +44,7 @@ end
 Xssmaze.push("dashboard-level5", "/dashboard/level5/?query=a", "modal body raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"modal\"><div class=\"modal-dialog\"><div class=\"modal-content\"><div class=\"modal-body\"><p>#{query}</p></div></div></div></div></body></html>"
 end
@@ -54,7 +54,7 @@ end
 Xssmaze.push("dashboard-level6", "/dashboard/level6/?query=a", "status badge raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/dashboard/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><span class=\"badge badge-primary\">#{query}</span></body></html>"
 end

--- a/src/mazes/double_encoding_xss.cr
+++ b/src/mazes/double_encoding_xss.cr
@@ -6,7 +6,7 @@ require "base64"
 Xssmaze.push("dblenc-level1", "/dblenc/level1/?query=a", "double URL decode before reflection",
   vuln: "reflected-html", delivery: ["query"], note: "two extra URL decodes on top of the framework's own, so percent-encoded payloads arrive as raw markup")
 maze_get "/dblenc/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   begin
     decoded = URI.decode(URI.decode(query))
@@ -25,7 +25,7 @@ end
 Xssmaze.push("dblenc-level2", "/dblenc/level2/?query=a", "HTML entity decode before reflection",
   vuln: "reflected-html", delivery: ["query"], note: "&lt; and &gt; are decoded back to angle brackets before reflection")
 maze_get "/dblenc/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   decoded = query
     .gsub("&lt;", "<")
@@ -45,7 +45,7 @@ end
 Xssmaze.push("dblenc-level3", "/dblenc/level3/?query=YQ==", "base64 decode before reflection",
   vuln: "reflected-html", delivery: ["query"], note: "the parameter must be base64; anything that fails to decode is replaced with a fixed error string, so a raw payload never reaches the page")
 maze_get "/dblenc/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   begin
     decoded = Base64.decode_string(query)
@@ -64,7 +64,7 @@ end
 Xssmaze.push("dblenc-level4", "/dblenc/level4/?query=a", "single URL decode before reflection",
   vuln: "reflected-html", delivery: ["query"], note: "the server URL-decodes once before reflecting")
 maze_get "/dblenc/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   begin
     decoded = URI.decode(query)

--- a/src/mazes/ecommerce_xss.cr
+++ b/src/mazes/ecommerce_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("ecommerce-level1", "/ecommerce/level1/?query=a", "product name raw reflection with itemprop",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><h1 class=\"product-title\" itemprop=\"name\">#{query}</h1></body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("ecommerce-level2", "/ecommerce/level2/?query=a", "product price raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><span class=\"price\">$#{query}</span></body></html>"
 end
@@ -23,7 +23,7 @@ end
 Xssmaze.push("ecommerce-level3", "/ecommerce/level3/?query=a", "search filter tag raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"filter-tag\"><span>#{query}</span><a href=\"#\" class=\"remove\">x</a></div></body></html>"
 end
@@ -33,7 +33,7 @@ end
 Xssmaze.push("ecommerce-level4", "/ecommerce/level4/?query=a", "cart item name in table cell raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><table><thead><tr><th>Item</th><th>Qty</th><th>Price</th></tr></thead><tbody><tr><td class=\"cart-item-name\">#{query}</td><td>1</td><td>$9.99</td></tr></tbody></table></body></html>"
 end
@@ -43,7 +43,7 @@ end
 Xssmaze.push("ecommerce-level5", "/ecommerce/level5/?query=a", "review body raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div class=\"review-body\"><p>#{query}</p></div></body></html>"
 end
@@ -53,7 +53,7 @@ end
 Xssmaze.push("ecommerce-level6", "/ecommerce/level6/?query=a", "breadcrumb active item raw reflection",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/ecommerce/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><ol class=\"breadcrumb\"><li>Home</li><li>Products</li><li class=\"active\">#{query}</li></ol></body></html>"
 end

--- a/src/mazes/encoding_edge_xss.cr
+++ b/src/mazes/encoding_edge_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("encodingedge-level1", "/encodingedge/level1/?query=a", "only adjacent <> pair encoded, individual < > pass through",
   vuln: "reflected-html", delivery: ["query"], note: "only the adjacent pair <> is entity-encoded; a lone < or > passes through")
 maze_get "/encodingedge/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Only encode the exact string "<>" — individual angle brackets survive
   filtered = query.gsub("<>", "&lt;&gt;")
 
@@ -15,7 +15,7 @@ end
 Xssmaze.push("encodingedge-level2", "/encodingedge/level2/?query=a", "case-sensitive <script strip (mixed case bypass)",
   vuln: "reflected-html", delivery: ["query"], note: "only the lowercase <script prefix is stripped; <Script> or any other tag passes")
 maze_get "/encodingedge/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Case-sensitive strip — only lowercase "<script" is removed
   filtered = query.gsub("<script", "")
 
@@ -27,7 +27,7 @@ end
 Xssmaze.push("encodingedge-level3", "/encodingedge/level3/?query=a", "only first double-quote encoded (sub not gsub)",
   vuln: "reflected-attr", delivery: ["query"], note: "only the first double quote is encoded (sub, not gsub); send a sacrificial quote before the real breakout")
 maze_get "/encodingedge/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Only first " is escaped — second " can break out of attribute
   filtered = query.sub("\"", "&quot;")
 
@@ -39,7 +39,7 @@ end
 Xssmaze.push("encodingedge-level4", "/encodingedge/level4/?query=a", "first 10 chars alpha hex-encoded, rest raw",
   vuln: "reflected-html", delivery: ["query"], note: "alphabetic characters in the first 10 are entity-encoded so they cannot form a tag name; pad with 10 digits before the payload")
 maze_get "/encodingedge/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Hex-encode alpha chars in first 10 characters only
   prefix = query[0, Math.min(10, query.size)]
   suffix = query.size > 10 ? query[10..] : ""
@@ -54,7 +54,7 @@ end
 Xssmaze.push("encodingedge-level5", "/encodingedge/level5/?query=a", "angle brackets to fullwidth, reflected in attribute (quote breakout)",
   vuln: "reflected-attr", delivery: ["query"], note: "angle brackets become fullwidth look-alikes, so no tag can be opened; break out of the double-quoted input value and add an event handler")
 maze_get "/encodingedge/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Convert angle brackets to fullwidth Unicode equivalents
   filtered = query.gsub("<", "\uFF1C").gsub(">", "\uFF1E")
 
@@ -67,7 +67,7 @@ end
 Xssmaze.push("encodingedge-level6", "/encodingedge/level6/?query=a", "regex strips <...> tags from input, reflected in attribute (no angles needed)",
   vuln: "reflected-attr", delivery: ["query"], note: "anything shaped like a tag is regex-stripped; break out of the double-quoted input value and add an event handler, which needs no angle brackets")
 maze_get "/encodingedge/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Strip anything that looks like an HTML tag
   filtered = query.gsub(/<[^>]*>/, "")
 

--- a/src/mazes/event_handler.cr
+++ b/src/mazes/event_handler.cr
@@ -24,34 +24,34 @@ end
 Xssmaze.push("eventhandler-xss-level1", "/eventhandler/level1/?query=a", "eventhandler-xss (basic)",
   vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped, so no tag can be opened; the payload has to be a bare attribute injected into the wrapper <div ...>, e.g. onmouseover=alert(1), and needs its event to fire")
 maze_get "/eventhandler/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   EventHandlerHelper.build_html(query)
 end
 
 Xssmaze.push("eventhandler-xss-level2", "/eventhandler/level2/?query=a", "eventhandler-xss (level 2)",
   vuln: "reflected-attr", delivery: ["query"], note: "as level 1, and onerror/onload/onclick are removed by name; other handlers survive")
 maze_get "/eventhandler/level2/" do |env|
-  query = EventHandlerHelper.sanitize(env.params.query["query"], 2)
+  query = EventHandlerHelper.sanitize(env.params.query.fetch("query", ""), 2)
   EventHandlerHelper.build_html(query)
 end
 
 Xssmaze.push("eventhandler-xss-level3", "/eventhandler/level3/?query=a", "eventhandler-xss (level 3)",
   vuln: "reflected-attr", delivery: ["query"], note: "as level 1, and seven handler names are removed; unlisted ones such as ondblclick survive")
 maze_get "/eventhandler/level3/" do |env|
-  query = EventHandlerHelper.sanitize(env.params.query["query"], 3)
+  query = EventHandlerHelper.sanitize(env.params.query.fetch("query", ""), 3)
   EventHandlerHelper.build_html(query)
 end
 
 Xssmaze.push("eventhandler-xss-level4", "/eventhandler/level4/?query=a", "eventhandler-xss (level 4)",
   vuln: "reflected-attr", delivery: ["query"], note: "as level 1, and animation/drag handlers plus javascript: are removed; ontoggle and onpointerover survive")
 maze_get "/eventhandler/level4/" do |env|
-  query = EventHandlerHelper.sanitize(env.params.query["query"], 4)
+  query = EventHandlerHelper.sanitize(env.params.query.fetch("query", ""), 4)
   EventHandlerHelper.build_html(query)
 end
 
 Xssmaze.push("eventhandler-xss-level5", "/eventhandler/level5/?query=a", "eventhandler-xss (level 5)",
   vuln: "reflected-attr", delivery: ["query"], note: "as level 1, with a long handler denylist stripped in a single pass, so ononclickclick= rejoins into onclick=")
 maze_get "/eventhandler/level5/" do |env|
-  query = EventHandlerHelper.sanitize(env.params.query["query"], 5)
+  query = EventHandlerHelper.sanitize(env.params.query.fetch("query", ""), 5)
   EventHandlerHelper.build_html(query)
 end

--- a/src/mazes/filter_chain_xss.cr
+++ b/src/mazes/filter_chain_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("filterchain-level1", "/filterchain/level1/?query=a", "common tag blacklist (script/img/svg stripped)",
   vuln: "reflected-html", delivery: ["query"], note: "script/img/svg/iframe/object/embed/link/style stripped; use an allowed tag with an event handler (e.g. <details ontoggle>)")
 maze_get "/filterchain/level1/" do |env|
-  query = Filters.strip_tags(env.params.query["query"], ["script", "img", "svg", "iframe", "object", "embed", "link", "style"])
+  query = Filters.strip_tags(env.params.query.fetch("query", ""), ["script", "img", "svg", "iframe", "object", "embed", "link", "style"])
 
   "<html><body>#{query}</body></html>"
 end
@@ -11,7 +11,7 @@ end
 Xssmaze.push("filterchain-level2", "/filterchain/level2/?query=a", "event handlers + script tags stripped",
   vuln: "reflected-html", delivery: ["query"], note: "event handlers and <script> stripped; use a non-event vector")
 maze_get "/filterchain/level2/" do |env|
-  query = Filters.strip_event_handlers(env.params.query["query"])
+  query = Filters.strip_event_handlers(env.params.query.fetch("query", ""))
   query = Filters.strip_tags(query, ["script"])
 
   "<html><body>#{query}</body></html>"
@@ -21,7 +21,7 @@ end
 Xssmaze.push("filterchain-level3", "/filterchain/level3/?query=a", "lowercase + protocol strip in href",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into a double-quoted href after lowercasing and js:/data: strip; break out of the attribute")
 maze_get "/filterchain/level3/" do |env|
-  query = env.params.query["query"].downcase
+  query = env.params.query.fetch("query", "").downcase
   query = Filters.strip_js_protocol(query)
   query = query.gsub(/data\s*:/i, "")
 
@@ -32,7 +32,7 @@ end
 Xssmaze.push("filterchain-level4", "/filterchain/level4/?query=a", "angle encode + double quote strip in single-quote attr",
   vuln: "reflected-attr", delivery: ["query"], note: "single-quoted class attribute; angle brackets entity-encoded and the double quote stripped, so break out with a single quote and add an event handler")
 maze_get "/filterchain/level4/" do |env|
-  query = Filters.encode_angles(env.params.query["query"])
+  query = Filters.encode_angles(env.params.query.fetch("query", ""))
   query = query.gsub("\"", "")
 
   "<html><body><div class='#{query}'>Hello</div></body></html>"
@@ -43,7 +43,7 @@ end
 Xssmaze.push("filterchain-level5", "/filterchain/level5/?query=a", "parens + backtick + angles all stripped",
   vuln: "reflected-attr", delivery: ["query"], note: "double-quoted class attribute; angle brackets, parens and backticks stripped, so break out and use a paren-free handler (e.g. onpointerover=location=name)")
 maze_get "/filterchain/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = Filters.strip_angles(query)
   query = Filters.strip_parens(query)
   query = query.gsub("`", "")
@@ -56,7 +56,7 @@ end
 Xssmaze.push("filterchain-level6", "/filterchain/level6/?query=a", "protocol whitelist bypass in src",
   vuln: "reflected-attr", delivery: ["query"], note: "double-quoted iframe src; js:/data:/vbscript: blacklisted, so break out with the quote and > or use a non-blacklisted protocol")
 maze_get "/filterchain/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = Filters.strip_js_protocol(query)
   query = query.gsub(/data\s*:/i, "")
   query = query.gsub(/vbscript\s*:/i, "")
@@ -68,7 +68,7 @@ end
 Xssmaze.push("filterchain-level7", "/filterchain/level7/?query=a", "angles+quotes stripped, unquoted attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "unquoted input value; angle brackets and quotes removed, so add a space and an event-handler attribute")
 maze_get "/filterchain/level7/" do |env|
-  query = Filters.strip_angles(env.params.query["query"])
+  query = Filters.strip_angles(env.params.query.fetch("query", ""))
   query = Filters.escape_quotes(query)
 
   "<html><body><input type=text value=#{query} name=search></body></html>"
@@ -78,7 +78,7 @@ end
 Xssmaze.push("filterchain-level8", "/filterchain/level8/?query=a", "JS context: close-script + backslash stripped",
   vuln: "reflected-js", delivery: ["query"], note: "single-quoted JS string; </script> and backslash stripped, so break out with a single quote")
 maze_get "/filterchain/level8/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub("</script>", "").gsub("\\", "")
 
   "<script>var q = '#{query}';</script>"

--- a/src/mazes/form_element_xss.cr
+++ b/src/mazes/form_element_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("formelement-level1", "/formelement/level1/?query=a", "reflection in input placeholder attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Form Element XSS Level 1</h1>
@@ -14,7 +14,7 @@ end
 Xssmaze.push("formelement-level2", "/formelement/level2/?query=a", "reflection in textarea placeholder attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Form Element XSS Level 2</h1>
@@ -26,7 +26,7 @@ end
 Xssmaze.push("formelement-level3", "/formelement/level3/?query=a", "reflection in button title attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Form Element XSS Level 3</h1>
@@ -38,7 +38,7 @@ end
 Xssmaze.push("formelement-level4", "/formelement/level4/?query=a", "reflection in select name attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Form Element XSS Level 4</h1>
@@ -50,7 +50,7 @@ end
 Xssmaze.push("formelement-level5", "/formelement/level5/?query=a", "reflection in option value attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Form Element XSS Level 5</h1>
@@ -62,7 +62,7 @@ end
 Xssmaze.push("formelement-level6", "/formelement/level6/?query=a", "reflection in label for attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/formelement/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Form Element XSS Level 6</h1>

--- a/src/mazes/hidden_reflection_xss.cr
+++ b/src/mazes/hidden_reflection_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("hidden-reflection-level1", "/hidden-reflection/level1/?query=a", "reflection in hidden input (type override)",
   vuln: "reflected-attr", delivery: ["query"], note: "type=hidden, and the parser drops a duplicate type attribute, so an injected handler never fires; break out into a new tag instead")
 maze_get "/hidden-reflection/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><form><input type=\"hidden\" name=\"token\" value=\"#{query}\"></form></body></html>"
 end
@@ -11,7 +11,7 @@ end
 Xssmaze.push("hidden-reflection-level2", "/hidden-reflection/level2/?query=a", "reflection in meta refresh URL",
   vuln: "reflected-attr", delivery: ["query"], note: "browsers refuse javascript: in a meta refresh; break out of the double-quoted content attribute instead")
 maze_get "/hidden-reflection/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><meta http-equiv=\"refresh\" content=\"0;url=#{query}\"></head><body>Redirecting...</body></html>"
 end
@@ -20,7 +20,7 @@ end
 Xssmaze.push("hidden-reflection-level3", "/hidden-reflection/level3/?query=a", "reflection in img data-original attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/hidden-reflection/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><img src=\"safe.jpg\" data-original=\"#{query}\" alt=\"image\"></body></html>"
 end
@@ -29,7 +29,7 @@ end
 Xssmaze.push("hidden-reflection-level4", "/hidden-reflection/level4/?query=a", "reflection in JSON script block (close script tag)",
   vuln: "reflected-html", delivery: ["query"], note: "the block is type=application/json and never executes as JS; close it with </script> and inject markup")
 maze_get "/hidden-reflection/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><script type=\"application/json\">{\"search\":\"#{query}\",\"page\":1}</script><div>Results</div></body></html>"
 end
@@ -38,7 +38,7 @@ end
 Xssmaze.push("hidden-reflection-level5", "/hidden-reflection/level5/?query=a", "reflection in CSS style block (close style tag)",
   vuln: "reflected-html", delivery: ["query"], note: "CSS text does not execute; close the </style> block and inject markup")
 maze_get "/hidden-reflection/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><style>.highlight { color: #{query} }</style></head><body><div class=\"highlight\">Text</div></body></html>"
 end
@@ -47,7 +47,7 @@ end
 Xssmaze.push("hidden-reflection-level6", "/hidden-reflection/level6/?query=a", "reflection in noscript tag (close noscript to inject)",
   vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled the noscript content is raw text; close </noscript> before injecting")
 maze_get "/hidden-reflection/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><noscript><div>JavaScript is disabled. Search: #{query}</div></noscript><div>Content</div></body></html>"
 end

--- a/src/mazes/hidden_xss.cr
+++ b/src/mazes/hidden_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("hidden-xss-level1", "/hidden/level1/?query=a", "input-hidden",
   vuln: "reflected-attr", delivery: ["query"], note: "type=hidden, so break out of the value attribute into a new tag rather than adding a handler to this element")
 maze_get "/hidden/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<input type=\"hidden\" value=\"#{query}\">"
 end
@@ -9,7 +9,7 @@ end
 Xssmaze.push("hidden-xss-level2", "/hidden/level2/?query=a", "input-hidden and escape < >",
   vuln: "reflected-attr", delivery: ["query"], note: "angle brackets are stripped and the input is type=hidden, whose duplicate type attribute the parser drops; the remaining vector is an injected accesskey plus a handler, which needs Firefox and an Alt+Shift keypress")
 maze_get "/hidden/level2/" do |env|
-  query = Filters.strip_angles(env.params.query["query"])
+  query = Filters.strip_angles(env.params.query.fetch("query", ""))
 
   "<input type=\"hidden\" value=\"#{query}\">"
 end
@@ -17,7 +17,7 @@ end
 Xssmaze.push("hidden-xss-level3", "/hidden/level3/?query=a", "input-hidden and escape < > and space",
   vuln: "reflected-attr", delivery: ["query"], note: "as level2, plus spaces are stripped, so separate the injected attributes with / or a tab")
 maze_get "/hidden/level3/" do |env|
-  query = Filters.strip_angles(env.params.query["query"])
+  query = Filters.strip_angles(env.params.query.fetch("query", ""))
   query = Filters.strip_spaces(query)
 
   "<input type=\"hidden\" value=\"#{query}\">"

--- a/src/mazes/inline_style_xss.cr
+++ b/src/mazes/inline_style_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("inlinestyle-level1", "/inlinestyle/level1/?query=a", "reflection in inline style color value (double-quoted)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/inlinestyle/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <div style=\"color: #{query}\">text</div>
@@ -17,7 +17,7 @@ end
 Xssmaze.push("inlinestyle-level2", "/inlinestyle/level2/?query=a", "reflection inside url() in inline style (single-quoted url, double-quoted attr)",
   vuln: "reflected-attr", delivery: ["query"], note: "inside a single-quoted url() in a style attribute; close the single quote then break the attribute with the double quote")
 maze_get "/inlinestyle/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <p style=\"background-image: url('#{query}')\">text</p>
@@ -30,7 +30,7 @@ end
 Xssmaze.push("inlinestyle-level3", "/inlinestyle/level3/?query=a", "reflection inside font-family in inline style (single-quoted value, double-quoted attr)",
   vuln: "reflected-attr", delivery: ["query"], note: "inside a single-quoted font-family; close the single quote then break the attribute with the double quote")
 maze_get "/inlinestyle/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <span style=\"font-family: '#{query}'\">text</span>
@@ -43,7 +43,7 @@ end
 Xssmaze.push("inlinestyle-level4", "/inlinestyle/level4/?query=a", "reflection inside content in inline style (single-quoted value, double-quoted attr)",
   vuln: "reflected-attr", delivery: ["query"], note: "inside a single-quoted content value; close the single quote then break the attribute with the double quote")
 maze_get "/inlinestyle/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <div style=\"content: '#{query}'\">text</div>
@@ -56,7 +56,7 @@ end
 Xssmaze.push("inlinestyle-level5", "/inlinestyle/level5/?query=a", "reflection in inline style width value (no inner quotes, double-quoted attr)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/inlinestyle/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <table><tr><td style=\"width: #{query}\">data</td></tr></table>
@@ -69,7 +69,7 @@ end
 Xssmaze.push("inlinestyle-level6", "/inlinestyle/level6/?query=a", "reflection as entire inline style value (double-quoted attr)",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/inlinestyle/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <div style=\"#{query}\">text</div>

--- a/src/mazes/json_context_xss.cr
+++ b/src/mazes/json_context_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("jsonctx-level1", "/jsonctx/level1/?query=a", "JSON body with text/html content type, HTML injection",
   vuln: "reflected-html", delivery: ["query"], note: "served as text/html despite the JSON body, so injected markup renders")
 maze_get "/jsonctx/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "{\"result\":\"#{query}\"}"
@@ -14,7 +14,7 @@ end
 Xssmaze.push("jsonctx-level2", "/jsonctx/level2/?query=a", "JSON in script block, close script to inject",
   vuln: "reflected-js", delivery: ["query"], note: "reflected into a JS string in a <script>; close the </script> or break the string")
 maze_get "/jsonctx/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><script>var data={\"q\":\"#{query}\"};</script></body></html>"
 end
@@ -24,7 +24,7 @@ end
 Xssmaze.push("jsonctx-level3", "/jsonctx/level3/?query=a", "JSONP response with text/html, HTML injection in data",
   vuln: "reflected-html", params: ["query", "callback"], delivery: ["query"], note: "served as text/html; also reflects the callback parameter, which the declared URL omits")
 maze_get "/jsonctx/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   callback = env.params.query.fetch("callback", "callback")
   env.response.content_type = "text/html"
 
@@ -36,7 +36,7 @@ end
 Xssmaze.push("jsonctx-level4", "/jsonctx/level4/?query=a", "JSON array in script block, close script to inject",
   vuln: "reflected-js", delivery: ["query"], note: "reflected into a JS array string in a <script>")
 maze_get "/jsonctx/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><script>var items=[\"#{query}\"];</script></body></html>"
 end
@@ -46,7 +46,7 @@ end
 Xssmaze.push("jsonctx-level5", "/jsonctx/level5/?query=a", "nested JSON in script block, close script to inject",
   vuln: "reflected-js", delivery: ["query"], note: "reflected into a nested JS object string in a <script>")
 maze_get "/jsonctx/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><script>var cfg={\"user\":{\"name\":\"#{query}\"}};</script></body></html>"
 end
@@ -56,7 +56,7 @@ end
 Xssmaze.push("jsonctx-level6", "/jsonctx/level6/?query=a", "JSON with text/html, query in multiple fields",
   vuln: "reflected-html", delivery: ["query"], note: "served as text/html; reflected in two fields")
 maze_get "/jsonctx/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   env.response.content_type = "text/html"
 
   "{\"title\":\"#{query}\",\"desc\":\"#{query}\"}"

--- a/src/mazes/list_iteration_xss.cr
+++ b/src/mazes/list_iteration_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("listiteration-level1", "/listiteration/level1/?query=apple,banana,cherry", "list iteration split by comma into li elements",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   parts = query.split(",")
   items = parts.map { |part| "<li>#{part}</li>" }.join("\n    ")
 
@@ -18,7 +18,7 @@ end
 Xssmaze.push("listiteration-level2", "/listiteration/level2/?query=col1|col2|col3", "list iteration split by pipe into td elements",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   parts = query.split("|")
   cells = parts.map { |part| "<td>#{part}</td>" }.join("")
 
@@ -32,7 +32,7 @@ end
 Xssmaze.push("listiteration-level3", "/listiteration/level3/?query=line1%0Aline2%0Aline3", "list iteration split by newline into p elements",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   parts = query.split("\n")
   paragraphs = parts.map { |part| "<p>#{part}</p>" }.join("\n    ")
 
@@ -46,7 +46,7 @@ end
 Xssmaze.push("listiteration-level4", "/listiteration/level4/?query=red+green+blue", "list iteration split by space into span tags",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   parts = query.split(" ")
   spans = parts.map { |part| "<span class=\"tag\">#{part}</span>" }.join(" ")
 
@@ -60,7 +60,7 @@ end
 Xssmaze.push("listiteration-level5", "/listiteration/level5/?query=opt1;opt2;opt3", "list iteration split by semicolon into option elements",
   vuln: "reflected-html", delivery: ["query"], note: "each part is reflected into an <option> body and value; close </option></select> to inject")
 maze_get "/listiteration/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   parts = query.split(";")
   options = parts.map { |part| "<option value=\"#{part}\">#{part}</option>" }.join("\n    ")
 
@@ -76,7 +76,7 @@ end
 Xssmaze.push("listiteration-level6", "/listiteration/level6/?query=a", "single dynamic item among 20 static li elements",
   vuln: "reflected-html", delivery: ["query"])
 maze_get "/listiteration/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   static_items = (1..20).map { |i| "<li>Static Item #{i}</li>" }.join("\n    ")
 
   "<html><body>

--- a/src/mazes/manifest_xss.cr
+++ b/src/mazes/manifest_xss.cr
@@ -5,7 +5,7 @@
 Xssmaze.push("manifest-level1", "/manifest/level1/?query=a", "page fetches manifest.json and innerHTMLs description field",
   vuln: "dom", sources: ["fetch-response"], sinks: ["innerHTML"], delivery: ["query"], note: "the value is JSON-escaped into the page, echoed by /manifest/level1/manifest.json and innerHTMLed; a double quote breaks the JSON, and innerHTML does not run a bare <script>, so use <img src=x onerror=...>")
 maze_get "/manifest/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<div id='out'></div>
    <script>
      fetch('/manifest/level1/manifest.json?query=' + encodeURIComponent(#{query.to_json}))
@@ -16,6 +16,6 @@ end
 
 maze_get "/manifest/level1/manifest.json" do |env|
   env.response.content_type = "application/json"
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   %({"description": "#{query}"})
 end

--- a/src/mazes/mathml_xss.cr
+++ b/src/mazes/mathml_xss.cr
@@ -1,14 +1,14 @@
 Xssmaze.push("mathml-level1", "/mathml/level1/?query=a", "MathML mtext raw reflection (parser context)",
   vuln: "reflected-html", delivery: ["query"], note: "reflected raw inside MathML <mtext>; browser MathML parsing enables sanitizer-bypass vectors")
 maze_get "/mathml/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<math><mtext>#{query}</mtext></math>"
 end
 
 Xssmaze.push("mathml-level2", "/mathml/level2/?query=a", "MathML annotation-xml encoding=text/html (HTML-in-MathML parser quirk)",
   vuln: "reflected-html", delivery: ["query"], note: "script removed once and case-sensitively; annotation-xml encoding=text/html is an HTML integration point, so injected markup is parsed as HTML")
 maze_get "/mathml/level2/" do |env|
-  query = env.params.query["query"].gsub("script", "")
+  query = env.params.query.fetch("query", "").gsub("script", "")
   "<math>
      <semantics>
        <annotation-xml encoding='text/html'>#{query}</annotation-xml>
@@ -19,6 +19,6 @@ end
 Xssmaze.push("mathml-level3", "/mathml/level3/?query=a", "MathML mglyph nested in mtext (HTML5 sanitizer-bypass quirk)",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into a single-quoted mglyph src; break out of the value")
 maze_get "/mathml/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<math><mtext><mglyph src='#{query}'></mglyph></mtext></math>"
 end

--- a/src/mazes/meta_refresh_xss.cr
+++ b/src/mazes/meta_refresh_xss.cr
@@ -1,27 +1,27 @@
 Xssmaze.push("metarefresh-level1", "/metarefresh/level1/?url=a", "<meta http-equiv=refresh> url unfiltered", "GET", ["url"],
   vuln: "reflected-attr", delivery: ["query"], note: "browsers refuse javascript: in a meta refresh; break out of the single-quoted content attribute")
 maze_get "/metarefresh/level1/" do |env|
-  url = env.params.query["url"]
+  url = env.params.query.fetch("url", "")
   "<meta http-equiv='refresh' content='0;url=#{url}'>"
 end
 
 Xssmaze.push("metarefresh-level2", "/metarefresh/level2/?url=a", "meta refresh with quote-strip filter", "GET", ["url"],
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "both quote characters are stripped so the single-quoted content attribute cannot be broken out of, and browsers refuse both javascript: and top-level data: navigation from a meta refresh; only an open redirect is left")
 maze_get "/metarefresh/level2/" do |env|
-  url = env.params.query["url"].gsub("'", "").gsub("\"", "")
+  url = env.params.query.fetch("url", "").gsub("'", "").gsub("\"", "")
   "<meta http-equiv='refresh' content='0;url=#{url}'>"
 end
 
 Xssmaze.push("metarefresh-level3", "/metarefresh/level3/?url=a", "meta refresh blocking literal javascript: only", "GET", ["url"],
   vuln: "reflected-attr", delivery: ["query"], note: "the javascript: strip is a red herring, since browsers refuse that scheme in a meta refresh anyway; the single-quoted content attribute is what breaks out")
 maze_get "/metarefresh/level3/" do |env|
-  url = env.params.query["url"].gsub("javascript:", "")
+  url = env.params.query.fetch("url", "").gsub("javascript:", "")
   "<meta http-equiv='refresh' content='2;url=#{url}'>"
 end
 
 Xssmaze.push("metarefresh-level4", "/metarefresh/level4/?url=a", "meta refresh content fully under user control", "GET", ["url"],
   vuln: "reflected-attr", delivery: ["query"], note: "the whole content attribute is user-controlled, but it is still an attribute: break out of the double quote")
 maze_get "/metarefresh/level4/" do |env|
-  url = env.params.query["url"]
+  url = env.params.query.fetch("url", "")
   "<meta http-equiv='refresh' content=\"#{url}\">"
 end

--- a/src/mazes/multi_vector_xss.cr
+++ b/src/mazes/multi_vector_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("multivector-level1", "/multivector/level1/?query=a", "3 forms, reflection in 2nd form input value only",
   vuln: "reflected-attr", delivery: ["query"], note: "only the second of three forms carries the reflection, in its input value")
 maze_get "/multivector/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<!DOCTYPE html>
 <html><body>
@@ -28,7 +28,7 @@ end
 Xssmaze.push("multivector-level2", "/multivector/level2/?query=a", "dual reflection: script var + HTML body paragraph",
   vuln: "reflected-html", delivery: ["query"], note: "also lands in a double-quoted JS string in an inline <script>")
 maze_get "/multivector/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<!DOCTYPE html>
 <html><body>
@@ -43,7 +43,7 @@ end
 Xssmaze.push("multivector-level3", "/multivector/level3/?query=a", "reflection in option value inside select with 10 options",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into the fourth <option value> of a ten-option <select>")
 maze_get "/multivector/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<!DOCTYPE html>
 <html><body>
@@ -68,7 +68,7 @@ end
 Xssmaze.push("multivector-level4", "/multivector/level4/?query=a", "5 input fields, reflection only in 3rd field value",
   vuln: "reflected-attr", delivery: ["query"], note: "only the third of five input values carries the reflection")
 maze_get "/multivector/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<!DOCTYPE html>
 <html><body>
@@ -89,7 +89,7 @@ end
 Xssmaze.push("multivector-level5", "/multivector/level5/?query=a", "triple reflection: title + meta content + div body",
   vuln: "reflected-html", delivery: ["query"], note: "three contexts — <title>, meta content and a div body")
 maze_get "/multivector/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<!DOCTYPE html>
 <html>
@@ -109,7 +109,7 @@ end
 Xssmaze.push("multivector-level6", "/multivector/level6/?query=a", "deep nested reflection: article > section > div > p",
   vuln: "reflected-html", delivery: ["query"], note: "the reflection is nested four levels deep, in article > section > div > p")
 maze_get "/multivector/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<!DOCTYPE html>
 <html lang=\"en\">

--- a/src/mazes/nested_context_xss.cr
+++ b/src/mazes/nested_context_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("nestedctx-level1", "/nestedctx/level1/?query=a", "reflected in div title attribute next to script tag",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/nestedctx/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><div title=\"#{query}\"><script>var a=\"safe\";</script></div></body></html>"
 end
 
@@ -10,7 +10,7 @@ end
 Xssmaze.push("nestedctx-level2", "/nestedctx/level2/?query=a", "reflected inside div inside textarea (must escape textarea)",
   vuln: "reflected-html", delivery: ["query"], note: "the div and its title attribute are inert text inside <textarea> RCDATA, so close </textarea> before anything can parse as markup")
 maze_get "/nestedctx/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><textarea><div title=\"#{query}\"></div></textarea></body></html>"
 end
 
@@ -18,7 +18,7 @@ end
 Xssmaze.push("nestedctx-level3", "/nestedctx/level3/?query=a", "reflected in JS string containing HTML (close script tag)",
   vuln: "reflected-js", delivery: ["query"], note: "the surrounding <div> markup is inside the JS string literal; break the double-quoted string or close </script>")
 maze_get "/nestedctx/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><script>var a=\"<div>#{query}</div>\";</script></body></html>"
 end
 
@@ -26,7 +26,7 @@ end
 Xssmaze.push("nestedctx-level4", "/nestedctx/level4/?query=a", "reflected inside title element within SVG context",
   vuln: "reflected-html", delivery: ["query"], note: "SVG <title> is ordinary markup in foreign content, and an injected <script> inside <svg> is an SVG script element that still runs")
 maze_get "/nestedctx/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><svg><rect><title>#{query}</title></rect></svg></body></html>"
 end
 
@@ -34,7 +34,7 @@ end
 Xssmaze.push("nestedctx-level5", "/nestedctx/level5/?query=a", "reflected inside CSS comment within style tag",
   vuln: "reflected-html", delivery: ["query"], note: "lands inside a CSS comment; close the comment and the </style> element to reach an HTML context")
 maze_get "/nestedctx/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><head><style>/* #{query} */body{color:red}</style></head><body><p>Content</p></body></html>"
 end
 
@@ -42,6 +42,6 @@ end
 Xssmaze.push("nestedctx-level6", "/nestedctx/level6/?query=a", "reflected in data attribute of div with child img element",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/nestedctx/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<html><body><div data-x=\"#{query}\"><img src=\"safe.jpg\"></div></body></html>"
 end

--- a/src/mazes/noscript_xss.cr
+++ b/src/mazes/noscript_xss.cr
@@ -1,14 +1,14 @@
 Xssmaze.push("noscript-level1", "/noscript/level1/?query=a", "raw reflection inside <noscript>",
   vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled a browser parses <noscript> content as raw text, so the payload must open with </noscript> before any tag is recognised")
 maze_get "/noscript/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<noscript>#{query}</noscript>"
 end
 
 Xssmaze.push("noscript-level2", "/noscript/level2/?query=a", "noscript content fed back to innerHTML by client JS",
   vuln: "dom", sources: ["textContent"], sinks: ["innerHTML"], delivery: ["query"], note: "the raw-text <noscript> body is relayed into innerHTML, so no </noscript> breakout is needed; innerHTML does not run a bare <script>, so use <img src=x onerror=...>")
 maze_get "/noscript/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<noscript id='ns'>#{query}</noscript>
    <div id='out'></div>
    <script>
@@ -19,13 +19,13 @@ end
 Xssmaze.push("noscript-level3", "/noscript/level3/?query=a", "<noscript> stripped only literally; nested case bypass",
   vuln: "reflected-html", delivery: ["query"], note: "only the exact lowercase <noscript> and </noscript> strings are stripped, and only once, so </NOSCRIPT> or </nos</noscript>cript> gets out of the raw-text element")
 maze_get "/noscript/level3/" do |env|
-  query = env.params.query["query"].gsub("<noscript>", "").gsub("</noscript>", "")
+  query = env.params.query.fetch("query", "").gsub("<noscript>", "").gsub("</noscript>", "")
   "<noscript>#{query}</noscript>"
 end
 
 Xssmaze.push("noscript-level4", "/noscript/level4/?query=a", "<noscript> with reflected attribute on inner <meta>",
   vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled the <meta> is never a real element (it sits in <noscript> raw text) and a meta refresh to javascript: does not execute anyway; close </noscript> and inject a tag")
 maze_get "/noscript/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<noscript><meta http-equiv='refresh' content='0;url=#{query}'></noscript>"
 end

--- a/src/mazes/parser_differential_xss.cr
+++ b/src/mazes/parser_differential_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("pdiff-level1", "/pdiff/level1/?query=a", "reflection in <noscript> tag (parser differential with JS enabled)",
   vuln: "reflected-html", delivery: ["query"], note: "with scripting enabled <noscript> content is raw text, so close </noscript> before the payload can parse")
 maze_get "/pdiff/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><noscript>#{query}</noscript><p>safe</p></body></html>"
 end
@@ -11,7 +11,7 @@ end
 Xssmaze.push("pdiff-level2", "/pdiff/level2/?query=a", "reflection after unclosed <select> tag",
   vuln: "reflected-html", delivery: ["query"], note: "inside <select> the parser drops most tags, but a <script> start tag is still processed")
 maze_get "/pdiff/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><select><option>#{query}</body></html>"
 end
@@ -20,7 +20,7 @@ end
 Xssmaze.push("pdiff-level3", "/pdiff/level3/?query=a", "reflection inside <math> MathML namespace",
   vuln: "reflected-html", delivery: ["query"], note: "MathML foreign content: a bare <script> would be created in the MathML namespace and never run, so use an HTML breakout tag such as <img>")
 maze_get "/pdiff/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><math><mi>#{query}</mi></math></body></html>"
 end
@@ -29,7 +29,7 @@ end
 Xssmaze.push("pdiff-level4", "/pdiff/level4/?query=a", "reflection after unclosed <table> row (foster parenting)",
   vuln: "reflected-html", delivery: ["query"], note: "despite the unclosed table the reflection is inside the <td>, an ordinary content context")
 maze_get "/pdiff/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><table><tr><td>#{query}</body></html>"
 end
@@ -38,7 +38,7 @@ end
 Xssmaze.push("pdiff-level5", "/pdiff/level5/?query=a", "reflection inside deprecated <xmp> tag",
   vuln: "reflected-html", delivery: ["query"], note: "<xmp> is a raw-text element; close </xmp> first")
 maze_get "/pdiff/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><xmp>#{query}</xmp></body></html>"
 end
@@ -47,7 +47,7 @@ end
 Xssmaze.push("pdiff-level6", "/pdiff/level6/?query=a", "reflection inside iframe srcdoc attribute",
   vuln: "reflected-attr", sinks: ["srcdoc"], delivery: ["query"], note: "the attribute value is parsed as its own document inside the frame, so a tag payload runs without breaking the attribute")
 maze_get "/pdiff/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><iframe srcdoc=\"#{query}\"></iframe></body></html>"
 end

--- a/src/mazes/polyglot_context_xss.cr
+++ b/src/mazes/polyglot_context_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("polyctx-level1", "/polyctx/level1/?query=a", "dual reflection: body + attribute value",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into both an input value attribute and the body; either is exploitable")
 maze_get "/polyctx/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Polyglot Context Level 1</h1>
@@ -16,7 +16,7 @@ end
 Xssmaze.push("polyctx-level2", "/polyctx/level2/?query=a", "dual reflection: script string + body",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into a <script> string and the body; </script> breakout covers both")
 maze_get "/polyctx/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Polyglot Context Level 2</h1>
@@ -29,7 +29,7 @@ end
 Xssmaze.push("polyctx-level3", "/polyctx/level3/?query=a", "triple reflection: comment + attribute + body",
   vuln: "reflected-html", delivery: ["query"], note: "reflected in an HTML comment, a title attribute and the body; all three are exploitable")
 maze_get "/polyctx/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Polyglot Context Level 3</h1>
@@ -42,7 +42,7 @@ end
 Xssmaze.push("polyctx-level4", "/polyctx/level4/?query=a", "single-pass script tag strip, body reflection",
   vuln: "reflected-html", delivery: ["query"], note: "<script> stripped in a single pass; use <img>/<svg> or a nested tag")
 maze_get "/polyctx/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   filtered = query.gsub(/<script[^>]*>|<\/script>/i, "")
 
   "<html><body>
@@ -56,7 +56,7 @@ end
 Xssmaze.push("polyctx-level5", "/polyctx/level5/?query=a", "dual reflection: JS single-quoted + HTML double-quoted attr",
   vuln: "reflected-js", delivery: ["query"], note: "reflected into a single-quoted <script> string and a double-quoted attribute; </script> breakout reaches both")
 maze_get "/polyctx/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Polyglot Context Level 5</h1>
@@ -70,7 +70,7 @@ end
 Xssmaze.push("polyctx-level6", "/polyctx/level6/?query=a", "dual reflection: style tag + body div",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into a <style> block and the body; the body reflection is a direct HTML injection")
 maze_get "/polyctx/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head>
   <style>body { color: #{query}; }</style>

--- a/src/mazes/post_method_xss.cr
+++ b/src/mazes/post_method_xss.cr
@@ -6,7 +6,7 @@ maze_get "/postmethod/level1/" do |_|
   "<html><body><form action='/postmethod/level1/' method='post'><input type='text' name='query' value='a'><input type='submit'></form></body></html>"
 end
 maze_post "/postmethod/level1/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
 
   "<html><body>#{query}</body></html>"
 end
@@ -19,7 +19,7 @@ maze_get "/postmethod/level2/" do |_|
   "<html><body><form action='/postmethod/level2/' method='post'><input type='text' name='query' value='a'><input type='submit'></form></body></html>"
 end
 maze_post "/postmethod/level2/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
 
   "<html><body><input type=\"text\" value=\"#{query}\"></body></html>"
 end
@@ -33,7 +33,7 @@ maze_get "/postmethod/level3/" do |_|
   <script>function send(){var x=new XMLHttpRequest();x.open('POST','/postmethod/level3/');x.setRequestHeader('Content-Type','application/json;charset=UTF-8');x.send(JSON.stringify({query:document.querySelector('input[name=query]').value}));}</script></body></html>"
 end
 maze_post "/postmethod/level3/" do |env|
-  query = env.params.json["query"].as(String)
+  query = env.params.json.fetch("query", "").as(String)
 
   "<html><body>#{query}</body></html>"
 end
@@ -46,7 +46,7 @@ maze_get "/postmethod/level4/" do |_|
   "<html><body><form action='/postmethod/level4/' method='post'><input type='text' name='query' value='a'><input type='submit'></form></body></html>"
 end
 maze_post "/postmethod/level4/" do |env|
-  query = env.params.body["query"].as(String)
+  query = env.params.body.fetch("query", "")
 
   "<html><body><script>var x = \"#{query}\";</script></body></html>"
 end
@@ -59,7 +59,7 @@ maze_get "/postmethod/level5/" do |_|
   "<html><body><form action='/postmethod/level5/' method='post'><input type='text' name='name' value='a'><input type='submit'></form></body></html>"
 end
 maze_post "/postmethod/level5/" do |env|
-  query = env.params.body["name"].as(String)
+  query = env.params.body.fetch("name", "")
 
   "<html><body>#{query}</body></html>"
 end
@@ -72,7 +72,7 @@ maze_get "/postmethod/level6/" do |_|
   "<html><body><form action='/postmethod/level6/' method='post'><input type='text' name='query' value='a'><input type='submit'></form></body></html>"
 end
 maze_post "/postmethod/level6/" do |env|
-  query = Filters.strip_angles(env.params.body["query"].as(String))
+  query = Filters.strip_angles(env.params.body.fetch("query", ""))
 
   "<html><body><input type=\"text\" value=\"#{query}\"></body></html>"
 end

--- a/src/mazes/redirect_xss.cr
+++ b/src/mazes/redirect_xss.cr
@@ -3,7 +3,7 @@
 Xssmaze.push("redirectxss-level1", "/redirectxss/level1/?query=a", "reflection in href attribute unfiltered (javascript: protocol)",
   vuln: "reflected-attr", delivery: ["query"], note: "double-quoted href; use a javascript: URL (needs a click) or break out with the quote and >")
 maze_get "/redirectxss/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><a href=\"#{query}\">Click here</a></body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("redirectxss-level2", "/redirectxss/level2/?query=a", "reflection in meta refresh URL",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into the meta-refresh content attribute; break out with the quote and > (javascript:/data: in meta refresh is blocked by modern browsers)")
 maze_get "/redirectxss/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><meta http-equiv=\"refresh\" content=\"0;url=#{query}\"></head><body>Redirecting...</body></html>"
 end
@@ -23,7 +23,7 @@ end
 Xssmaze.push("redirectxss-level3", "/redirectxss/level3/?query=a", "reflection in form action attribute (javascript: protocol)",
   vuln: "reflected-attr", delivery: ["query"], note: "form action; a javascript: URL fires on submit or break out with the quote and >")
 maze_get "/redirectxss/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><form action=\"#{query}\"><input type='submit' value='Submit'></form></body></html>"
 end
@@ -33,7 +33,7 @@ end
 Xssmaze.push("redirectxss-level4", "/redirectxss/level4/?query=a", "reflection in window.location assignment inside script",
   vuln: "reflected-js", delivery: ["query"], note: "reflected into a double-quoted JS string; close the </script> or break the string")
 maze_get "/redirectxss/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><script>window.location=\"#{query}\";</script></body></html>"
 end
@@ -43,7 +43,7 @@ end
 Xssmaze.push("redirectxss-level5", "/redirectxss/level5/?query=a", "reflection in href URL param (attribute breakout)",
   vuln: "reflected-attr", delivery: ["query"], note: "double-quoted href; break out with the quote and >")
 maze_get "/redirectxss/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><a href=\"/redirect?url=#{query}\">Click to redirect</a></body></html>"
 end
@@ -53,7 +53,7 @@ end
 Xssmaze.push("redirectxss-level6", "/redirectxss/level6/?query=a", "reflection in object data attribute (javascript: or data: URI)",
   vuln: "reflected-attr", delivery: ["query"], note: "object data attribute; break out with the quote and > or use a javascript:/data: URI")
 maze_get "/redirectxss/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><object data=\"#{query}\"></object></body></html>"
 end

--- a/src/mazes/sanitizer_bypass_xss.cr
+++ b/src/mazes/sanitizer_bypass_xss.cr
@@ -4,7 +4,7 @@ require "html"
 Xssmaze.push("sanitizer-level1", "/sanitizer/level1/?query=a", "HTML entity body + raw attribute",
   vuln: "reflected-attr", delivery: ["query"], note: "the body copy is HTML-escaped; the title attribute is raw, so break out with the quote")
 maze_get "/sanitizer/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><div title=\"#{query}\">#{HTML.escape(query)}</div></body></html>"
 end
@@ -13,7 +13,7 @@ end
 Xssmaze.push("sanitizer-level2", "/sanitizer/level2/?query=a", "recursive dangerous tag strip",
   vuln: "reflected-html", delivery: ["query"], note: "script/iframe/object keywords removed recursively; use a different tag or event vector")
 maze_get "/sanitizer/level2/" do |env|
-  query = Filters.strip_keyword_recursive(env.params.query["query"], "script")
+  query = Filters.strip_keyword_recursive(env.params.query.fetch("query", ""), "script")
   query = Filters.strip_keyword_recursive(query, "iframe")
   query = Filters.strip_keyword_recursive(query, "object")
 
@@ -24,7 +24,7 @@ end
 Xssmaze.push("sanitizer-level3", "/sanitizer/level3/?query=a", "tag whitelist: p/b/i/a/br only",
   vuln: "reflected-html", delivery: ["query"], note: "only p/b/i/a/br are whitelisted, but <a> keeps its attributes; use an <a> event handler or javascript: href (needs interaction)")
 maze_get "/sanitizer/level3/" do |env|
-  query = Filters.whitelist_tags(env.params.query["query"], ["p", "b", "i", "a", "br"])
+  query = Filters.whitelist_tags(env.params.query.fetch("query", ""), ["p", "b", "i", "a", "br"])
 
   "<html><body>#{query}</body></html>"
 end
@@ -33,7 +33,7 @@ end
 Xssmaze.push("sanitizer-level4", "/sanitizer/level4/?query=a", "script to comment replacement",
   vuln: "reflected-html", delivery: ["query"], note: "<script>...</script> is turned into an HTML comment; use a non-script vector like <img onerror>")
 maze_get "/sanitizer/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   query = query.gsub(/<script/i, "<!--").gsub(/<\/script>/i, "-->")
 
   "<html><body>#{query}</body></html>"
@@ -43,7 +43,7 @@ end
 Xssmaze.push("sanitizer-level5", "/sanitizer/level5/?query=a", "double HTML entity encode (browser decodes once)",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "double HTML-entity encoded; the browser decodes only once, leaving inert entities in both the body and the title attribute, so no breakout is possible")
 maze_get "/sanitizer/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Double encode: < → &amp;lt;
   # Browser will decode once to &lt; which is still safe in body
   # But if injected in an attribute that browser decodes, it might work
@@ -56,7 +56,7 @@ end
 Xssmaze.push("sanitizer-level6", "/sanitizer/level6/?query=a", "href allowed, javascript:/data: stripped",
   vuln: "reflected-html", delivery: ["query"], note: "only <a> is allowed and javascript:/data: hrefs are stripped, but event-handler attributes on <a> survive (needs interaction)")
 maze_get "/sanitizer/level6/" do |env|
-  query = Filters.whitelist_tags(env.params.query["query"], ["a"])
+  query = Filters.whitelist_tags(env.params.query.fetch("query", ""), ["a"])
   # Additionally strip dangerous protocols from href
   query = query.gsub(/href\s*=\s*["']?\s*javascript\s*:/i, "href=\"#")
   query = query.gsub(/href\s*=\s*["']?\s*data\s*:/i, "href=\"#")

--- a/src/mazes/seo_context_xss.cr
+++ b/src/mazes/seo_context_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("seoctx-level1", "/seoctx/level1/?query=a", "reflection in og:title meta content attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><meta property=\"og:title\" content=\"#{query}\"></head><body>Page</body></html>"
 end
@@ -15,7 +15,7 @@ end
 Xssmaze.push("seoctx-level2", "/seoctx/level2/?query=a", "reflection in keywords meta content attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><meta name=\"keywords\" content=\"#{query}\"></head><body>Page</body></html>"
 end
@@ -26,7 +26,7 @@ end
 Xssmaze.push("seoctx-level3", "/seoctx/level3/?query=a", "reflection in og:description meta content attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><meta property=\"og:description\" content=\"#{query}\"></head><body>Page</body></html>"
 end
@@ -37,7 +37,7 @@ end
 Xssmaze.push("seoctx-level4", "/seoctx/level4/?query=a", "reflection in og:url meta content attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><meta property=\"og:url\" content=\"#{query}\"></head><body>Page</body></html>"
 end
@@ -48,7 +48,7 @@ end
 Xssmaze.push("seoctx-level5", "/seoctx/level5/?query=a", "reflection in canonical link href attribute",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/seoctx/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><link rel=\"canonical\" href=\"#{query}\"></head><body>Page</body></html>"
 end
@@ -59,7 +59,7 @@ end
 Xssmaze.push("seoctx-level6", "/seoctx/level6/?query=a", "dual reflection in meta author and body span",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into the meta content attribute and again as span text; the span copy takes markup directly")
 maze_get "/seoctx/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><meta name=\"author\" content=\"#{query}\"></head><body><span class=\"author\">#{query}</span></body></html>"
 end

--- a/src/mazes/srcset_xss.cr
+++ b/src/mazes/srcset_xss.cr
@@ -6,27 +6,27 @@
 Xssmaze.push("srcset-level1", "/srcset/level1/?query=a", "attribute-context injection in <img srcset> (multi-candidate)",
   vuln: "reflected-attr", delivery: ["query"], note: "a srcset URL never executes on its own — the bug is the unescaped single-quoted attribute around it")
 maze_get "/srcset/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<img srcset='#{query}'>"
 end
 
 Xssmaze.push("srcset-level2", "/srcset/level2/?query=a", "attribute-context injection in <source srcset> inside <picture>",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/srcset/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<picture><source srcset='#{query}'><img src='/fallback.png'></picture>"
 end
 
 Xssmaze.push("srcset-level3", "/srcset/level3/?query=a", "attribute-context injection with comma stripped (descriptor bypass)",
   vuln: "reflected-attr", delivery: ["query"], note: "commas are stripped and a \" 1x\" descriptor is appended after the reflection")
 maze_get "/srcset/level3/" do |env|
-  query = env.params.query["query"].gsub(",", "")
+  query = env.params.query.fetch("query", "").gsub(",", "")
   "<img srcset='#{query} 1x'>"
 end
 
 Xssmaze.push("srcset-level4", "/srcset/level4/?query=a", "attribute-context injection on <link rel=preload imagesrcset>",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/srcset/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   "<link rel='preload' as='image' imagesrcset='#{query}'>"
 end

--- a/src/mazes/svg_xss.cr
+++ b/src/mazes/svg_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("svg-xss-level1", "/svg/level1/?query=a", "SVG onload XSS",
   vuln: "reflected-attr", delivery: ["query"], note: "lands directly in an svg onload handler; the value runs as JS on load, no breakout needed")
 maze_get "/svg/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG XSS Level 1</h1>
@@ -12,7 +12,7 @@ end
 Xssmaze.push("svg-xss-level2", "/svg/level2/?query=a", "SVG animate XSS",
   vuln: "reflected-attr", delivery: ["query"], note: "reflected into an svg <animate> values attribute; break out of the double-quoted value")
 maze_get "/svg/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG XSS Level 2</h1>
@@ -23,7 +23,7 @@ end
 Xssmaze.push("svg-xss-level3", "/svg/level3/?query=a", "SVG foreignObject XSS",
   vuln: "reflected-js", delivery: ["query"], note: "reflected raw as the body of a <script> inside <foreignObject>; injected JS executes directly")
 maze_get "/svg/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG XSS Level 3</h1>
@@ -34,7 +34,7 @@ end
 Xssmaze.push("svg-xss-level4", "/svg/level4/?query=a", "SVG use XSS with href",
   vuln: "reflected-attr", delivery: ["query"], note: "svg <use> href; break out of the double-quoted attribute")
 maze_get "/svg/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG XSS Level 4</h1>
@@ -45,7 +45,7 @@ end
 Xssmaze.push("svg-xss-level5", "/svg/level5/?query=a", "SVG embedded with data URI",
   vuln: "reflected-attr", delivery: ["query"], note: "lands in a single-quoted svg onload inside a data:image/svg+xml embed; runs as JS on load")
 maze_get "/svg/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>SVG XSS Level 5</h1>
@@ -56,7 +56,7 @@ end
 Xssmaze.push("svg-xss-level6", "/svg/level6/?query=a", "SVG with filtered script tags",
   vuln: "reflected-attr", delivery: ["query"], note: "<script> tags are stripped, but the value lands in an svg onload handler, so inject JS directly")
 maze_get "/svg/level6/" do |env|
-  query = env.params.query["query"].gsub("<script", "").gsub("</script>", "")
+  query = env.params.query.fetch("query", "").gsub("<script", "").gsub("</script>", "")
 
   "<html><body>
   <h1>SVG XSS Level 6</h1>

--- a/src/mazes/template_injection_xss.cr
+++ b/src/mazes/template_injection_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("tplinject-level1", "/tplinject/level1/?query=a", "reflection inside JS template literal interpolation",
   vuln: "reflected-js", delivery: ["query"], note: "reflected inside a ${\"...\"} expression in a JS template literal; break out of the double-quoted string or the </script>")
 maze_get "/tplinject/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection XSS Level 1</h1>
@@ -21,7 +21,7 @@ end
 Xssmaze.push("tplinject-level2", "/tplinject/level2/?query=a", "HTML template element cloned to innerHTML",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "reflected into an inert <template>, whose innerHTML is then re-injected into the page via innerHTML, executing it")
 maze_get "/tplinject/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection XSS Level 2</h1>
@@ -40,7 +40,7 @@ end
 Xssmaze.push("tplinject-level3", "/tplinject/level3/?query=a", "JS string assigned to innerHTML (indirect DOM sink)",
   vuln: "reflected-js", sinks: ["innerHTML"], delivery: ["query"], note: "reflected raw into a single-quoted JS string that is concatenated into innerHTML; break out with a single quote")
 maze_get "/tplinject/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection XSS Level 3</h1>
@@ -59,7 +59,7 @@ end
 Xssmaze.push("tplinject-level4", "/tplinject/level4/?query=a", "script type=text/template rendered via innerHTML",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "reflected into an inert <script type=text/template>, whose innerHTML is re-injected via innerHTML")
 maze_get "/tplinject/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection XSS Level 4</h1>
@@ -83,7 +83,7 @@ end
 Xssmaze.push("tplinject-level5", "/tplinject/level5/?query=a", "server-side double template render",
   vuln: "reflected-html", delivery: ["query"], note: "server-side placeholder substitution places the value raw into the page body")
 maze_get "/tplinject/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   # First pass: build template with placeholder
   template = "<div class='wrapper'>{{content}}</div>"
@@ -104,7 +104,7 @@ end
 Xssmaze.push("tplinject-level6", "/tplinject/level6/?query=a", "data-attribute read by JS and written to innerHTML",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "reflected into a data-user attribute that JS reads and writes to innerHTML")
 maze_get "/tplinject/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>Template Injection XSS Level 6</h1>

--- a/src/mazes/url_param_context_xss.cr
+++ b/src/mazes/url_param_context_xss.cr
@@ -4,7 +4,7 @@
 Xssmaze.push("url-param-ctx-level1", "/url-param-ctx/level1/?query=a", "reflection in a href URL query parameter value",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><a href=\"https://example.com/search?q=#{query}\">Search link</a></body></html>"
 end
@@ -15,7 +15,7 @@ end
 Xssmaze.push("url-param-ctx-level2", "/url-param-ctx/level2/?query=a", "reflection in form action URL query parameter value",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><form action=\"/submit?token=#{query}\"><input type=\"submit\" value=\"Go\"></form></body></html>"
 end
@@ -26,7 +26,7 @@ end
 Xssmaze.push("url-param-ctx-level3", "/url-param-ctx/level3/?query=a", "reflection in img src URL query parameter value",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><img src=\"/image?name=#{query}\"></body></html>"
 end
@@ -37,7 +37,7 @@ end
 Xssmaze.push("url-param-ctx-level4", "/url-param-ctx/level4/?query=a", "reflection in link href URL query parameter value",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><link href=\"/css?theme=#{query}\" rel=\"stylesheet\"></head><body><p>Styled page</p></body></html>"
 end
@@ -48,7 +48,7 @@ end
 Xssmaze.push("url-param-ctx-level5", "/url-param-ctx/level5/?query=a", "reflection in script src URL query parameter value",
   vuln: "reflected-attr", delivery: ["query"], note: "double-quoted script src; break out with the quote and > then close the </script> to inject a tag")
 maze_get "/url-param-ctx/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><script src=\"/js?v=#{query}\"></script></head><body><p>Script loaded</p></body></html>"
 end
@@ -59,7 +59,7 @@ end
 Xssmaze.push("url-param-ctx-level6", "/url-param-ctx/level6/?query=a", "reflection in iframe src URL query parameter value",
   vuln: "reflected-attr", delivery: ["query"])
 maze_get "/url-param-ctx/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><iframe src=\"/embed?id=#{query}\"></iframe></body></html>"
 end

--- a/src/mazes/waf_bypass_xss.cr
+++ b/src/mazes/waf_bypass_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("waf-bypass-level1", "/waf-bypass/level1/?query=a", "case-insensitive script tag strip",
   vuln: "reflected-html", delivery: ["query"], note: "script removed once and case-insensitively; use a nested tag or a non-script vector")
 maze_get "/waf-bypass/level1/" do |env|
-  query = Filters.strip_keyword_ci(env.params.query["query"], "script")
+  query = Filters.strip_keyword_ci(env.params.query.fetch("query", ""), "script")
 
   "<html><body>#{query}</body></html>"
 end
@@ -11,7 +11,7 @@ end
 Xssmaze.push("waf-bypass-level2", "/waf-bypass/level2/?query=a", "alert/confirm/prompt function strip",
   vuln: "reflected-html", delivery: ["query"], note: "alert/confirm/prompt names are stripped; use another sink such as Function or a string-built name")
 maze_get "/waf-bypass/level2/" do |env|
-  query = Filters.strip_keyword_ci(env.params.query["query"], "alert")
+  query = Filters.strip_keyword_ci(env.params.query.fetch("query", ""), "alert")
   query = Filters.strip_keyword_ci(query, "confirm")
   query = Filters.strip_keyword_ci(query, "prompt")
 
@@ -22,7 +22,7 @@ end
 Xssmaze.push("waf-bypass-level3", "/waf-bypass/level3/?query=a", "event strip + angle encode in double-quote attr",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "reflected into a double-quoted input value, but angle brackets are entity-encoded (no new tags) and every on*= handler is stripped, so the attribute breakout reaches no JS sink")
 maze_get "/waf-bypass/level3/" do |env|
-  query = Filters.encode_angles(env.params.query["query"])
+  query = Filters.encode_angles(env.params.query.fetch("query", ""))
   query = Filters.strip_event_handlers(query)
 
   "<html><body><input type=\"text\" value=\"#{query}\"></body></html>"
@@ -32,7 +32,7 @@ end
 Xssmaze.push("waf-bypass-level4", "/waf-bypass/level4/?query=a", "quote entity escape in JS string",
   vuln: "reflected-js", delivery: ["query"], note: "quotes are entity-escaped so the JS string cannot be broken, but angle brackets pass, so close the </script> to inject HTML")
 maze_get "/waf-bypass/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
   # Only escape quotes, allow angle brackets (for </script> breakout)
   query = query.gsub("'", "&#39;").gsub("\"", "&quot;")
 
@@ -43,7 +43,7 @@ end
 Xssmaze.push("waf-bypass-level5", "/waf-bypass/level5/?query=a", "only < stripped (> allowed)",
   vuln: "non-xss-control", delivery: ["query"], exploitable: false, note: "every < is stripped, so no tag can be opened in the body context; the reflection is inert")
 maze_get "/waf-bypass/level5/" do |env|
-  query = env.params.query["query"].gsub("<", "")
+  query = env.params.query.fetch("query", "").gsub("<", "")
 
   "<html><body>#{query}</body></html>"
 end
@@ -52,7 +52,7 @@ end
 Xssmaze.push("waf-bypass-level6", "/waf-bypass/level6/?query=a", "dual reflection: src attribute + body",
   vuln: "reflected-html", delivery: ["query"], note: "reflected into both an img src attribute and the body; the body is a direct HTML injection")
 maze_get "/waf-bypass/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body><img src=\"#{query}\"><div>Search: #{query}</div></body></html>"
 end
@@ -61,7 +61,7 @@ end
 Xssmaze.push("waf-bypass-level7", "/waf-bypass/level7/?query=a", "lowercase + script keyword strip",
   vuln: "reflected-html", delivery: ["query"], note: "input is lowercased then script removed; use a lowercase non-script vector")
 maze_get "/waf-bypass/level7/" do |env|
-  query = env.params.query["query"].downcase
+  query = env.params.query.fetch("query", "").downcase
   query = query.gsub("script", "")
 
   "<html><body>#{query}</body></html>"
@@ -72,7 +72,7 @@ end
 Xssmaze.push("waf-bypass-level8", "/waf-bypass/level8/?query=a", "equals sign stripped",
   vuln: "reflected-html", delivery: ["query"], note: "= is stripped; use a tag that needs no attribute value (e.g. <script>)")
 maze_get "/waf-bypass/level8/" do |env|
-  query = env.params.query["query"].gsub("=", "")
+  query = env.params.query.fetch("query", "").gsub("=", "")
 
   "<html><body>#{query}</body></html>"
 end

--- a/src/mazes/websocket_xss.cr
+++ b/src/mazes/websocket_xss.cr
@@ -1,7 +1,7 @@
 Xssmaze.push("websocket-xss-level1", "/websocket/level1/?query=a", "WebSocket message XSS (basic)",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "simulated socket message: the value is server-inlined into a JS string, not received over a real WebSocket")
 maze_get "/websocket/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>WebSocket XSS Level 1</h1>
@@ -22,7 +22,7 @@ end
 Xssmaze.push("websocket-xss-level2", "/websocket/level2/?query=a", "WebSocket JSON message XSS",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "simulated socket message laundered through a JSON.parse round-trip")
 maze_get "/websocket/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>WebSocket XSS Level 2</h1>
@@ -44,7 +44,7 @@ end
 Xssmaze.push("websocket-xss-level3", "/websocket/level3/?query=a", "WebSocket with HTML message rendering",
   vuln: "dom", sources: ["server-reflected"], sinks: ["innerHTML"], delivery: ["query"], note: "simulated socket message concatenated into innerHTML")
 maze_get "/websocket/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>WebSocket XSS Level 3</h1>
@@ -72,7 +72,7 @@ end
 Xssmaze.push("websocket-xss-level4", "/websocket/level4/?query=a", "WebSocket with eval-based message processing",
   vuln: "dom", sources: ["server-reflected"], sinks: ["eval", "innerHTML"], delivery: ["query"], note: "simulated socket command passed to eval")
 maze_get "/websocket/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>WebSocket XSS Level 4</h1>
@@ -97,7 +97,7 @@ end
 Xssmaze.push("websocket-xss-level5", "/websocket/level5/?query=a", "WebSocket with DOM manipulation",
   vuln: "dom", sources: ["server-reflected"], sinks: ["setAttribute", "event-handler-attribute"], delivery: ["query"], note: "sets an onclick attribute from a JSON-parsed message; requires a user click")
 maze_get "/websocket/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><body>
   <h1>WebSocket XSS Level 5</h1>

--- a/src/mazes/xml_context_xss.cr
+++ b/src/mazes/xml_context_xss.cr
@@ -2,7 +2,7 @@
 Xssmaze.push("xmlctx-level1", "/xmlctx/level1/?query=a", "XHTML page with query in p element (text/html)",
   vuln: "reflected-html", delivery: ["query"], note: "served as text/html despite the XHTML prolog, so markup in the <p> renders")
 maze_get "/xmlctx/level1/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">
@@ -16,7 +16,7 @@ end
 Xssmaze.push("xmlctx-level2", "/xmlctx/level2/?query=a", "query in CDATA section inside script tag",
   vuln: "reflected-js", delivery: ["query"], note: "reflected into a double-quoted JS string inside a CDATA section; break the string or close the </script>")
 maze_get "/xmlctx/level2/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head></head><body>
 <script type=\"text/javascript\">
@@ -31,7 +31,7 @@ end
 Xssmaze.push("xmlctx-level3", "/xmlctx/level3/?query=a", "query in XML processing instruction context",
   vuln: "reflected-html", delivery: ["query"], note: "served as text/html, so the <?xml ...?> is a bogus comment; a > ends it and the following bytes are HTML")
 maze_get "/xmlctx/level3/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<?xml version=\"1.0\" #{query} ?>
 <html><head><title>XML PI</title></head>
@@ -42,7 +42,7 @@ end
 Xssmaze.push("xmlctx-level4", "/xmlctx/level4/?query=a", "query in deprecated xmp tag",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside <xmp> raw-text; close it with </xmp>")
 maze_get "/xmlctx/level4/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><title>XMP Context</title></head>
 <body><xmp>#{query}</xmp></body></html>"
@@ -52,7 +52,7 @@ end
 Xssmaze.push("xmlctx-level5", "/xmlctx/level5/?query=a", "query in deprecated listing tag",
   vuln: "reflected-html", delivery: ["query"], note: "reflected inside <listing> raw-text; close it with </listing>")
 maze_get "/xmlctx/level5/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><title>Listing Context</title></head>
 <body><listing>#{query}</listing></body></html>"
@@ -62,7 +62,7 @@ end
 Xssmaze.push("xmlctx-level6", "/xmlctx/level6/?query=a", "query reflected before plaintext tag",
   vuln: "reflected-html", delivery: ["query"], note: "reflected in a <div> before the <plaintext> tag, so normal HTML injection works")
 maze_get "/xmlctx/level6/" do |env|
-  query = env.params.query["query"]
+  query = env.params.query.fetch("query", "")
 
   "<html><head><title>Plaintext Context</title></head>
 <body><div>#{query}</div><plaintext>This text is rendered as plain text and no HTML is parsed after this tag.</plaintext></body></html>"


### PR DESCRIPTION
## What changed

Slice **S4** of the "mazes 5xx on missing parameter" fix — 36 maze files, handler
bodies only.

Every maze in this slice read its input with a **non-optional** accessor:

- `env.params.query["query"]` / `env.params.query["url"]`
- `env.params.body["query"].as(String)` / `env.params.body["name"].as(String)`
- `env.params.json["query"].as(String)`

When the parameter is absent, `HTTP::Params#[]` (and the JSON hash lookup) raise
`KeyError`, which Kemal turns into **HTTP 500**. A scanner crawling `/sitemap.xml`
(which lists paths with the query string stripped) or fuzzing one parameter at a
time hits a wall of 500s instead of the reflection the maze exists to teach — the
same defect class already fixed for cookies/headers in `Xssmaze.cookie_value`.

Each read now uses a defaulting `fetch` with a **plain empty-string** default,
matching the style already in `stored_pattern_xss.cr` / `bounty_scanner_xss.cr`:

- `env.params.query.fetch("query", "")`
- `env.params.body.fetch("query", "")` (the redundant `.as(String)` drops out —
  `HTTP::Params#fetch` already returns `String`)
- `env.params.json.fetch("query", "").as(String)` (the JSON hash stores
  `AllParamTypes`, so the cast is kept)

No `Xssmaze.push(...)` metadata was touched; the vulnerability, filters, and
present-parameter HTML are unchanged.

## Files changed

All 36 files listed for slice S4 (`src/mazes/{advanced,api_response,boolean_attr,
cms_pattern,context_escape_v2,dashboard,double_encoding,ecommerce,encoding_edge,
event_handler,filter_chain,form_element,hidden_reflection,hidden,inline_style,
json_context,list_iteration,manifest,mathml,meta_refresh,multi_vector,
nested_context,noscript,parser_differential,polyglot_context,post_method,redirect,
sanitizer_bypass,seo_context,srcset,svg,template_injection,url_param_context,
waf_bypass,websocket,xml_context}_xss.cr`). 201 catalog endpoints.

## How I verified

Built a **before** binary (parent commit) and an **after** binary (this commit),
ran both, and swept the 201 catalog endpoints in this slice.

**(1) Bare GET sweep** — every maze path with no query string:

```
BEFORE 5xx: 193
AFTER  5xx: 0
```

**(1b) POST empty-body sweep** — the 6 POST mazes, empty form body and empty JSON body:

```
BEFORE 5xx: 12   (all 6 x {form,json})
AFTER  5xx: 0
```

**(2) Isolated-parameter sweep** — multi-param mazes, each parameter sent on its
own with a payload. Only one multi-param maze in this slice
(`/jsonctx/level3/`, params `query` + `callback`):

```
AFTER isolated-param 5xx: 0
```

**(3) Present-parameter path unchanged** — requested each maze at its exact
catalog URL (payload in the declared params for POST) against before and after and
diffed the response body + status:

```
endpoints diffed: 201
endpoints whose body/status CHANGED: 0
```

**(4) Toolchain**

```
crystal spec           -> 194 examples, 0 failures, 0 errors, 0 pending
crystal tool format --check -> clean
ameba src/mazes/       -> 182 inspected, 0 failures
```

## For the reviewer

- The default is a plain `""` everywhere, including `meta_refresh` (`url` param) —
  I did **not** copy the `"/"` default that the out-of-slice `redirect.cr` uses,
  per the brief ("plain empty string unless the surrounding code clearly wants
  otherwise").
- `json_context/level3`'s `callback` param already used `fetch` before this change;
  only its `query` read needed fixing.
- No slicing reads (`[0, n]`) exist in this slice, so there is no empty-string
  `IndexError` risk to check.
- `spec/smoke_spec.cr` is intentionally left untouched (the orchestrator extends it
  once all slices land).
