### PR TITLE
fix(mazes): make modern-bypass-level19's origin check parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **`modern-bypass-level19` works again.** Its inline script never parsed:
+  `/https://xssmaze.com/.test(...)` tokenises as the regex `/https:/` followed by a `//` line
+  comment, leaving the `if (` unclosed, so the whole `<script>` was a SyntaxError, the
+  `message` listener was never registered and the `eval` sink was unreachable. That is a typo,
+  not a filter. The slashes are escaped, the level is a real postMessage → `eval` DOM flow
+  again, and its deliberately unanchored origin RegExp still accepts
+  `https://xssmaze.com.attacker.com` — verified end to end in headless Chrome via the
+  `/beacon` oracle (matching origin fires, unrelated origin does not)
 - **The lab stopped 500ing on a bare request.** 768 of 1031 GET mazes answered HTTP 500 to a
   path with no query string, because `env.params.query["x"]` raises `KeyError` when the
   parameter is absent. That is what a crawler saw first: `/sitemap.xml` publishes paths with

--- a/solutions/modern-bypass.md
+++ b/solutions/modern-bypass.md
@@ -133,13 +133,13 @@ Modern real-world XSS bypasses: multi-step state, DOM clobbering config, Vue.js 
 ### modern-bypass-level19
 
 `/modern-bypass/level19/`
-- payload: `no payload — control`
-- context: the inline script does not parse. `if (/https://xssmaze.com/.test(event.origin))`
-  tokenises as the regex `/https:/` followed by a `//…` line comment, leaving
-  the `if (` unclosed — a genuine SyntaxError (verified: the whole `<script>`
-  fails, so `addEventListener('message', …)` never runs). The listener is never
-  registered and nothing reaches `eval`, no matter what origin trick a sender
-  attempts. A true negative.
+- payload: `postMessage({action:'execute',code:'alert(1)'},'*')` from an origin such as `https://xssmaze.com.attacker.com`
+- context: client-only — the payload is a `postMessage`, so a request-only scanner
+  cannot deliver it and a miss here is not a detection failure. The page validates
+  the sender with `/https:\/\/xssmaze.com/.test(event.origin)`, an **unanchored**
+  RegExp: it asks whether the origin *contains* `https://xssmaze.com`, not whether
+  it equals it. `https://xssmaze.com.attacker.com` therefore passes, and
+  `data.code` reaches `eval`. Frame the page, post from a matching origin, done.
 
 ### modern-bypass-level20
 

--- a/src/mazes/modern_realworld_bypass_xss.cr
+++ b/src/mazes/modern_realworld_bypass_xss.cr
@@ -491,7 +491,7 @@ end
 # Level 19: Web Messaging (postMessage) Origin RegExp Bypass
 # Evaluates event data from postMessage listeners where origin validation has weak unanchored RegExp.
 Xssmaze.push("modern-bypass-level19", "/modern-bypass/level19/", "Web Messaging (postMessage) origin RegExp bypass", "GET", [] of String,
-  vuln: "non-xss-control", sources: ["postMessage"], sinks: ["eval"], delivery: ["postmessage"], exploitable: false, note: "the inline script does not parse: `/https://xssmaze.com/.test(...)` tokenises as a regex followed by a line comment, so the if is never closed and the message listener is never registered. Nothing reaches eval, so reporting no XSS here is the correct result")
+  vuln: "dom", sources: ["postMessage"], sinks: ["eval"], delivery: ["postmessage"], note: "needs a real browser: the payload is a postMessage, so a request-only scanner cannot deliver it. The origin check is an unanchored RegExp, so any origin merely containing `https://xssmaze.com` passes — `https://xssmaze.com.attacker.com` is the intended bypass")
 maze_get "/modern-bypass/level19/" do |_env|
   "<!doctype html><html><head><meta charset='utf-8'><title>PostMessage Portal</title></head><body>
   <h1>Modern Bypass Level 19</h1>
@@ -501,7 +501,7 @@ maze_get "/modern-bypass/level19/" do |_env|
   <script>
     window.addEventListener('message', function(event) {
       // Weak origin validation: unanchored RegExp allowing domains like https://xssmaze.com.attacker.com
-      if (/https://xssmaze.com/.test(event.origin)) {
+      if (/https:\\/\\/xssmaze.com/.test(event.origin)) {
         var data = event.data;
         if (data && data.action === 'execute') {
           // Dynamic execution of message payload code


### PR DESCRIPTION
The last item from the metadata triage. `modern-bypass-level19` was classified
`non-xss-control` in #47 — correct for the code as it stood, but the reason was a typo, not a
deliberate filter, so the level had silently done nothing since it was written.

## The bug

```js
if (/https://xssmaze.com/.test(event.origin)) {
```

The regex literal terminates at its second `/`, so this tokenises as the regex `/https:/`
followed by a `//…` line comment. The `if (` is never closed, the whole `<script>` is a
`SyntaxError`, `addEventListener('message', …)` never runs, and the `eval(data.code)` sink is
unreachable no matter what a sender does.

```
$ node --check   # before
SyntaxError
```

## The fix

Escape the two slashes. That is the whole change to the handler — the RegExp stays
**unanchored**, which is the level's actual lesson: it asks whether the origin *contains*
`https://xssmaze.com`, not whether it equals it.

```js
if (/https:\/\/xssmaze.com/.test(event.origin)) {
```

Metadata goes back to what the level was always meant to be: `dom`, `postMessage` → `eval`,
`delivery: ["postmessage"]`, which derives `reach: "client"` — a request-only scanner cannot
deliver a postMessage, so a miss here is correctly not counted as a detection failure.

The `solutions/` entry was rewritten too; it had been marked `no payload — control` in #52 and
now documents the real bypass.

## Verification

Script parses, and the weakness is intact:

```
$ node --check                                                    # after: parses
$ node -e "/https:\/\/xssmaze.com/.test('https://xssmaze.com.attacker.com')"   -> true
$ node -e "/https:\/\/xssmaze.com/.test('https://evil.example')"               -> false
```

End to end in real headless Chrome, driving the maze's own listener with a `MessageEvent`
carrying the attacker origin, and using the lab's `/beacon` execution oracle so the result is
proof of execution rather than a string match:

```
token=l19ok   origin=https://xssmaze.com.attacker.com   fired=True
token=l19bad  origin=https://evil.example               fired=False
```

The driver page was hosted on the lab's own origin (through `/basic/level1/`) so the relative
`fetch('/beacon/…')` inside the eval'd payload resolves — a cross-origin driver could not have
exercised the sink.

```
$ crystal spec            196 examples, 0 failures
$ crystal tool format --check   clean
```

Catalog after: 1064 endpoints, 0 unclassified, controls 28 → 27, `reach` server 1040 /
client 24 (unchanged — this level was already client-delivered).