### PR TITLE
test(smoke): cover the bare path and each parameter sent alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **The lab stopped 500ing on a bare request.** 768 of 1031 GET mazes answered HTTP 500 to a
+  path with no query string, because `env.params.query["x"]` raises `KeyError` when the
+  parameter is absent. That is what a crawler saw first: `/sitemap.xml` publishes paths with
+  the query string stripped, so 158 of its first 200 URLs were 500s, and any scanner fuzzing
+  one parameter at a time crashed the levels that read a sibling. All 796 non-optional reads
+  now default, behaviour with the parameter present is byte-identical, and the smoke spec
+  gained the two shapes that missed this — a bare path, and each parameter sent with no
+  siblings (#53, #54, #55, #56)
 - **Every endpoint is classified.** `unclassified` went 838 -> 0 and `reach: "unknown"` with
   it, so `/map/json?reach=server` now returns the 1040 endpoints a request-only scanner can
   actually reach instead of the 206 it used to admit to. 28 endpoints are marked

--- a/spec/smoke_spec.cr
+++ b/spec/smoke_spec.cr
@@ -103,6 +103,39 @@ describe "catalog smoke test" do
     SmokeSpec.report(failures)
   end
 
+  # `/sitemap.xml` publishes paths with the query string stripped, and a scanner
+  # that fuzzes one parameter at a time never sends the others. Both shapes used
+  # to reach a non-optional `env.params.query["x"]` and come back 500 — 768 of
+  # 1031 GET mazes did, which is what a crawler saw before it fuzzed anything.
+  # The sweep below layers its payload on top of `maze.url`, so `?query=a` is
+  # always along for the ride and neither shape is covered there.
+  it "answers a bare path, with no query string at all, without a 5xx" do
+    failures = [] of String
+    SmokeSpec.mazes.each do |maze|
+      SmokeSpec.check(failures, maze, maze.url.partition('?').first)
+    end
+    SmokeSpec.report(failures)
+  end
+
+  it "answers each parameter sent on its own, with no siblings, without a 5xx" do
+    failures = [] of String
+
+    SmokeSpec.mazes.each do |maze|
+      params = SmokeSpec.params_for(maze)
+      # One parameter alone is what the sweep above already covers once the
+      # sibling defaults exist; the point here is levels that declare several.
+      next if params.size < 2
+
+      path = maze.url.partition('?').first
+      params.each do |param|
+        next if SmokeSpec.header_param?(param)
+        SmokeSpec.check(failures, maze, SmokeSpec.with_query(path, param, SmokeSpec::PAYLOADS.first))
+      end
+    end
+
+    SmokeSpec.report(failures)
+  end
+
   it "survives the canonical payloads on every GET parameter" do
     failures = [] of String
 


### PR DESCRIPTION
Closes the blind spot that let 768 of 1031 GET mazes ship answering 500 to a bare crawl,
now that the four handler slices (#53, #54, #55, #56) have landed. Held back until they
merged so it never failed CI mid-flight.

## Why the existing sweep missed it

`SmokeSpec.with_query` builds its request from `maze.url`, which already carries `?query=a`,
and *sets* the target parameter on top. So the required parameter was always along for the
ride. Neither of the two shapes a real tool produces was ever exercised:

- **A bare path.** `/sitemap.xml` publishes maze paths with the query string stripped — the
  README tells tools to ingest it. 158 of its first 200 URLs returned 500.
- **One parameter, no siblings.** Normal scanner behaviour. Send only `?callback=…` to a
  level that also reads `query` and it crashed instead of reflecting.

## What this adds

Two examples:

- `answers a bare path, with no query string at all, without a 5xx` — every maze path,
  query string removed.
- `answers each parameter sent on its own, with no siblings, without a 5xx` — restricted to
  mazes declaring more than one parameter, since the single-parameter case is already covered
  once the defaults exist.

Both reuse the existing `check`/`report` helpers, so a failure still names the maze and the
exact URL and the list is capped the same way.

## Verification

Against `main` with only slice S2 merged, the new examples failed with **570 endpoints**,
matching an independent hand sweep. Against `main` with all four slices:

```
$ crystal spec
196 examples, 0 failures, 0 errors, 0 pending

$ crystal tool format --check
(clean)
```

Full-catalog measurement on this branch: **1031 GET mazes, 0 still 5xx on a bare path**
(was 768). Response bodies at each maze's catalog URL are byte-identical to `main` across
1028 mazes — the three excluded (`bugbounty-level7`, `nonce-level1`, `nonce-level2`) differ
between any two runs by design, one echoing the request Host and two carrying a per-request
random CSP nonce.

Also adds the `## Unreleased` CHANGELOG entry for the fix.